### PR TITLE
Use internal inspect formatter in corpus_survey instead of spawning `lcats display`

### DIFF
--- a/lcats/lcats/analysis/corpus_survey.py
+++ b/lcats/lcats/analysis/corpus_survey.py
@@ -2,12 +2,14 @@
 
 import argparse
 from dataclasses import dataclass
+import json
 import pathlib
 import subprocess
 import sys
 from typing import Any, Mapping, Optional, Protocol, Sequence
 import unicodedata
 
+import lcats.inspect
 import tqdm
 
 
@@ -161,18 +163,12 @@ def find_json_files(directories):
 
 
 def run_lcats_display(file_path: pathlib.Path) -> str:
-    """Run `lcats display` and return emitted text for one corpus file."""
-    result = subprocess.run(
-        ["lcats", "display", str(file_path)],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"lcats display failed for {file_path}:\n{result.stderr.strip()}"
-        )
-    return result.stdout
+    """Render one corpus JSON file using the same formatter as `lcats display`."""
+    with file_path.open("r", encoding="utf-8") as json_file:
+        data = json.load(json_file)
+
+    rendered = lcats.inspect.format_story_json(data, max_body_chars=None, width=80)
+    return f"{rendered}\n"
 
 
 def run_special_characters_check(

--- a/lcats/tests/analysis/test_corpus_survey.py
+++ b/lcats/tests/analysis/test_corpus_survey.py
@@ -1,5 +1,8 @@
 """Unit tests for lcats.analysis.corpus_survey architecture."""
 
+import json
+import pathlib
+import tempfile
 import unittest
 import unittest.mock
 
@@ -86,6 +89,30 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
         args = parser.parse_args([])
         self.assertEqual(10, args.context)
         self.assertFalse(args.nocontext)
+
+    def test_run_lcats_display_uses_internal_formatter_api(self):
+        sample_story = {
+            "name": "Sample",
+            "author": ["Author"],
+            "metadata": {"source": "unit-test"},
+            "body": "Hello world",
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            story_path = pathlib.Path(temp_dir) / "story.json"
+            with story_path.open("w", encoding="utf-8") as story_file:
+                json.dump(sample_story, story_file)
+
+            with unittest.mock.patch.object(
+                corpus_survey.lcats.inspect,
+                "format_story_json",
+                return_value="rendered",
+            ) as mock_formatter:
+                output = corpus_survey.run_lcats_display(story_path)
+
+        mock_formatter.assert_called_once_with(
+            sample_story, max_body_chars=None, width=80
+        )
+        self.assertEqual("rendered\n", output)
 
     def test_bad_start_and_bad_end_report_precise_spans(self):
         cases = [


### PR DESCRIPTION
### Motivation
- Avoid launching a subprocess to run the CLI when the same rendering functionality is available in-process, reducing overhead and improving testability.

### Description
- Replaced `run_lcats_display` subprocess invocation with direct JSON loading and rendering via `lcats.inspect.format_story_json(max_body_chars=None, width=80)` in `lcats/lcats/analysis/corpus_survey.py`.
- Added `import json` and `import lcats.inspect` and updated `run_lcats_display` to return the formatted string with a trailing newline.
- Added a unit test `test_run_lcats_display_uses_internal_formatter_api` in `lcats/tests/analysis/test_corpus_survey.py` that writes a temporary JSON story, patches the formatter, and asserts the internal API is called and output is returned.

### Testing
- Ran `scripts/format` and `scripts/lint` in the package and both succeeded.
- Ran the updated unit test module with `python -m unittest tests.analysis.test_corpus_survey` and it passed.
- Ran the full test suite with `scripts/test` in this environment and it failed due to unrelated environment issues (missing `parameterized` test dependency and blocked network access causing `tiktoken` encoding download failures), not because of the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03d14f5b48327bff10eb062df64c0)