### PR TITLE
Add `lcats survey` command and argparse routing

### DIFF
--- a/lcats/lcats/analysis/corpus_survey.py
+++ b/lcats/lcats/analysis/corpus_survey.py
@@ -346,10 +346,10 @@ def build_parser():
     return parser
 
 
-def main() -> int:
+def main(argv: Optional[Sequence[str]] = None) -> int:
     """Run the corpus quality checker CLI."""
     parser = build_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.context < 0:
         parser.error("--context must be >= 0")

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -1,7 +1,9 @@
 """Command-line interface for the Literary Captain's Advisory Tool System (LCATS)."""
 
+import argparse
 import sys
 
+from lcats.analysis import corpus_survey
 import lcats.inspect
 import lcats.gatherers.main
 
@@ -12,6 +14,7 @@ Commands:
     gather    Gathers corpus data to a local database.
     inspect   Inspects a story JSON file and summarizes its contents.
     display   Displays entire story JSON file in a human-readable format.
+    survey    Surveys corpus files for quality issues.
     index     Preprocesses a corpus to answer questions.
     advise    LCATS command-line advising tool.
     eval      Evaluate LCATS on a benchmark suite.
@@ -44,6 +47,9 @@ def dispatch(command, args):
     elif command == "display":
         return lcats.inspect.display_files(*args)
 
+    elif command == "survey":
+        return "", corpus_survey.main(args)
+
     elif command == "index":
         return "Indexing data files is not yet implemented.", 1
 
@@ -62,11 +68,17 @@ def dispatch(command, args):
 
 def main():
     """Main entry point for the LCATS command-line interface."""
-    if len(sys.argv) < 2:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", nargs="?")
+    parser.add_argument("args", nargs=argparse.REMAINDER)
+    parsed = parser.parse_args()
+
+    if parsed.command is None:
         print(usage())
         sys.exit(1)
-    result, status = dispatch(sys.argv[1], sys.argv[2:])
-    print(result)
+    result, status = dispatch(parsed.command, parsed.args)
+    if result:
+        print(result)
     sys.exit(status)
 
 

--- a/lcats/tests/cli_test.py
+++ b/lcats/tests/cli_test.py
@@ -34,6 +34,16 @@ class TestCli(unittest.TestCase):
         self.assertEqual(expected_message, actual_message)
         self.assertEqual(expected_status, actual_status)
 
+    @patch("lcats.analysis.corpus_survey.main")
+    def test_dispatch_survey(self, mock_main):
+        """Ensure the survey command delegates to corpus_survey.main."""
+        mock_main.return_value = 0
+
+        actual_message, actual_status = cli.dispatch("survey", ["corpora/sherlock"])
+        self.assertEqual("", actual_message)
+        self.assertEqual(0, actual_status)
+        mock_main.assert_called_once_with(["corpora/sherlock"])
+
     @parameterized.parameterized.expand(
         [
             ("index", "Indexing data files is not yet implemented."),
@@ -52,6 +62,25 @@ class TestCli(unittest.TestCase):
         result, response = cli.dispatch("unknown", [])
         self.assertEqual(result, "Unknown command: unknown")
         self.assertEqual(response, 1)
+
+    @patch("sys.argv", ["lcats", "survey", "corpora/sherlock"])
+    @patch("lcats.analysis.corpus_survey.main")
+    def test_main_survey_invocation(self, mock_main):
+        """Ensure CLI main routes survey arguments via argparse."""
+        mock_main.return_value = 0
+
+        with self.assertRaises(SystemExit) as cm:
+            cli.main()
+
+        self.assertEqual(0, cm.exception.code)
+        mock_main.assert_called_once_with(["corpora/sherlock"])
+
+    @patch("sys.argv", ["lcats", "--help"])
+    def test_main_help_flag_exits(self):
+        """Ensure argparse handles the built-in help flag."""
+        with self.assertRaises(SystemExit) as cm:
+            cli.main()
+        self.assertEqual(0, cm.exception.code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Expose the existing corpus survey functionality as a first-class top-level CLI command so users can run `lcats survey ...` directly. 
- Allow the library survey entry point to be invoked programmatically from the top-level CLI while preserving the existing thin script wrapper behavior. 

### Description
- Added `survey` to the top-level usage text and dispatch mapping so `dispatch("survey", args)` delegates to the survey library entry point (`lcats.analysis.corpus_survey.main`).
- Updated `lcats.cli.main()` to use `argparse` to parse a command and remainder arguments and to print command output only when non-empty so subcommands that stream output (like survey) work cleanly.
- Changed `lcats.analysis.corpus_survey.main` signature to accept an optional `argv` (`Optional[Sequence[str]]`) and pass it into `parser.parse_args(argv)` so it can be called from the CLI with explicit args.
- Added unit tests in `lcats/tests/cli_test.py` to verify survey dispatch delegation, argparse-based `lcats survey ...` routing, and basic `--help` behavior; retained the thin script wrapper under `scripts/utils/corpora_quality_check.py` unchanged for backward compatibility.

### Testing
- Ran the full test runner via `./scripts/test`, which failed in this environment due to external network/proxy issues when `tiktoken` attempted to download encodings and inability to install the `parameterized` test dependency, so I did not mark the full suite as green.
- Ran `python -m unittest tests.analysis.test_corpus_survey` which passed locally against the modified code.
- Verified syntax/compilation with `python -m py_compile lcats/cli.py lcats/analysis/corpus_survey.py tests/cli_test.py` which succeeded.
- Performed a smoke invocation that patched `sys.argv` to simulate `lcats survey corpora/sherlock` and `lcats --help`, and confirmed `lcats.analysis.corpus_survey.main` is called with the expected argument list and that the CLI exits with expected codes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03d60935c8327b20b2f7ca84a6dc1)