### PR TITLE
Special-character extractor: classification, evidence, and allowlist support

### DIFF
--- a/lcats/lcats/analysis/corpus_survey.py
+++ b/lcats/lcats/analysis/corpus_survey.py
@@ -480,6 +480,7 @@ def run_special_characters_check(
     displayed_text: str,
     extract_script: str,
     allow_smart: bool,
+    allowlist_config: str,
     excluded_codepoints,
     excluded_chars,
     context: int,
@@ -492,6 +493,8 @@ def run_special_characters_check(
 
     if allow_smart:
         cmd.append("--allow-smart")
+    if allowlist_config:
+        cmd.append(f"--allowlist-config={allowlist_config}")
     if excluded_codepoints:
         cmd.append("--exclude-codepoint=" + ",".join(excluded_codepoints))
     if excluded_chars:
@@ -552,6 +555,7 @@ def survey_file(file_path: pathlib.Path, args) -> list[tuple[str, str]]:
                 displayed_text=displayed_text,
                 extract_script=args.extract_script,
                 allow_smart=args.allow_smart,
+                allowlist_config=args.allowlist_config,
                 excluded_codepoints=args.exclude_codepoint,
                 excluded_chars=args.exclude_char,
                 context=args.context,
@@ -611,6 +615,11 @@ def build_parser():
         "--extract-script",
         default="scripts/utils/extract_special_chars.py",
         help="Path to the extract_special_chars.py script.",
+    )
+    parser.add_argument(
+        "--allowlist-config",
+        default="",
+        help="Optional JSON config path for allowed characters/codepoints.",
     )
 
     parser.add_argument(
@@ -711,7 +720,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                         if args.header and not header_written:
                             print(
                                 "path\tcodepoint\tchar\tunicode_name\t"
-                                "occurrence_index\toffset\tcontext"
+                                "occurrence_index\toffset\tcontext\t"
+                                "classification\tevidence"
                             )
                             header_written = True
                         print(f"{file_path}\t{line}")

--- a/lcats/scripts/utils/extract_special_chars.py
+++ b/lcats/scripts/utils/extract_special_chars.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import argparse
+import json
+import pathlib
+import re
 import sys
 import unicodedata
 
@@ -16,7 +19,31 @@ TSV_COLUMNS = [
     "occurrence_index",
     "offset",
     "context",
+    "classification",
+    "evidence",
 ]
+MOJIBAKE_RE = re.compile(r"(?:Ã.|Â.|â.|ð.|�)")
+
+
+class AllowlistConfig:
+    """Allowlist settings loaded from CLI and optional JSON config."""
+
+    def __init__(self):
+        self.allowed_chars = set()
+        self.allowed_codepoints = set()
+        self.allowed_unicode_names = set()
+        self.allowed_categories = set()
+
+    def is_allowed(self, ch: str) -> bool:
+        if ch in self.allowed_chars:
+            return True
+        if f"U+{ord(ch):04X}" in self.allowed_codepoints:
+            return True
+        if get_unicode_name(ch) in self.allowed_unicode_names:
+            return True
+        if unicodedata.category(ch) in self.allowed_categories:
+            return True
+        return False
 
 
 def parse_codepoint(text: str) -> str:
@@ -63,7 +90,32 @@ def build_excluded_set(exclude_chars, exclude_codepoints):
     return excluded
 
 
-def is_allowed(ch: str, allow_smart: bool) -> bool:
+def load_allowlist_config(config_path: str | None) -> AllowlistConfig:
+    """Load allowlist config from JSON, returning an empty config when unset."""
+    config = AllowlistConfig()
+    if not config_path:
+        return config
+
+    with pathlib.Path(config_path).open("r", encoding="utf-8") as config_file:
+        payload = json.load(config_file)
+
+    for ch in payload.get("allowed_chars", []):
+        for value in ch:
+            config.allowed_chars.add(value)
+
+    for codepoint in payload.get("allowed_codepoints", []):
+        config.allowed_codepoints.add(f"U+{ord(parse_codepoint(codepoint)):04X}")
+
+    for name in payload.get("allowed_unicode_names", []):
+        config.allowed_unicode_names.add(name)
+
+    for category in payload.get("allowed_categories", []):
+        config.allowed_categories.add(category)
+
+    return config
+
+
+def is_allowed(ch: str, allow_smart: bool, allowlist: AllowlistConfig) -> bool:
     """Return True when a character is allowed by the configured filters."""
     if ch.isascii():
         if ch.isalnum():
@@ -74,14 +126,36 @@ def is_allowed(ch: str, allow_smart: bool) -> bool:
             return True
     if allow_smart and ch in SMART_ALLOWED:
         return True
+    if allowlist.is_allowed(ch):
+        return True
     return False
 
 
-def is_flagged(ch: str, allow_smart: bool, excluded: set[str]) -> bool:
+def is_flagged(
+    ch: str, allow_smart: bool, excluded: set[str], allowlist: AllowlistConfig
+) -> bool:
     """Return True when a character should be reported."""
     if ch in excluded:
         return False
-    return not is_allowed(ch, allow_smart)
+    return not is_allowed(ch, allow_smart, allowlist)
+
+
+def classify_character(text: str, offset: int, ch: str) -> tuple[str, str]:
+    """Classify one character with a compact evidence string."""
+    if ch in SMART_ALLOWED:
+        return ("valid-typography", "common typographic punctuation")
+
+    window_start = max(0, offset - 2)
+    window_end = min(len(text), offset + 3)
+    window = text[window_start:window_end]
+    match = MOJIBAKE_RE.search(window)
+    if match:
+        return ("mojibake-pattern", f"matched mojibake fragment '{match.group(0)}'")
+
+    return (
+        "suspicious-unicode",
+        f"unicode_category={unicodedata.category(ch)}; non-ascii outside allowlist",
+    )
 
 
 def iter_input(files):
@@ -126,6 +200,7 @@ def iter_special_character_rows(
     text: str,
     allow_smart: bool,
     excluded: set[str],
+    allowlist: AllowlistConfig,
     context: int,
     name_width: int,
 ):
@@ -133,10 +208,11 @@ def iter_special_character_rows(
     occurrence_counts = {}
 
     for offset, ch in enumerate(text):
-        if not is_flagged(ch, allow_smart, excluded):
+        if not is_flagged(ch, allow_smart, excluded, allowlist):
             continue
 
         occurrence_counts[ch] = occurrence_counts.get(ch, 0) + 1
+        classification, evidence = classify_character(text, offset, ch)
         row = [
             path,
             f"U+{ord(ch):04X}",
@@ -145,6 +221,8 @@ def iter_special_character_rows(
             str(occurrence_counts[ch]),
             str(offset),
             escape_for_tsv(get_context_snippet(text, offset, context)),
+            classification,
+            escape_for_tsv(evidence),
         ]
         yield "\t".join(row)
 
@@ -158,6 +236,15 @@ def build_parser() -> argparse.ArgumentParser:
         )
     )
     parser.add_argument("files", nargs="*")
+    parser.add_argument(
+        "--allowlist-config",
+        default="",
+        help=(
+            "Optional path to a JSON allowlist config containing keys such as "
+            "allowed_chars, allowed_codepoints, allowed_unicode_names, and "
+            "allowed_categories."
+        ),
+    )
     parser.add_argument(
         "--allow-smart",
         action="store_true",
@@ -237,6 +324,7 @@ def main(argv=None) -> int:
         parser.error("--name-width must be >= 0")
 
     excluded = build_excluded_set(args.exclude_char, args.exclude_codepoint)
+    allowlist = load_allowlist_config(args.allowlist_config)
 
     try:
         if args.header:
@@ -254,6 +342,7 @@ def main(argv=None) -> int:
                 text=text,
                 allow_smart=args.allow_smart,
                 excluded=excluded,
+                allowlist=allowlist,
                 context=args.context,
                 name_width=args.name_width,
             ):

--- a/lcats/tests/analysis/test_corpus_survey.py
+++ b/lcats/tests/analysis/test_corpus_survey.py
@@ -134,6 +134,7 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
                 displayed_text="pi√©ce",
                 extract_script="scripts/utils/extract_special_chars.py",
                 allow_smart=True,
+                allowlist_config="",
                 excluded_codepoints=["00A0"],
                 excluded_chars=["é"],
                 context=10,
@@ -160,6 +161,7 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
                 displayed_text="pi√©ce",
                 extract_script="scripts/utils/extract_special_chars.py",
                 allow_smart=True,
+                allowlist_config="quality/allowlist.json",
                 excluded_codepoints=[],
                 excluded_chars=[],
                 context=10,
@@ -173,6 +175,7 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
         self.assertNotIn("--context=10", cmd)
         self.assertIn("--name-width=12", cmd)
         self.assertIn("--header", cmd)
+        self.assertIn("--allowlist-config=quality/allowlist.json", cmd)
 
     def test_parser_defaults_include_context(self):
         parser = corpus_survey.build_parser()

--- a/lcats/tests/utils_tests/extract_special_chars_test.py
+++ b/lcats/tests/utils_tests/extract_special_chars_test.py
@@ -31,6 +31,7 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
                 text=text,
                 allow_smart=False,
                 excluded=set(),
+                allowlist=self.module.AllowlistConfig(),
                 context=10,
                 name_width=0,
             )
@@ -53,6 +54,7 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
                 text=text,
                 allow_smart=False,
                 excluded=set(),
+                allowlist=self.module.AllowlistConfig(),
                 context=0,
                 name_width=0,
             )
@@ -70,6 +72,7 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
                 text=text,
                 allow_smart=False,
                 excluded=set(),
+                allowlist=self.module.AllowlistConfig(),
                 context=10,
                 name_width=0,
             )
@@ -89,6 +92,7 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
                 text=text,
                 allow_smart=False,
                 excluded=set(),
+                allowlist=self.module.AllowlistConfig(),
                 context=10,
                 name_width=0,
             )
@@ -109,6 +113,7 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
                 text=unnamed_char,
                 allow_smart=False,
                 excluded=set(),
+                allowlist=self.module.AllowlistConfig(),
                 context=10,
                 name_width=0,
             )
@@ -125,6 +130,7 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
                 text=text,
                 allow_smart=False,
                 excluded=set(),
+                allowlist=self.module.AllowlistConfig(),
                 context=10,
                 name_width=6,
             )
@@ -140,6 +146,7 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
                 text=text,
                 allow_smart=False,
                 excluded=set(),
+                allowlist=self.module.AllowlistConfig(),
                 context=10,
                 name_width=0,
             )
@@ -159,7 +166,48 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
         self.assertEqual(0, exit_code)
         lines = [line for line in output.getvalue().splitlines() if line.strip()]
         self.assertEqual(2, len(lines))
-        self.assertTrue(lines[0].endswith("\t"))
+        self.assertEqual("", lines[0].split("\t")[6])
+
+    def test_classification_distinguishes_typography_mojibake_and_suspicious(self):
+        text = "‘quote’ Ã© ©"
+        rows = list(
+            self.module.iter_special_character_rows(
+                path="stdin",
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=self.module.AllowlistConfig(),
+                context=10,
+                name_width=0,
+            )
+        )
+
+        classifications = [row.split("\t")[7] for row in rows]
+        self.assertIn("valid-typography", classifications)
+        self.assertIn("mojibake-pattern", classifications)
+        self.assertIn("suspicious-unicode", classifications)
+
+    def test_allowlist_config_allows_configured_character(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = pathlib.Path(tmpdir) / "allowlist.json"
+            config_path.write_text(
+                '{"allowed_codepoints":["00A9"]}',
+                encoding="utf-8",
+            )
+            allowlist = self.module.load_allowlist_config(str(config_path))
+
+        rows = list(
+            self.module.iter_special_character_rows(
+                path="stdin",
+                text="©",
+                allow_smart=False,
+                excluded=set(),
+                allowlist=allowlist,
+                context=10,
+                name_width=0,
+            )
+        )
+        self.assertEqual([], rows)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Improve detection precision by distinguishing normal typography from encoding/ocr corruption and mojibake patterns. 
- Make findings explainable by attaching a compact `classification` and `evidence` to each reported occurrence. 
- Allow project-specific exceptions via a JSON allowlist so known valid non-ASCII characters do not generate noise. 

### Description
- Added per-occurrence classification and evidence to the extractor and TSV output by extending rows with `classification` and `evidence` and introducing `classify_character()` to produce `valid-typography`, `mojibake-pattern`, or `suspicious-unicode`. 
- Introduced an optional JSON allowlist loader `load_allowlist_config()` and `AllowlistConfig` to permit configured `allowed_chars`, `allowed_codepoints`, `allowed_unicode_names`, and `allowed_categories`. 
- Added a simple mojibake heuristic (`MOJIBAKE_RE`) and used Unicode category metadata for explanatory evidence. 
- Propagated `--allowlist-config` through `lcats.analysis.corpus_survey` so the corpus survey CLI forwards the setting to the extractor and updated emitted header to include new columns. 
- Updated function signatures and tests in `extract_special_chars.py`, `corpus_survey.py`, and associated unit tests to cover classification and allowlist behavior. 

### Testing
- Ran targeted unit tests: `python -m unittest tests/utils_tests/extract_special_chars_test.py tests/analysis/test_corpus_survey.py` and they passed. 
- Ran formatting and lint checks: `scripts/format --check` and `scripts/lint` and both passed. 
- Ran full test suite `scripts/test` but it failed due to environment issues unrelated to these changes (missing `parameterized` dependency in the environment and blocked network access preventing `tiktoken` encoding fetch); these are external to the PR and not caused by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04720e2a88327ab3f68caf9f573e8)