### PR TITLE
Refactor corpus_survey character buckets and add mojibake sequence detection

### DIFF
--- a/lcats/lcats/analysis/corpus_survey.py
+++ b/lcats/lcats/analysis/corpus_survey.py
@@ -27,7 +27,7 @@ DEFAULT_EXCLUDED_CODEPOINTS = [
     "202F",  # NARROW NO-BREAK SPACE
     "00A0",  # NO-BREAK SPACE
 ]
-DEFAULT_EXCLUDED_CHARS = [
+SAFE_EXCLUDED_CHARS = [
     "£",  # Pound Sign
     "ç",  # Latin Small Letter C with Cedilla
     "é",  # Latin Small Letter E with Acute
@@ -40,33 +40,40 @@ DEFAULT_EXCLUDED_CHARS = [
     "ü",  # Latin Small Letter U with Diaeresis
     "è",  # Latin Small Letter E with Grave
     "ë",  # Latin Small Letter E with Diaeresis
-    "°",  # Degree Sign
-    "´",  # Acute Accent
-    "×",  # Multiplication Sign
     "ï",  # Latin Small Letter I with Diaeresis
     "ô",  # Latin Small Letter O with Circumflex
     "ä",  # Latin Small Letter A with Diaeresis
     "ê",  # Latin Small Letter E with Circumflex
-    "ā",  # Latin Small Letter A with Macron
-    "ī",  # Latin Small Letter I with Macron
-    "ū",  # Latin Small Letter U with Macron
     "À",  # Latin Capital Letter A with Grave
-    "Â",  # Latin Capital Letter A with Circumflex
-    "Ã",  # Latin Capital Letter A with Tilde
     "Ç",  # Latin Capital Letter C with Cedilla
     "É",  # Latin Capital Letter E with Acute
     "Ê",  # Latin Capital Letter E with Circumflex
     "Î",  # Latin Capital Letter I with Circumflex
     "Ü",  # Latin Capital Letter U with Diaeresis
     "à",  # Latin Small Letter A with Grave
-    "â",  # Latin Small Letter A with Circumflex
     "ó",  # Latin Small Letter O with Acute
     "ù",  # Latin Small Letter U with Grave
     "û",  # Latin Small Letter U with Circumflex
+    "―",  # Horizontal Bar
+]
+RARE_REVIEW_CHARS = [
+    "°",  # Degree Sign
+    "´",  # Acute Accent
+    "×",  # Multiplication Sign
+    "ā",  # Latin Small Letter A with Macron
+    "ī",  # Latin Small Letter I with Macron
+    "ū",  # Latin Small Letter U with Macron
     "Ō",  # Latin Capital Letter O with Macron
     "ō",  # Latin Small Letter O with Macron
-    "ū",  # Latin Small Letter U with Macron
 ]
+MOJIBAKE_TRIGGER_CHARS = [
+    "Â",  # Latin Capital Letter A with Circumflex
+    "Ã",  # Latin Capital Letter A with Tilde
+    "â",  # Latin Small Letter A with Circumflex
+]
+DEFAULT_EXCLUDED_CHARS = (
+    SAFE_EXCLUDED_CHARS + RARE_REVIEW_CHARS + MOJIBAKE_TRIGGER_CHARS
+)
 DEFAULT_CHECKS = ["special-characters"]
 
 BOUNDARY_WINDOW_LINES = 12
@@ -92,16 +99,35 @@ class Detector(Protocol):
 
 
 class SpecialCharactersDetector:
-    """Placeholder detector that reuses existing special-character rules."""
+    """Classify unusual characters with safe, review, and mojibake buckets."""
+
+    _A_CIRCUMFLEX_MOJIBAKE_RE = re.compile(r"Â(?:[\u00A0-\u00BF]|[^\w\s])")
+    _A_TILDE_MOJIBAKE_RE = re.compile(r"Ã[\u00A0-\u00BF]")
+    _BROKEN_PUNCT_MOJIBAKE_SEQS = {
+        "â€™",
+        "â€œ",
+        "â€\u009d",
+        "â€“",
+        "â€”",
+        "â€¦",
+    }
 
     def __init__(
         self,
         *,
         allow_smart: bool = True,
+        safe_excluded_chars: Optional[Sequence[str]] = None,
+        rare_review_chars: Optional[Sequence[str]] = None,
+        mojibake_trigger_chars: Optional[Sequence[str]] = None,
         excluded_chars: Optional[Sequence[str]] = None,
     ):
         self.allow_smart = allow_smart
-        self.excluded_chars = set(excluded_chars or [])
+        legacy_excluded_chars = set(excluded_chars or [])
+        self.safe_excluded_chars = (
+            set(safe_excluded_chars or []) | legacy_excluded_chars
+        )
+        self.rare_review_chars = set(rare_review_chars or [])
+        self.mojibake_trigger_chars = set(mojibake_trigger_chars or [])
 
     def _is_allowed(self, ch: str) -> bool:
         if ch.isascii():
@@ -111,10 +137,78 @@ class SpecialCharactersDetector:
             return True
         return False
 
-    def run(self, text: str) -> list[Finding]:
+    def _detect_mojibake_sequences(self, text: str) -> list[Finding]:
         findings = []
+        pattern_checks = [
+            ("A-circumflex-sequence", self._A_CIRCUMFLEX_MOJIBAKE_RE),
+            ("A-tilde-sequence", self._A_TILDE_MOJIBAKE_RE),
+        ]
+        for pattern_type, pattern in pattern_checks:
+            for match in pattern.finditer(text):
+                findings.append(
+                    Finding(
+                        kind="mojibake-sequence",
+                        severity="error",
+                        span=(match.start(), match.end()),
+                        message="Likely mojibake sequence.",
+                        evidence={
+                            "type": pattern_type,
+                            "sequence": match.group(0),
+                        },
+                    )
+                )
+
+        for sequence in self._BROKEN_PUNCT_MOJIBAKE_SEQS:
+            start = 0
+            while True:
+                index = text.find(sequence, start)
+                if index == -1:
+                    break
+                findings.append(
+                    Finding(
+                        kind="mojibake-sequence",
+                        severity="error",
+                        span=(index, index + len(sequence)),
+                        message="Likely mojibake punctuation sequence.",
+                        evidence={
+                            "type": "broken-punctuation-sequence",
+                            "sequence": sequence,
+                        },
+                    )
+                )
+                start = index + 1
+
+        findings.sort(key=lambda finding: finding.span)
+        return findings
+
+    def run(self, text: str) -> list[Finding]:
+        findings = self._detect_mojibake_sequences(text)
+        mojibake_covered_indexes = set()
+        for finding in findings:
+            for index in range(finding.span[0], finding.span[1]):
+                mojibake_covered_indexes.add(index)
+
         for idx, ch in enumerate(text):
-            if ch in self.excluded_chars or self._is_allowed(ch):
+            if idx in mojibake_covered_indexes:
+                continue
+            if ch in self.safe_excluded_chars or self._is_allowed(ch):
+                continue
+            if ch in self.rare_review_chars:
+                findings.append(
+                    Finding(
+                        kind="rare-review-character",
+                        severity="info",
+                        span=(idx, idx + 1),
+                        message=f"Uncommon character for review U+{ord(ch):04X}",
+                        evidence={
+                            "character": ch,
+                            "codepoint": f"U+{ord(ch):04X}",
+                            "unicode_name": unicodedata.name(ch, "UNKNOWN"),
+                        },
+                    )
+                )
+                continue
+            if ch in self.mojibake_trigger_chars:
                 continue
 
             findings.append(
@@ -435,7 +529,11 @@ def run_detectors(
 
     if detectors is None:
         detectors = [
-            SpecialCharactersDetector(),
+            SpecialCharactersDetector(
+                safe_excluded_chars=SAFE_EXCLUDED_CHARS,
+                rare_review_chars=RARE_REVIEW_CHARS,
+                mojibake_trigger_chars=MOJIBAKE_TRIGGER_CHARS,
+            ),
             StartDetector(),
             EndDetector(),
             ChapterHeadingDetector(),

--- a/lcats/tests/analysis/test_corpus_survey.py
+++ b/lcats/tests/analysis/test_corpus_survey.py
@@ -240,6 +240,63 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
 
         self.assertEqual([], findings)
 
+    def test_safe_accented_characters_and_horizontal_bar_are_not_flagged(self):
+        detector = corpus_survey.SpecialCharactersDetector(
+            safe_excluded_chars=corpus_survey.SAFE_EXCLUDED_CHARS,
+            rare_review_chars=corpus_survey.RARE_REVIEW_CHARS,
+            mojibake_trigger_chars=corpus_survey.MOJIBAKE_TRIGGER_CHARS,
+        )
+        text = "A naïve café uses æ and œ with ― punctuation."
+
+        findings = detector.run(text)
+
+        self.assertEqual([], findings)
+
+    def test_rare_review_characters_emit_low_severity_findings(self):
+        detector = corpus_survey.SpecialCharactersDetector(
+            safe_excluded_chars=corpus_survey.SAFE_EXCLUDED_CHARS,
+            rare_review_chars=corpus_survey.RARE_REVIEW_CHARS,
+            mojibake_trigger_chars=corpus_survey.MOJIBAKE_TRIGGER_CHARS,
+        )
+
+        findings = detector.run("Transliteration: Ō ā ×")
+
+        self.assertEqual(3, len(findings))
+        for finding in findings:
+            self.assertEqual("rare-review-character", finding.kind)
+            self.assertEqual("info", finding.severity)
+
+    def test_mojibake_sequences_emit_high_severity_findings(self):
+        detector = corpus_survey.SpecialCharactersDetector(
+            safe_excluded_chars=corpus_survey.SAFE_EXCLUDED_CHARS,
+            rare_review_chars=corpus_survey.RARE_REVIEW_CHARS,
+            mojibake_trigger_chars=corpus_survey.MOJIBAKE_TRIGGER_CHARS,
+        )
+        text = "Broken tokens: Â£ and Ã© and â€™."
+
+        findings = detector.run(text)
+
+        self.assertGreaterEqual(len(findings), 3)
+        self.assertTrue(
+            all(finding.kind == "mojibake-sequence" for finding in findings)
+        )
+        self.assertTrue(all(finding.severity == "error" for finding in findings))
+
+    def test_valid_accented_text_does_not_flood_findings(self):
+        detector = corpus_survey.SpecialCharactersDetector(
+            safe_excluded_chars=corpus_survey.SAFE_EXCLUDED_CHARS,
+            rare_review_chars=corpus_survey.RARE_REVIEW_CHARS,
+            mojibake_trigger_chars=corpus_survey.MOJIBAKE_TRIGGER_CHARS,
+        )
+        text = (
+            "Émile wrote about naïve readers in café salons while "
+            "François and Zoë discussed œuvre and æsthetics."
+        )
+
+        findings = detector.run(text)
+
+        self.assertEqual([], findings)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation

- The previous single mixed allowlist conflated safe accented letters, rare-but-valid symbols, and characters that commonly appear in mojibake sequences, causing poor signal quality.  
- Encoding failures (UTF-8 decoded as cp1252/latin-1) are usually visible as sequences, not single isolated codepoints, so detection should focus on patterns.  
- `U+2015 (―)` has been observed as legitimate in this corpus and should be treated as safe by default.

### Description

- Introduced explicit buckets: `SAFE_EXCLUDED_CHARS`, `RARE_REVIEW_CHARS`, and `MOJIBAKE_TRIGGER_CHARS` in `lcats/lcats/analysis/corpus_survey.py`, and kept `DEFAULT_EXCLUDED_CHARS` as an aggregate for CLI backward compatibility.  
- Reworked `SpecialCharactersDetector` to:  
  - detect likely mojibake patterns via `_detect_mojibake_sequences` (regexes for `Â...` and `Ã...` and a table of classic broken punctuation sequences beginning with `â`), emitting `kind="mojibake-sequence"` with `severity="error"`;  
  - classify characters in `RARE_REVIEW_CHARS` as `kind="rare-review-character"` with `severity="info"` (low-severity review findings);  
  - treat `SAFE_EXCLUDED_CHARS` (including `―`) as quiet by default and suppress noise from `MOJIBAKE_TRIGGER_CHARS` unless they participate in a detected sequence.  
- Preserved legacy `excluded_chars` parameter by merging it into `safe_excluded_chars` to keep CLI behavior stable.  
- Wired the default detectors in `run_detectors` to construct `SpecialCharactersDetector` with the new buckets so the new behavior is the default.

### Testing

- Added unit tests in `lcats/tests/analysis/test_corpus_survey.py` that assert: safe accented text (and `―`) do not produce findings, `RARE_REVIEW_CHARS` produce low-severity (`info`) findings, mojibake sequences (`Â...`, `Ã...`, and `â...` punctuation sequences) produce high-severity (`error`) findings, and ordinary accented prose does not flood findings.  
- Ran the focused test module via `python -m unittest tests.analysis.test_corpus_survey` and it passed.  
- Ran `scripts/format` and `scripts/lint` (formatting/lint fixes applied where needed) and both finished successfully.  
- Ran the full test suite via `scripts/test`; unrelated environment/dependency failures occurred (tiktoken attempted remote fetch blocked by proxy and missing `parameterized` package), so full-suite failures are external to these changes and not caused by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06d6fc34c8327a355c2f3ecc2ed5f)