### PR TITLE
Add start/end boundary contamination detectors to corpus survey

### DIFF
--- a/lcats/STYLE.md
+++ b/lcats/STYLE.md
@@ -28,6 +28,7 @@ If you follow only a few rules, follow these:
 5. **Tests**
    - Use `unittest` (not `pytest`)  
    - Prefer deterministic tests
+   - Use the `capture` library to suppress print output.
 
 6. **General Principle**
    - Prefer clarity and consistency over cleverness
@@ -217,7 +218,8 @@ python -m unittest discover -s tests -p "*_test.py"
 Rules:
 - Deterministic tests only
 - No network calls (unless mocked)
-- Mirror package structure
+- Avoid printing or use the lcats.utils.capture library to suppress output
+- Mirror package structure - test sample_module in sample_module_tests
 - Mocking is allowed, but prefer testing behavior through upstream objects with stubbed internals rather than mocking the exact method under test
 
 GOOD:

--- a/lcats/lcats/analysis/corpus_survey.py
+++ b/lcats/lcats/analysis/corpus_survey.py
@@ -3,6 +3,7 @@
 import argparse
 from dataclasses import dataclass
 import pathlib
+import re
 import subprocess
 import sys
 from typing import Any, Mapping, Optional, Protocol, Sequence
@@ -127,6 +128,110 @@ class SpecialCharactersDetector:
         return findings
 
 
+class StartDetector:
+    """Detect likely non-story contamination at the start of text."""
+
+    def __init__(self, *, max_scan_chars: int = 500, max_lines: int = 8):
+        self.max_scan_chars = max_scan_chars
+        self.max_lines = max_lines
+        self._compiled_patterns = [
+            ("title-line", re.compile(r"^\s*title\s*:\s*.+$", re.IGNORECASE)),
+            ("author-line", re.compile(r"^\s*(?:by|author)\s*:?\s+.+$", re.IGNORECASE)),
+            (
+                "editor-note",
+                re.compile(r"^\s*(?:\[)?editor(?:'|’)s?\s+note[:\]].*$", re.IGNORECASE),
+            ),
+        ]
+
+    def _scan_prefix(self, text: str) -> tuple[int, str]:
+        if not text:
+            return 0, ""
+        scan_end = min(len(text), self.max_scan_chars)
+        prefix = text[:scan_end]
+        candidate_lines = prefix.splitlines(keepends=True)[: self.max_lines]
+        scanned = "".join(candidate_lines)
+        return len(scanned), scanned
+
+    def run(self, text: str) -> list[Finding]:
+        findings = []
+        _, scanned_prefix = self._scan_prefix(text)
+        offset = 0
+
+        for line in scanned_prefix.splitlines(keepends=True):
+            stripped = line.strip()
+            if not stripped:
+                offset += len(line)
+                continue
+
+            for pattern_name, pattern in self._compiled_patterns:
+                match = pattern.match(line)
+                if not match:
+                    continue
+                span = (offset + match.start(), offset + match.end())
+                findings.append(
+                    Finding(
+                        kind="start-contamination",
+                        severity="warning",
+                        span=span,
+                        message=f"Suspicious start content ({pattern_name})",
+                        evidence={
+                            "pattern": pattern_name,
+                            "matched_text": line.strip(),
+                        },
+                    )
+                )
+                break
+            offset += len(line)
+
+        return findings
+
+
+class EndDetector:
+    """Detect likely non-story contamination at the end of text."""
+
+    def __init__(self, *, max_scan_chars: int = 2500):
+        self.max_scan_chars = max_scan_chars
+        self._compiled_patterns = [
+            (
+                "the-end",
+                re.compile(r"(?im)^\s*the\s+end\s*[.!]?\s*$"),
+            ),
+            (
+                "gutenberg-footer",
+                re.compile(
+                    r"(?i)(project\s+gutenberg|www\.gutenberg\.org|start:\s*full\s+license)"
+                ),
+            ),
+        ]
+
+    def run(self, text: str) -> list[Finding]:
+        findings = []
+        if not text:
+            return findings
+
+        scan_start = max(0, len(text) - self.max_scan_chars)
+        tail = text[scan_start:]
+
+        for pattern_name, pattern in self._compiled_patterns:
+            for match in pattern.finditer(tail):
+                span = (scan_start + match.start(), scan_start + match.end())
+                findings.append(
+                    Finding(
+                        kind="end-contamination",
+                        severity="warning",
+                        span=span,
+                        message=f"Suspicious end content ({pattern_name})",
+                        evidence={
+                            "pattern": pattern_name,
+                            "matched_text": match.group(0),
+                        },
+                    )
+                )
+
+        findings.sort(key=lambda finding: (finding.span[0], finding.span[1]))
+        return findings
+
+
 def run_detectors(
     text: str, config: Optional[Mapping[str, Any]] = None
 ) -> list[Finding]:
@@ -135,7 +240,7 @@ def run_detectors(
     detectors = resolved.get("detectors")
 
     if detectors is None:
-        detectors = [SpecialCharactersDetector()]
+        detectors = [SpecialCharactersDetector(), StartDetector(), EndDetector()]
 
     findings = []
     for detector in detectors:
@@ -220,6 +325,26 @@ def run_special_characters_check(
     return result.stdout.strip()
 
 
+def run_boundary_contamination_check(displayed_text: str) -> str:
+    """Run boundary contamination detectors and emit TSV rows."""
+    detectors = [StartDetector(), EndDetector()]
+    findings = run_detectors(displayed_text, config={"detectors": detectors})
+    lines = []
+    for finding in findings:
+        lines.append(
+            "\t".join(
+                [
+                    finding.kind,
+                    finding.severity,
+                    str(finding.span[0]),
+                    str(finding.span[1]),
+                    finding.message,
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
 def survey_file(file_path: pathlib.Path, args) -> list[tuple[str, str]]:
     """Run enabled checks on a single corpus file and return check outputs."""
     displayed_text = run_lcats_display(file_path)
@@ -238,6 +363,10 @@ def survey_file(file_path: pathlib.Path, args) -> list[tuple[str, str]]:
                 name_width=args.name_width,
                 header=False,
             )
+            if output:
+                findings.append((check_name, output))
+        elif check_name == "boundary-contamination":
+            output = run_boundary_contamination_check(displayed_text)
             if output:
                 findings.append((check_name, output))
         else:
@@ -274,7 +403,7 @@ def build_parser():
         default=[],
         help=(
             "Check(s) to run. Repeatable or comma-separated. "
-            "Currently supported: special-characters"
+            "Currently supported: special-characters,boundary-contamination"
         ),
     )
     parser.add_argument(

--- a/lcats/tests/analysis/fixtures/boundary_contamination/clean_story.txt
+++ b/lcats/tests/analysis/fixtures/boundary_contamination/clean_story.txt
@@ -1,0 +1,2 @@
+The wind rose across the marsh and the lamps in the village went out.
+No one spoke until morning.

--- a/lcats/tests/analysis/fixtures/boundary_contamination/end_gutenberg.txt
+++ b/lcats/tests/analysis/fixtures/boundary_contamination/end_gutenberg.txt
@@ -1,0 +1,4 @@
+The road vanished into rain.
+
+*** END OF THE PROJECT GUTENBERG EBOOK EXAMPLE ***
+For more information, visit www.gutenberg.org

--- a/lcats/tests/analysis/fixtures/boundary_contamination/end_the_end.txt
+++ b/lcats/tests/analysis/fixtures/boundary_contamination/end_the_end.txt
@@ -1,0 +1,2 @@
+The detective closed the ledger and blew out the lamp.
+THE END

--- a/lcats/tests/analysis/fixtures/boundary_contamination/start_contaminated.txt
+++ b/lcats/tests/analysis/fixtures/boundary_contamination/start_contaminated.txt
@@ -1,0 +1,5 @@
+Title: The Haunted Window
+By Jane Roe
+[Editor's Note: This was recovered from old notes.]
+
+The fog came down before dawn.

--- a/lcats/tests/analysis/test_corpus_survey.py
+++ b/lcats/tests/analysis/test_corpus_survey.py
@@ -1,5 +1,6 @@
 """Unit tests for lcats.analysis.corpus_survey architecture."""
 
+import pathlib
 import unittest
 import unittest.mock
 
@@ -10,14 +11,52 @@ class CorpusSurveyArchitectureTest(unittest.TestCase):
     """Tests for detector orchestration and placeholder special-char detector."""
 
     def setUp(self):
+        self.fixture_dir = (
+            pathlib.Path(__file__).resolve().parent / "fixtures" / "boundary_contamination"
+        )
         self.clean_text = "This is plain ASCII text."
         self.bad_start_text = "© starts with a bad char"
         self.bad_end_text = "ends with a bad char ©"
         self.encoding_issue_text = "contains replacement char: �"
 
+    def _fixture_text(self, filename: str) -> str:
+        return (self.fixture_dir / filename).read_text(encoding="utf-8")
+
     def test_clean_text_has_no_findings(self):
         findings = corpus_survey.run_detectors(self.clean_text, config={})
         self.assertEqual([], findings)
+
+    def test_start_detector_fixtures(self):
+        cases = [
+            ("start_contaminated.txt", 3),
+            ("clean_story.txt", 0),
+        ]
+
+        for fixture_name, expected_count in cases:
+            with self.subTest(fixture_name=fixture_name):
+                findings = corpus_survey.StartDetector().run(
+                    self._fixture_text(fixture_name)
+                )
+                self.assertEqual(expected_count, len(findings))
+                for finding in findings:
+                    self.assertEqual("start-contamination", finding.kind)
+
+    def test_end_detector_fixtures(self):
+        cases = [
+            ("end_the_end.txt", "the-end"),
+            ("end_gutenberg.txt", "gutenberg-footer"),
+        ]
+
+        for fixture_name, expected_pattern in cases:
+            with self.subTest(fixture_name=fixture_name):
+                findings = corpus_survey.EndDetector().run(
+                    self._fixture_text(fixture_name)
+                )
+                self.assertGreaterEqual(len(findings), 1)
+                patterns = [finding.evidence["pattern"] for finding in findings]
+                self.assertIn(expected_pattern, patterns)
+                for finding in findings:
+                    self.assertEqual("end-contamination", finding.kind)
 
 
 class CorpusSurveyCliHelpersTest(unittest.TestCase):

--- a/lcats/tests/analysis/test_corpus_survey.py
+++ b/lcats/tests/analysis/test_corpus_survey.py
@@ -14,7 +14,9 @@ class CorpusSurveyArchitectureTest(unittest.TestCase):
 
     def setUp(self):
         self.fixture_dir = (
-            pathlib.Path(__file__).resolve().parent / "fixtures" / "boundary_contamination"
+            pathlib.Path(__file__).resolve().parent
+            / "fixtures"
+            / "boundary_contamination"
         )
         self.clean_text = "This is plain ASCII text."
         self.bad_start_text = "© starts with a bad char"

--- a/lcats/tests/cli_test.py
+++ b/lcats/tests/cli_test.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import parameterized
 
 from lcats import cli
+from lcats.utils import capture
 
 
 class TestCli(unittest.TestCase):
@@ -78,8 +79,9 @@ class TestCli(unittest.TestCase):
     @patch("sys.argv", ["lcats", "--help"])
     def test_main_help_flag_exits(self):
         """Ensure argparse handles the built-in help flag."""
-        with self.assertRaises(SystemExit) as cm:
-            cli.main()
+        with capture.suppress_output():
+            with self.assertRaises(SystemExit) as cm:
+                cli.main()
         self.assertEqual(0, cm.exception.code)
 
 


### PR DESCRIPTION
### Motivation
- Detect and report likely non-story contamination at story boundaries (titles/bylines/editor notes at the start; “THE END” and Project Gutenberg footers at the end) without modifying corpus files.

### Description
- Implemented `StartDetector` and `EndDetector` in `lcats.analysis.corpus_survey` using conservative, regex-based heuristics and scan limits to locate suspicious start/end spans.
- Integrated the detectors into the default pipeline used by `run_detectors` so they run when custom detectors are not provided, and added `run_boundary_contamination_check` to produce TSV-like rows for the CLI.
- Wired a new `boundary-contamination` check into `survey_file` and updated the `--check-for` help text in `build_parser` to advertise the new check.
- Added fixture-based unit tests and text fixtures under `lcats/tests/analysis/fixtures/boundary_contamination/` and extended `lcats/tests/analysis/test_corpus_survey.py` to exercise the new detectors.

### Testing
- Ran the targeted tests with `python -m unittest tests.analysis.test_corpus_survey` from the package context and the new start/end detector tests passed (9 tests, OK). 
- Ran the full suite via `scripts/test` in this environment and it failed due to unrelated external issues: `tiktoken` attempted to download encodings (network blocked) and several tests failed due to a missing `parameterized` dependency; these failures are environmental and not caused by the new detectors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03de16e088327aa81c59aee6093ad)