### PR TITLE
Add boundary and structural content detectors

### DIFF
--- a/lcats/lcats/analysis/corpus_survey.py
+++ b/lcats/lcats/analysis/corpus_survey.py
@@ -4,6 +4,7 @@ import argparse
 from dataclasses import dataclass
 import json
 import pathlib
+import re
 import subprocess
 import sys
 from typing import Any, Mapping, Optional, Protocol, Sequence
@@ -68,6 +69,9 @@ DEFAULT_EXCLUDED_CHARS = [
 ]
 DEFAULT_CHECKS = ["special-characters"]
 
+BOUNDARY_WINDOW_LINES = 12
+STRUCTURAL_WINDOW_LINES = 40
+
 
 @dataclass(frozen=True)
 class Finding:
@@ -129,6 +133,299 @@ class SpecialCharactersDetector:
         return findings
 
 
+def _line_offsets(text: str) -> list[tuple[int, str]]:
+    """Return (start_index, line_text_without_newline) for each line."""
+    offsets = []
+    position = 0
+    for raw_line in text.splitlines(keepends=True):
+        line = raw_line.rstrip("\r\n")
+        offsets.append((position, line))
+        position += len(raw_line)
+
+    if not offsets and text:
+        offsets.append((0, text))
+
+    return offsets
+
+
+def _make_line_finding(
+    *,
+    kind: str,
+    severity: str,
+    line_start: int,
+    line_text: str,
+    message: str,
+    evidence: Mapping[str, Any],
+) -> Finding:
+    """Create a line-based finding with a precise character span."""
+    return Finding(
+        kind=kind,
+        severity=severity,
+        span=(line_start, line_start + len(line_text)),
+        message=message,
+        evidence=evidence,
+    )
+
+
+class StartDetector:
+    """Detect likely non-story preamble content near the story start."""
+
+    _AUTHOR_RE = re.compile(r"^by\s+[A-Za-z][A-Za-z .,'\-]+$", re.IGNORECASE)
+    _EDITOR_NOTE_RE = re.compile(
+        r"^(\[)?(editor'?s note|transcriber'?s note|introduction|preface)\b",
+        re.IGNORECASE,
+    )
+
+    def run(self, text: str) -> list[Finding]:
+        findings = []
+        for line_no, (start, line) in enumerate(_line_offsets(text), start=1):
+            trimmed = line.strip()
+            if not trimmed:
+                continue
+            if line_no > BOUNDARY_WINDOW_LINES:
+                break
+
+            if self._AUTHOR_RE.match(trimmed):
+                findings.append(
+                    _make_line_finding(
+                        kind="start-contamination",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely author line at start of story.",
+                        evidence={"line": trimmed, "type": "author-line"},
+                    )
+                )
+                continue
+
+            if self._EDITOR_NOTE_RE.match(trimmed):
+                findings.append(
+                    _make_line_finding(
+                        kind="start-contamination",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely editorial note at start of story.",
+                        evidence={"line": trimmed, "type": "editor-note"},
+                    )
+                )
+                continue
+
+            if line_no <= 3 and self._looks_like_title(trimmed):
+                findings.append(
+                    _make_line_finding(
+                        kind="start-contamination",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely title heading at story start.",
+                        evidence={"line": trimmed, "type": "title-line"},
+                    )
+                )
+
+        return findings
+
+    @staticmethod
+    def _looks_like_title(line: str) -> bool:
+        if len(line) < 4 or len(line) > 90:
+            return False
+        if line.endswith((".", "!", "?", ";", ":")):
+            return False
+        words = [word for word in re.split(r"\s+", line) if word]
+        if len(words) < 2 or len(words) > 12:
+            return False
+        alpha_words = [word for word in words if any(ch.isalpha() for ch in word)]
+        if len(alpha_words) < 2:
+            return False
+        titleish = sum(word[0].isupper() for word in alpha_words if word[0].isalpha())
+        return titleish >= max(2, len(alpha_words) - 1)
+
+
+class EndDetector:
+    """Detect likely non-story footer content near the story end."""
+
+    _GUTENBERG_RE = re.compile(
+        r"(project gutenberg|gutenberg (ebook|license)|\*\*\* end of)",
+        re.IGNORECASE,
+    )
+
+    def run(self, text: str) -> list[Finding]:
+        lines = _line_offsets(text)
+        if not lines:
+            return []
+
+        findings = []
+        start_index = max(0, len(lines) - BOUNDARY_WINDOW_LINES)
+        for line_no in range(start_index, len(lines)):
+            start, line = lines[line_no]
+            trimmed = line.strip()
+            if not trimmed:
+                continue
+
+            if trimmed.upper() == "THE END":
+                findings.append(
+                    _make_line_finding(
+                        kind="end-contamination",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely explicit ending marker.",
+                        evidence={"line": trimmed, "type": "the-end"},
+                    )
+                )
+                continue
+
+            if self._GUTENBERG_RE.search(trimmed):
+                findings.append(
+                    _make_line_finding(
+                        kind="end-contamination",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely Gutenberg footer content.",
+                        evidence={"line": trimmed, "type": "gutenberg-footer"},
+                    )
+                )
+
+        return findings
+
+
+class ChapterHeadingDetector:
+    """Detect chapter-style heading lines embedded in story text."""
+
+    _CHAPTER_RE = re.compile(
+        r"^(chapter|book|part)\s+([ivxlcdm]+|\d+)([\s:.-]+.*)?$", re.IGNORECASE
+    )
+
+    def run(self, text: str) -> list[Finding]:
+        findings = []
+        for line_no, (start, line) in enumerate(_line_offsets(text), start=1):
+            if line_no > STRUCTURAL_WINDOW_LINES:
+                break
+            trimmed = line.strip()
+            if not trimmed or len(trimmed) > 90:
+                continue
+            if self._CHAPTER_RE.match(trimmed):
+                findings.append(
+                    _make_line_finding(
+                        kind="structural-artifact",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely chapter heading.",
+                        evidence={"line": trimmed, "type": "chapter-heading"},
+                    )
+                )
+        return findings
+
+
+class TocRemnantsDetector:
+    """Detect table-of-contents remnants such as dotted leader lines."""
+
+    _CONTENTS_HEADER_RE = re.compile(r"^(table of contents|contents)$", re.IGNORECASE)
+    _TOC_ENTRY_RE = re.compile(
+        r"^([ivxlcdm\d]+\.?\s+)?[A-Za-z][A-Za-z ,.'\-]+\.{2,}\s*\d+\s*$"
+    )
+
+    def run(self, text: str) -> list[Finding]:
+        lines = _line_offsets(text)[:STRUCTURAL_WINDOW_LINES]
+        findings = []
+        entry_count = 0
+
+        for start, line in lines:
+            trimmed = line.strip()
+            if not trimmed:
+                continue
+
+            if self._CONTENTS_HEADER_RE.match(trimmed):
+                findings.append(
+                    _make_line_finding(
+                        kind="structural-artifact",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely table-of-contents heading.",
+                        evidence={"line": trimmed, "type": "toc-heading"},
+                    )
+                )
+                continue
+
+            if self._TOC_ENTRY_RE.match(trimmed):
+                entry_count += 1
+                findings.append(
+                    _make_line_finding(
+                        kind="structural-artifact",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely table-of-contents entry.",
+                        evidence={"line": trimmed, "type": "toc-entry"},
+                    )
+                )
+
+        if entry_count < 2:
+            findings = [
+                finding
+                for finding in findings
+                if finding.evidence.get("type") != "toc-entry"
+            ]
+
+        return findings
+
+
+class SectionBreakDetector:
+    """Detect standalone section-break ornament lines."""
+
+    _SECTION_RE = re.compile(r"^(\*\s*){3,}$|^(\-\s*){3,}$|^~{3,}$|^\*\s\*\s\*$")
+
+    def run(self, text: str) -> list[Finding]:
+        findings = []
+        for start, line in _line_offsets(text):
+            trimmed = line.strip()
+            if not trimmed:
+                continue
+            if self._SECTION_RE.match(trimmed):
+                findings.append(
+                    _make_line_finding(
+                        kind="structural-artifact",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely section break marker.",
+                        evidence={"line": trimmed, "type": "section-break"},
+                    )
+                )
+        return findings
+
+
+class IllustrationCaptionDetector:
+    """Detect illustration caption lines that are likely non-story artifacts."""
+
+    _CAPTION_RE = re.compile(
+        r"^(\[?illustration\]?[:.]?|figure\s+\d+[:.]|fig\.\s*\d+[:.])",
+        re.IGNORECASE,
+    )
+
+    def run(self, text: str) -> list[Finding]:
+        findings = []
+        for start, line in _line_offsets(text):
+            trimmed = line.strip()
+            if not trimmed or len(trimmed) > 120:
+                continue
+            if self._CAPTION_RE.match(trimmed):
+                findings.append(
+                    _make_line_finding(
+                        kind="structural-artifact",
+                        severity="warning",
+                        line_start=start,
+                        line_text=line,
+                        message="Likely illustration caption.",
+                        evidence={"line": trimmed, "type": "illustration-caption"},
+                    )
+                )
+        return findings
+
+
 def run_detectors(
     text: str, config: Optional[Mapping[str, Any]] = None
 ) -> list[Finding]:
@@ -137,7 +434,15 @@ def run_detectors(
     detectors = resolved.get("detectors")
 
     if detectors is None:
-        detectors = [SpecialCharactersDetector()]
+        detectors = [
+            SpecialCharactersDetector(),
+            StartDetector(),
+            EndDetector(),
+            ChapterHeadingDetector(),
+            TocRemnantsDetector(),
+            SectionBreakDetector(),
+            IllustrationCaptionDetector(),
+        ]
 
     findings = []
     for detector in detectors:

--- a/lcats/tests/analysis/fixtures/bad_end_markers.txt
+++ b/lcats/tests/analysis/fixtures/bad_end_markers.txt
@@ -1,0 +1,4 @@
+She closed the letter and fed it to the stove.
+
+THE END
+*** END OF THE PROJECT GUTENBERG EBOOK THE HAUNTED WINDOW ***

--- a/lcats/tests/analysis/fixtures/bad_start_title_author_note.txt
+++ b/lcats/tests/analysis/fixtures/bad_start_title_author_note.txt
@@ -1,0 +1,5 @@
+THE HAUNTED WINDOW
+By Jane Doe
+Editor's Note: This text was lightly modernized.
+
+The rain had stopped by dawn, and the house listened.

--- a/lcats/tests/analysis/fixtures/clean_story_excerpt.txt
+++ b/lcats/tests/analysis/fixtures/clean_story_excerpt.txt
@@ -1,0 +1,3 @@
+The rain had stopped by dawn, and the house listened.
+Mira crossed the entry hall and paused at the door, unsure.
+She heard only the ticking clock and her own breath.

--- a/lcats/tests/analysis/fixtures/structural_artifacts.txt
+++ b/lcats/tests/analysis/fixtures/structural_artifacts.txt
@@ -1,0 +1,9 @@
+Contents
+I. Arrival.................................. 1
+II. The Letter.............................. 9
+
+Chapter I
+
+* * *
+
+[Illustration: The old house at dusk.]

--- a/lcats/tests/analysis/test_corpus_survey.py
+++ b/lcats/tests/analysis/test_corpus_survey.py
@@ -17,9 +17,67 @@ class CorpusSurveyArchitectureTest(unittest.TestCase):
         self.bad_start_text = "© starts with a bad char"
         self.bad_end_text = "ends with a bad char ©"
         self.encoding_issue_text = "contains replacement char: �"
+        self.fixture_dir = pathlib.Path(__file__).parent / "fixtures"
+
+    def _fixture_text(self, filename):
+        return (self.fixture_dir / filename).read_text(encoding="utf-8")
 
     def test_clean_text_has_no_findings(self):
         findings = corpus_survey.run_detectors(self.clean_text, config={})
+        self.assertEqual([], findings)
+
+    def test_start_detector_finds_title_author_and_editor_note(self):
+        text = self._fixture_text("bad_start_title_author_note.txt")
+        findings = corpus_survey.StartDetector().run(text)
+
+        types = [finding.evidence["type"] for finding in findings]
+        self.assertIn("title-line", types)
+        self.assertIn("author-line", types)
+        self.assertIn("editor-note", types)
+
+    def test_end_detector_finds_the_end_and_gutenberg_footer(self):
+        text = self._fixture_text("bad_end_markers.txt")
+        findings = corpus_survey.EndDetector().run(text)
+
+        types = [finding.evidence["type"] for finding in findings]
+        self.assertIn("the-end", types)
+        self.assertIn("gutenberg-footer", types)
+
+    def test_structural_detectors_find_expected_artifacts(self):
+        text = self._fixture_text("structural_artifacts.txt")
+        detectors = [
+            corpus_survey.ChapterHeadingDetector(),
+            corpus_survey.TocRemnantsDetector(),
+            corpus_survey.SectionBreakDetector(),
+            corpus_survey.IllustrationCaptionDetector(),
+        ]
+
+        findings = []
+        for detector in detectors:
+            findings.extend(detector.run(text))
+
+        types = [finding.evidence["type"] for finding in findings]
+        self.assertIn("chapter-heading", types)
+        self.assertIn("toc-heading", types)
+        self.assertIn("toc-entry", types)
+        self.assertIn("section-break", types)
+        self.assertIn("illustration-caption", types)
+
+    def test_structural_detectors_avoid_false_positives_on_clean_excerpt(self):
+        text = self._fixture_text("clean_story_excerpt.txt")
+        detectors = [
+            corpus_survey.StartDetector(),
+            corpus_survey.EndDetector(),
+            corpus_survey.ChapterHeadingDetector(),
+            corpus_survey.TocRemnantsDetector(),
+            corpus_survey.SectionBreakDetector(),
+            corpus_survey.IllustrationCaptionDetector(),
+        ]
+
+        findings = []
+        for detector in detectors:
+            findings.extend(detector.run(text))
+
         self.assertEqual([], findings)
 
 

--- a/lcats/tests/analysis/test_corpus_survey.py
+++ b/lcats/tests/analysis/test_corpus_survey.py
@@ -113,7 +113,6 @@ class CorpusSurveyArchitectureTest(unittest.TestCase):
                     self.assertEqual("end-contamination", finding.kind)
 
 
-
 class CorpusSurveyCliHelpersTest(unittest.TestCase):
     """Tests for corpus_survey CLI helper functions moved from script."""
 


### PR DESCRIPTION
### Motivation
- Detect non-story structural artifacts and boundary contamination (start/end markers, TOC remnants, section breaks, illustration captions) to improve corpus quality checks.

### Description
- Added multiple detectors to `lcats/lcats/analysis/corpus_survey.py`: `StartDetector`, `EndDetector`, `ChapterHeadingDetector`, `TocRemnantsDetector`, `SectionBreakDetector`, and `IllustrationCaptionDetector` and integrated them into the default detector pipeline while keeping the existing `SpecialCharactersDetector`.
- Added stable helpers `_line_offsets` and `_make_line_finding` to produce precise, deterministic character spans for line-based findings.
- Implemented heuristics to reduce false positives (e.g., TOC entry count guard, bounded search windows `BOUNDARY_WINDOW_LINES` / `STRUCTURAL_WINDOW_LINES`).
- Added fixture-based unit tests in `lcats/tests/analysis/test_corpus_survey.py` and example texts under `lcats/tests/analysis/fixtures/` to exercise start/end and structural detectors.

### Testing
- Ran the focused test file with `python -m unittest tests.analysis.test_corpus_survey -v` and all tests passed.
- Ran `scripts/format` and `scripts/lint`; formatting was applied and lint checks pass after formatting.
- Ran the full test suite with `scripts/test`; this environment produced failures unrelated to the changes due to external issues (missing `parameterized` package and blocked network access causing `tiktoken` encoding download to fail).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03e8eefc48327857cf1c4fb2a3f4d)