### PR TITLE
corpus_survey: add TSV output, file write, and progress control

### DIFF
--- a/lcats/lcats/analysis/corpus_survey.py
+++ b/lcats/lcats/analysis/corpus_survey.py
@@ -1,6 +1,7 @@
 """Corpus survey architecture primitives and detector orchestration."""
 
 import argparse
+import csv
 from dataclasses import dataclass
 import json
 import pathlib
@@ -75,6 +76,24 @@ DEFAULT_EXCLUDED_CHARS = (
     SAFE_EXCLUDED_CHARS + RARE_REVIEW_CHARS + MOJIBAKE_TRIGGER_CHARS
 )
 DEFAULT_CHECKS = ["special-characters"]
+DEFAULT_OUTPUT_FORMAT = "human"
+TSV_COLUMNS = [
+    "path",
+    "check",
+    "kind",
+    "severity",
+    "codepoint",
+    "char",
+    "unicode_name",
+    "occurrence_index",
+    "offset",
+    "span_start",
+    "span_end",
+    "context",
+    "classification",
+    "evidence",
+    "message",
+]
 
 BOUNDARY_WINDOW_LINES = 12
 STRUCTURAL_WINDOW_LINES = 40
@@ -642,10 +661,101 @@ def run_boundary_contamination_check(displayed_text: str) -> str:
     return "\n".join(lines)
 
 
-def survey_file(file_path: pathlib.Path, args) -> list[tuple[str, str]]:
-    """Run enabled checks on a single corpus file and return check outputs."""
+def _empty_tsv_row() -> dict[str, str]:
+    """Return a blank TSV row with all stable fields present."""
+    return {column: "" for column in TSV_COLUMNS}
+
+
+def _severity_from_classification(classification: str) -> str:
+    """Map special-character classification to severity."""
+    lowered = classification.lower()
+    if "mojibake" in lowered:
+        return "error"
+    if "rare" in lowered:
+        return "info"
+    if lowered:
+        return "warning"
+    return "warning"
+
+
+def parse_special_character_rows(
+    tsv_output: str, file_path: pathlib.Path
+) -> list[dict[str, str]]:
+    """Parse extractor TSV output into stable report rows."""
+    if not tsv_output.strip():
+        return []
+
+    rows = []
+    parsed_rows = list(csv.reader(tsv_output.splitlines(), delimiter="\t"))
+    if parsed_rows and parsed_rows[0] and parsed_rows[0][0] == "codepoint":
+        parsed_rows = parsed_rows[1:]
+
+    for parts in parsed_rows:
+        if not parts:
+            continue
+        padded = parts + [""] * (8 - len(parts))
+        row = _empty_tsv_row()
+        row.update(
+            {
+                "path": str(file_path),
+                "check": "special-characters",
+                "kind": "special-character",
+                "severity": _severity_from_classification(padded[6]),
+                "codepoint": padded[0],
+                "char": padded[1],
+                "unicode_name": padded[2],
+                "occurrence_index": padded[3],
+                "offset": padded[4],
+                "context": padded[5],
+                "classification": padded[6],
+                "evidence": padded[7],
+                "message": "Special character finding.",
+            }
+        )
+        rows.append(row)
+
+    return rows
+
+
+def _finding_to_row(
+    file_path: pathlib.Path, check_name: str, finding: Finding
+) -> dict[str, str]:
+    """Convert one Finding into a stable TSV row."""
+    row = _empty_tsv_row()
+    row.update(
+        {
+            "path": str(file_path),
+            "check": check_name,
+            "kind": finding.kind,
+            "severity": finding.severity,
+            "span_start": str(finding.span[0]),
+            "span_end": str(finding.span[1]),
+            "evidence": json.dumps(dict(finding.evidence), ensure_ascii=False),
+            "message": finding.message,
+        }
+    )
+    return row
+
+
+def _clean_row(file_path: pathlib.Path) -> dict[str, str]:
+    """Build a summary row for files with no findings."""
+    row = _empty_tsv_row()
+    row.update(
+        {
+            "path": str(file_path),
+            "check": "summary",
+            "kind": "clean",
+            "severity": "info",
+            "message": "No findings.",
+        }
+    )
+    return row
+
+
+def survey_file(file_path: pathlib.Path, args) -> list[dict[str, str]]:
+    """Run enabled checks on a single corpus file and return report rows."""
     displayed_text = run_lcats_display(file_path)
-    findings = []
+    rows = []
 
     for check_name in args.check_for:
         if check_name == "special-characters":
@@ -661,16 +771,19 @@ def survey_file(file_path: pathlib.Path, args) -> list[tuple[str, str]]:
                 name_width=args.name_width,
                 header=False,
             )
-            if output:
-                findings.append((check_name, output))
+            rows.extend(parse_special_character_rows(output, file_path))
         elif check_name == "boundary-contamination":
-            output = run_boundary_contamination_check(displayed_text)
-            if output:
-                findings.append((check_name, output))
+            boundary_findings = run_detectors(
+                displayed_text, config={"detectors": [StartDetector(), EndDetector()]}
+            )
+            rows.extend(
+                _finding_to_row(file_path, check_name, finding)
+                for finding in boundary_findings
+            )
         else:
             raise ValueError(f"Unsupported check: {check_name}")
 
-    return findings
+    return rows
 
 
 def parse_csv_args(values):
@@ -753,9 +866,41 @@ def build_parser():
     )
     parser.add_argument(
         "--header",
+        dest="header",
         action="store_true",
-        help="Emit a TSV header row.",
+        help="Emit a TSV header row (default in TSV mode).",
     )
+    parser.add_argument(
+        "--no-header",
+        dest="header",
+        action="store_false",
+        help="Do not emit a TSV header row.",
+    )
+    parser.set_defaults(header=None)
+    parser.add_argument(
+        "--format",
+        choices=["human", "tsv"],
+        default=DEFAULT_OUTPUT_FORMAT,
+        help="Output format (human or machine-readable TSV).",
+    )
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Optional output file path (default: stdout).",
+    )
+    parser.add_argument(
+        "--progress",
+        dest="progress",
+        action="store_true",
+        help="Force-enable the progress bar.",
+    )
+    parser.add_argument(
+        "--no-progress",
+        dest="progress",
+        action="store_false",
+        help="Disable the progress bar.",
+    )
+    parser.set_defaults(progress=None)
 
     parser.add_argument(
         "--exclude-codepoint",
@@ -776,6 +921,41 @@ def build_parser():
         ),
     )
     return parser
+
+
+def _show_progress(progress_arg: Optional[bool]) -> bool:
+    """Resolve progress-bar visibility from CLI choice and TTY defaults."""
+    if progress_arg is not None:
+        return progress_arg
+    return sys.stderr.isatty()
+
+
+def _write_human_rows(
+    output_stream, file_path: pathlib.Path, rows: Sequence[Mapping[str, str]]
+) -> None:
+    """Write human-readable findings for one file."""
+    print(str(file_path), file=output_stream)
+    for row in rows:
+        check_name = row.get("check", "")
+        severity = row.get("severity", "")
+        message = row.get("message", "")
+        codepoint = row.get("codepoint", "")
+        character = row.get("char", "")
+        span_start = row.get("span_start", "")
+        span_end = row.get("span_end", "")
+
+        details = []
+        if codepoint:
+            details.append(codepoint)
+        if character:
+            details.append(repr(character))
+        if span_start or span_end:
+            details.append(f"span={span_start}:{span_end}")
+        suffix = f" ({', '.join(details)})" if details else ""
+        print(
+            f"  [{check_name}] {severity}: {message}{suffix}",
+            file=output_stream,
+        )
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -802,31 +982,46 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     try:
         files_found = list(find_json_files(args.directories))
-        header_written = False
+        output_stream = sys.stdout
+        if args.output:
+            output_stream = pathlib.Path(args.output).open(
+                "w", encoding="utf-8", newline=""
+            )
 
-        for file_path in tqdm.tqdm(files_found):
-            findings = survey_file(file_path, args)
+        header_enabled = args.header
+        if header_enabled is None:
+            header_enabled = args.format == "tsv"
 
-            if findings:
+        tsv_writer = None
+        if args.format == "tsv":
+            tsv_writer = csv.DictWriter(
+                output_stream,
+                fieldnames=TSV_COLUMNS,
+                delimiter="\t",
+                extrasaction="ignore",
+            )
+            if header_enabled:
+                tsv_writer.writeheader()
+
+        for file_path in tqdm.tqdm(
+            files_found, disable=not _show_progress(args.progress)
+        ):
+            rows = survey_file(file_path, args)
+            if rows:
                 had_findings = True
-                for check_name, output in findings:
-                    if len(args.check_for) > 1:
-                        print(f"#check={check_name}\tpath={file_path}")
-                    for line in output.splitlines():
-                        if not line.strip():
-                            continue
-                        if args.header and not header_written:
-                            print(
-                                "path\tcodepoint\tchar\tunicode_name\t"
-                                "occurrence_index\toffset\tcontext\t"
-                                "classification\tevidence"
-                            )
-                            header_written = True
-                        print(f"{file_path}\t{line}")
+                if args.format == "tsv":
+                    for row in rows:
+                        tsv_writer.writerow(row)
+                else:
+                    _write_human_rows(output_stream, file_path, rows)
             elif args.print_clean_filenames:
-                print(file_path)
-                print("[clean]")
+                if args.format == "tsv":
+                    tsv_writer.writerow(_clean_row(file_path))
+                else:
+                    print(f"{file_path} [clean]", file=output_stream)
 
+        if output_stream is not sys.stdout:
+            output_stream.close()
         return 1 if had_findings else 0
 
     except BrokenPipeError:

--- a/lcats/tests/analysis_tests/corpus_survey_test.py
+++ b/lcats/tests/analysis_tests/corpus_survey_test.py
@@ -5,6 +5,7 @@ import pathlib
 import tempfile
 import unittest
 import unittest.mock
+from unittest import mock
 
 from lcats.analysis import corpus_survey
 
@@ -296,6 +297,198 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
         findings = detector.run(text)
 
         self.assertEqual([], findings)
+
+    def test_parse_special_character_rows_uses_stable_schema(self):
+        output = "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tspecial\tliteral"
+
+        rows = corpus_survey.parse_special_character_rows(
+            output, pathlib.Path("story.json")
+        )
+
+        self.assertEqual(1, len(rows))
+        row = rows[0]
+        self.assertEqual(corpus_survey.TSV_COLUMNS, list(row.keys()))
+        self.assertEqual("story.json", row["path"])
+        self.assertEqual("special-characters", row["check"])
+        self.assertEqual("U+00A9", row["codepoint"])
+
+    def test_parse_special_character_rows_skips_header_line(self):
+        output = (
+            "codepoint\tchar\tunicode_name\toccurrence_index\t"
+            "offset\tcontext\tclassification\tevidence\n"
+            "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tspecial\tliteral"
+        )
+
+        rows = corpus_survey.parse_special_character_rows(
+            output, pathlib.Path("story.json")
+        )
+
+        self.assertEqual(1, len(rows))
+        self.assertEqual("U+00A9", rows[0]["codepoint"])
+
+    def test_main_tsv_output_has_stable_columns_for_multiple_checks(self):
+        rows = [
+            {
+                "path": "story.json",
+                "check": "special-characters",
+                "kind": "special-character",
+                "severity": "warning",
+                "codepoint": "U+00A9",
+                "char": "©",
+                "unicode_name": "COPYRIGHT SIGN",
+                "occurrence_index": "1",
+                "offset": "2",
+                "span_start": "",
+                "span_end": "",
+                "context": "ctx",
+                "classification": "special",
+                "evidence": "literal",
+                "message": "Special character finding.",
+            },
+            {
+                "path": "story.json",
+                "check": "boundary-contamination",
+                "kind": "start-contamination",
+                "severity": "warning",
+                "codepoint": "",
+                "char": "",
+                "unicode_name": "",
+                "occurrence_index": "",
+                "offset": "",
+                "span_start": "0",
+                "span_end": "10",
+                "context": "",
+                "classification": "",
+                "evidence": '{"line":"By Author"}',
+                "message": "Likely author line at start of story.",
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            story_path = pathlib.Path(temp_dir) / "story.json"
+            story_path.write_text("{}", encoding="utf-8")
+
+            with mock.patch.object(
+                corpus_survey, "find_json_files", return_value=[story_path]
+            ), mock.patch.object(
+                corpus_survey, "survey_file", return_value=rows
+            ), mock.patch.object(
+                corpus_survey.sys.stderr, "isatty", return_value=False
+            ), mock.patch(
+                "sys.stdout"
+            ) as fake_stdout:
+                exit_code = corpus_survey.main(
+                    [
+                        "--format",
+                        "tsv",
+                        "--check-for",
+                        "special-characters,boundary-contamination",
+                        "--no-progress",
+                        temp_dir,
+                    ]
+                )
+
+        self.assertEqual(1, exit_code)
+        output = "".join(call.args[0] for call in fake_stdout.write.call_args_list)
+        lines = [line for line in output.splitlines() if line]
+        self.assertGreaterEqual(len(lines), 3)
+        self.assertEqual("\t".join(corpus_survey.TSV_COLUMNS), lines[0])
+        self.assertTrue(all(not line.startswith("#check=") for line in lines[1:]))
+
+    def test_main_tsv_output_file_writes_and_skips_stdout(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            story_path = pathlib.Path(temp_dir) / "story.json"
+            story_path.write_text("{}", encoding="utf-8")
+            output_path = pathlib.Path(temp_dir) / "report.tsv"
+            row = corpus_survey._clean_row(story_path)
+
+            with mock.patch.object(
+                corpus_survey, "find_json_files", return_value=[story_path]
+            ), mock.patch.object(
+                corpus_survey, "survey_file", return_value=[]
+            ), mock.patch.object(
+                corpus_survey.sys.stderr, "isatty", return_value=False
+            ), mock.patch(
+                "sys.stdout"
+            ) as fake_stdout:
+                exit_code = corpus_survey.main(
+                    [
+                        "--format",
+                        "tsv",
+                        "--output",
+                        str(output_path),
+                        "--print-clean-filenames",
+                        "--no-progress",
+                        temp_dir,
+                    ]
+                )
+
+            self.assertEqual(0, exit_code)
+            self.assertEqual([], fake_stdout.write.call_args_list)
+            written = output_path.read_text(encoding="utf-8")
+            self.assertIn("\t".join(corpus_survey.TSV_COLUMNS), written)
+            self.assertIn("summary\tclean\tinfo", written)
+            self.assertEqual("summary", row["check"])
+
+    def test_main_tsv_no_header_is_deterministic(self):
+        rows = [corpus_survey._clean_row(pathlib.Path("story.json"))]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            story_path = pathlib.Path(temp_dir) / "story.json"
+            story_path.write_text("{}", encoding="utf-8")
+
+            with mock.patch.object(
+                corpus_survey, "find_json_files", return_value=[story_path]
+            ), mock.patch.object(
+                corpus_survey, "survey_file", return_value=rows
+            ), mock.patch.object(
+                corpus_survey.sys.stderr, "isatty", return_value=False
+            ), mock.patch(
+                "sys.stdout"
+            ) as fake_stdout:
+                corpus_survey.main(
+                    ["--format", "tsv", "--no-header", "--no-progress", temp_dir]
+                )
+
+        output = "".join(call.args[0] for call in fake_stdout.write.call_args_list)
+        lines = [line for line in output.splitlines() if line]
+        self.assertEqual(1, len(lines))
+        self.assertNotEqual("\t".join(corpus_survey.TSV_COLUMNS), lines[0])
+
+    def test_main_progress_default_follows_tty(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            story_path = pathlib.Path(temp_dir) / "story.json"
+            story_path.write_text("{}", encoding="utf-8")
+
+            with mock.patch.object(
+                corpus_survey, "find_json_files", return_value=[story_path]
+            ), mock.patch.object(
+                corpus_survey, "survey_file", return_value=[]
+            ), mock.patch.object(
+                corpus_survey.sys.stderr, "isatty", return_value=False
+            ), mock.patch.object(
+                corpus_survey.tqdm, "tqdm"
+            ) as mock_tqdm:
+                mock_tqdm.side_effect = lambda items, disable: items
+                corpus_survey.main([temp_dir])
+
+        self.assertTrue(mock_tqdm.call_args.kwargs["disable"])
+
+    def test_main_no_progress_disables_tqdm(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            story_path = pathlib.Path(temp_dir) / "story.json"
+            story_path.write_text("{}", encoding="utf-8")
+
+            with mock.patch.object(
+                corpus_survey, "find_json_files", return_value=[story_path]
+            ), mock.patch.object(
+                corpus_survey, "survey_file", return_value=[]
+            ), mock.patch.object(
+                corpus_survey.tqdm, "tqdm"
+            ) as mock_tqdm:
+                mock_tqdm.side_effect = lambda items, disable: items
+                corpus_survey.main(["--no-progress", temp_dir])
+
+        self.assertTrue(mock_tqdm.call_args.kwargs["disable"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Make the corpus survey tool easier to use in scripts and pipelines by separating human-oriented output from machine-oriented tabular output and making tabular output stable and parseable.
- Allow users to opt into or out of progress reporting to avoid contaminating piped output and to be friendly in interactive sessions.
- Provide an option to write reports to a file so downstream tooling can consume results without capturing stdout.

### Description
- Added CLI options `--format` (`human`|`tsv`), `--output PATH`, `--progress`, and `--no-progress`, and `--header`/`--no-header` to `build_parser()` so output mode, destination, and progress visibility are explicit and controlled via flags.
- Introduced a stable TSV schema constant `TSV_COLUMNS` and switched TSV emission to `csv.DictWriter(..., delimiter="\t")` so columns are ordered, tab-separated, and safely escaped when needed.
- Parsed the special-character extractor output into the stable schema via `parse_special_character_rows(...)`, converted detector `Finding` objects into the same schema with `_finding_to_row(...)`, and emitted clean-file summary rows with `_clean_row(...)` so TSV mode never prints decorative or ad-hoc lines.
- Implemented progress visibility resolution in `_show_progress(...)` which uses explicit CLI choice when provided and otherwise defaults to `sys.stderr.isatty()`; `tqdm` is used with `disable=not _show_progress(...)` to avoid multiple code paths.
- Kept existing detector logic unchanged and added a simple human-mode printer `_write_human_rows(...)` so interactive output remains readable while TSV output remains pure rows.

### Testing
- Ran the targeted unit tests for this module with `python -m unittest tests.analysis_tests.corpus_survey_test` and they passed (new tests included cover schema parsing, header behavior, file output, and progress flags).
- Ran formatting and linting with `scripts/format` and `scripts/lint` and fixed formatting; both checks passed after changes.
- Ran the project test driver `scripts/test`; it reported unrelated failures in other suites caused by external environment/dependencies (tiktoken encoder download blocked by proxy and missing `parameterized` package), so full-suite failures are unrelated to this PR and the corpus_survey tests still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e076f092f483278a44cf440fa88bed)