### PR TITLE
Port human-facing guidance from styleguide.md into STYLE.md (preserve source)

### DIFF
--- a/lcats/STYLE.md
+++ b/lcats/STYLE.md
@@ -82,16 +82,34 @@ Key rules:
 
 Always import modules, not symbols, and access functionality via the module namespace.
 
+Preferred forms:
+- Standard library: `import pathlib`
+- LCATS modules: `from lcats.utils import names`
+
 GOOD:
 ```python
+import pathlib
 from lcats.utils import names
-names.normalize(...)
+
+config_path = pathlib.Path("config.yaml")
+normalized = names.normalize(config_path.stem)
 ```
 
 BAD:
 ```python
+import pathlib as pl
 from lcats.utils.names import normalize
+import lcats.utils.names as n
+
+config_path = pl.Path("config.yaml")
+normalized = normalize(config_path.stem)
 ```
+
+Use nested package imports in module form rather than symbol imports.
+
+### 3.2 Human-Oriented Examples (Imports)
+
+The examples above are normative examples for day-to-day import choices and are intended to make the import policy easier to apply during code review.
 
 ---
 
@@ -100,9 +118,23 @@ from lcats.utils.names import normalize
 Aliases should be avoided unless:
 - Widely accepted (`np`, `pd`)
 - Resolving name conflicts
-- Necessary for readability
+- Necessary for readability when names are unusually long
 
 Do not alias LCATS modules arbitrarily.
+
+GOOD:
+```python
+import numpy as np
+import pandas as pd
+from lcats.retrieval import ranking
+from lcats.retrieval import ranking as case_ranking  # collision/readability case
+```
+
+BAD:
+```python
+from lcats.retrieval import ranking as r
+from lcats.utils import names as n
+```
 
 ---
 
@@ -166,6 +198,30 @@ Rules:
 - Deterministic tests only
 - No network calls (unless mocked)
 - Mirror package structure
+- Mocking is allowed, but prefer testing behavior through upstream objects with stubbed internals rather than mocking the exact method under test
+
+GOOD:
+```python
+import unittest
+
+
+class TestMath(unittest.TestCase):
+    def test_add(self):
+        calc = Calculator()
+        self.assertEqual(calc.add(2, 3), 5)
+```
+
+BAD:
+```python
+import unittest
+from unittest.mock import patch
+
+
+class TestMath(unittest.TestCase):
+    @patch("lcats.math.Calculator.add", return_value=5)
+    def test_add(self, mock_add):
+        self.assertEqual(mock_add(2, 3), 5)
+```
 
 ---
 
@@ -197,6 +253,54 @@ Editors must conform to project configuration.
 CI must enforce:
 - formatting clean
 - lint clean
+
+### 10.1 Human-Oriented Examples (Formatting and Readability)
+
+When editing existing files, minimize unnecessary churn:
+- Keep functional changes and style-only changes separate when feasible
+- Follow the existing file/module style while editing
+- Do not reformat an entire file unless required for the task
+- Preserve existing comments when revising nearby code
+- New code should match surrounding style
+
+Example (style continuity):
+
+GOOD:
+```python
+# Existing code style: single quotes
+name = 'Alice'
+
+# New code follows the same style
+city = 'Paris'
+```
+
+BAD:
+```python
+# Existing code style: single quotes
+name = 'Alice'
+
+# New code mixes styles without need
+city = "Paris"
+```
+
+Spacing/readability examples (tooling remains authoritative):
+
+GOOD:
+```python
+result = (a + b) * (c - d)
+items = [1, 2, 3, 4]
+
+if value == 42:
+    print("Answer found!")
+```
+
+BAD:
+```python
+result=(a+b)*(c-d)
+items=[1,2,3,4]
+
+if(value==42):print("Answer found!")
+```
 
 ---
 
@@ -235,16 +339,33 @@ Avoid:
 Use Google-style docstrings for non-trivial public functions.
 One-line docstrings are acceptable for trivial functions.
 
+GOOD:
 ```python
-def func(x):
-    """Short description.
+def add(a: int, b: int) -> int:
+    """Adds two integers.
 
     Args:
-        x (int): description
+        a: First integer.
+        b: Second integer.
 
     Returns:
-        int
+        Sum of a and b.
     """
+    return a + b
+```
+
+Also good for trivial functions:
+```python
+def is_even(value: int) -> bool:
+    """Return True when value is even."""
+    return value % 2 == 0
+```
+
+BAD:
+```python
+def add(a, b):
+    # Adds two numbers
+    return a + b
 ```
 
 ---
@@ -288,6 +409,25 @@ Recommended:
 - Evaluation benchmarks
 - Dataset versioning
 - Experiment tracking
+
+---
+
+## 19. For Agents / LLM Assistants
+
+When generating or editing code for LCATS, apply rules in this order:
+
+1. Local LCATS rules in this file
+2. Existing project/tooling constraints (`scripts/format`, `scripts/lint`, existing module style)
+3. Google Python Style guidance when a local rule does not specify behavior
+4. PEP 8 only as fallback when neither local rules nor Google guidance cover the case
+
+Agent operating rules:
+- Prefer drop-in-ready code with minimal disruption to the edited file
+- Preserve existing comments and nearby code style unless intentionally changing style
+- Do not invent new style rules not documented here
+- Keep functional changes separate from style-only changes when possible
+- Follow LCATS import policy (`import module` / `from package import module`, not symbol imports)
+- Use `unittest` for tests and avoid over-mocking the exact behavior under test
 
 ---
 


### PR DESCRIPTION
### Motivation
- Preserve the human-facing explanations, Good/Bad examples, and LLM/agent guidance that were being lost during prior consolidation. 
- Make `STYLE.md` the canonical, self-contained guide while keeping the original `lcats/styleguide.md` intact. 
- Ensure examples are corrected to match current LCATS rules (e.g., module imports preferred) rather than dropped or blindly copied.

### Description
- Expanded the Imports section with explicit preferred forms and corrected Good/Bad examples aligned to LCATS import policy (`import module` / `from package import module`).
- Added a `Human-Oriented Examples (Imports)` subsection to preserve readable, review-friendly examples. 
- Preserved alias nuance and added concrete Good/Bad alias examples that respect project import policy and allowed exceptions (e.g., `np`, `pd`, collision/readability cases). 
- Ported unit-testing guidance into `STYLE.md` with Good/Bad examples and anti-overmocking guidance while keeping `unittest` as the project default. 
- Expanded Formatting & Linting with a `Human-Oriented Examples (Formatting and Readability)` subsection that advises minimizing churn, preserving local file style/comments, and includes spacing examples. 
- Enriched Docstring guidance with Good/Bad examples and an explicit one-line docstring example for trivial functions. 
- Added an explicit `For Agents / LLM Assistants` section carrying over agent-oriented operating rules and precedence (local LCATS rules → Google → PEP 8 fallback). 
- Left `lcats/styleguide.md` present and unchanged as requested.

### Testing
- Ran `git diff --check` to validate no whitespace/error diffs, which reported no problems. (passed)
- Verified presence of the source file with `test -f lcats/styleguide.md` to ensure it was not removed. (passed)
- Note: the full project test suite (`scripts/test`) was not run in this PR and should be executed in CI or before merging to confirm behavioral and lint/format checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e02add22788327ad7474b67dbaf5bf)