### PR TITLE
Refactor LCATS CLI help and subcommand parsing

### DIFF
--- a/lcats/lcats/analysis/corpus/cli.py
+++ b/lcats/lcats/analysis/corpus/cli.py
@@ -86,10 +86,11 @@ def parse_csv_args(values):
     return items
 
 
-def build_survey_parser() -> argparse.ArgumentParser:
+def build_survey_parser(add_help: bool = True) -> argparse.ArgumentParser:
     """Build parser for the survey subcommand."""
     parser = argparse.ArgumentParser(
-        description="Survey LCATS corpora files for issues."
+        description="Survey LCATS corpora files for issues.",
+        add_help=add_help,
     )
     parser.add_argument(
         "directories",
@@ -132,9 +133,12 @@ def build_survey_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def build_stats_parser() -> argparse.ArgumentParser:
+def build_stats_parser(add_help: bool = True) -> argparse.ArgumentParser:
     """Build parser for the stats subcommand."""
-    parser = argparse.ArgumentParser(description="Compute LCATS corpus statistics.")
+    parser = argparse.ArgumentParser(
+        description="Compute LCATS corpus statistics.",
+        add_help=add_help,
+    )
     parser.add_argument("directories", nargs="*", default=["data/"])
     parser.add_argument("--dedupe", dest="dedupe", action="store_true")
     parser.add_argument("--no-dedupe", dest="dedupe", action="store_false")
@@ -188,10 +192,13 @@ def survey_file(file_path: pathlib.Path, args) -> list[dict[str, str]]:
     return rows
 
 
-def run_survey(argv: Optional[Sequence[str]] = None) -> int:
+def run_survey(
+    argv: Optional[Sequence[str]] = None,
+    parsed_args: Optional[argparse.Namespace] = None,
+) -> int:
     """Run survey subcommand."""
     parser = build_survey_parser()
-    args = parser.parse_args(argv)
+    args = parsed_args if parsed_args is not None else parser.parse_args(argv)
     if args.context < 0:
         parser.error("--context must be >= 0")
     if args.name_width < 0:
@@ -256,10 +263,13 @@ def run_survey(argv: Optional[Sequence[str]] = None) -> int:
             output_stream.close()
 
 
-def run_stats(argv: Optional[Sequence[str]] = None) -> int:
+def run_stats(
+    argv: Optional[Sequence[str]] = None,
+    parsed_args: Optional[argparse.Namespace] = None,
+) -> int:
     """Run stats subcommand."""
     parser = build_stats_parser()
-    args = parser.parse_args(argv)
+    args = parsed_args if parsed_args is not None else parser.parse_args(argv)
     files = []
     for directory in args.directories:
         if pathlib.Path(directory).is_dir():

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -4,83 +4,238 @@ import argparse
 import sys
 
 from lcats.analysis.corpus import cli as corpus_cli
-import lcats.inspect
 import lcats.gatherers.main
-
-USAGE_MESSAGE = """Usage: lcats <command> [<args>]
-Commands:   
-    help      Display this help message.
-    info      Describes LCATS, the literary captain's advisory tool system.
-    gather    Gathers corpus data to a local database.
-    inspect   Inspects a story JSON file and summarizes its contents.
-    display   Displays entire story JSON file in a human-readable format.
-    survey    Surveys corpus files for quality issues.
-    stats     Computes corpus-level statistics.
-    index     Preprocesses a corpus to answer questions.
-    advise    LCATS command-line advising tool.
-    eval      Evaluate LCATS on a benchmark suite.
-"""
+import lcats.inspect
 
 
-def usage():
-    """Prints the usage message for the LCATS command-line interface."""
-    return USAGE_MESSAGE
+TOP_LEVEL_DESCRIPTION = (
+    "LCATS is a literary case-based reasoning toolkit for gathering, inspecting, "
+    "surveying, and analyzing corpora."
+)
+TOP_LEVEL_EPILOG = (
+    "Run 'lcats <command> --help' for more information.\n"
+    "You can also use 'lcats help <command>'."
+)
+
+
+def _handle_info(_args):
+    return "LCATS is a literary case based reasoning system.", 0
+
+
+def _handle_gather(args):
+    return lcats.gatherers.main.run(args.gatherers, dry_run=args.dry_run)
+
+
+def _handle_inspect(args):
+    return lcats.inspect.inspect_files(*args.files)
+
+
+def _handle_display(args):
+    return lcats.inspect.display_files(*args.files)
+
+
+def _handle_survey(args):
+    return "", corpus_cli.run_survey(parsed_args=args)
+
+
+def _handle_stats(args):
+    return "", corpus_cli.run_stats(parsed_args=args)
+
+
+def _handle_index(_args):
+    return "Indexing data files is not yet implemented.", 1
+
+
+def _handle_advise(_args):
+    return "Getting advice from LCATS is not yet implemented.", 1
+
+
+def _handle_eval(_args):
+    return "Evaluating LCATS is not yet implemented.", 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build and return the top-level LCATS command parser."""
+    parser = argparse.ArgumentParser(
+        prog="lcats",
+        description=TOP_LEVEL_DESCRIPTION,
+        epilog=TOP_LEVEL_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    command_parsers = {}
+
+    help_parser = subparsers.add_parser(
+        "help",
+        help="Display top-level or command-specific help.",
+        description="Display LCATS help, including command-specific help.",
+    )
+    help_parser.add_argument(
+        "topic",
+        nargs="?",
+        help="Optional command name, for example: lcats help survey",
+    )
+    command_parsers["help"] = help_parser
+
+    info_parser = subparsers.add_parser(
+        "info",
+        help="Describe LCATS.",
+        description="Describe LCATS, the literary captain's advisory tool system.",
+    )
+    info_parser.add_argument("args", nargs=argparse.REMAINDER)
+    info_parser.set_defaults(handler=_handle_info)
+    command_parsers["info"] = info_parser
+
+    gather_parser = subparsers.add_parser(
+        "gather",
+        help="Gather corpus data to a local database.",
+        description="Gather one or more configured corpora.",
+    )
+    gather_parser.add_argument(
+        "gatherers",
+        nargs="*",
+        help="Optional gatherer names. Defaults to all gatherers.",
+    )
+    gather_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show which gatherers would run without executing downloads.",
+    )
+    gather_parser.set_defaults(handler=_handle_gather)
+    command_parsers["gather"] = gather_parser
+
+    inspect_parser = subparsers.add_parser(
+        "inspect",
+        help="Summarize one or more story JSON files.",
+        description="Inspect one or more story JSON files and print summaries.",
+    )
+    inspect_parser.add_argument("files", nargs="*")
+    inspect_parser.set_defaults(handler=_handle_inspect)
+    command_parsers["inspect"] = inspect_parser
+
+    display_parser = subparsers.add_parser(
+        "display",
+        help="Display full story JSON content.",
+        description="Display one or more story JSON files in human-readable form.",
+    )
+    display_parser.add_argument("files", nargs="*")
+    display_parser.set_defaults(handler=_handle_display)
+    command_parsers["display"] = display_parser
+
+    survey_parent = corpus_cli.build_survey_parser(add_help=False)
+    survey_parser = subparsers.add_parser(
+        "survey",
+        parents=[survey_parent],
+        help="Survey corpus files for quality issues.",
+        description=(
+            "Survey LCATS corpus JSON files for quality issues such as special "
+            "characters and boundary contamination."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  lcats survey corpora/sherlock --check-for special-characters\n"
+            "  lcats survey data/ --format tsv --output findings.tsv\n"
+            "  lcats survey corpora/sherlock --no-progress --print-clean-filenames"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    survey_parser.set_defaults(handler=_handle_survey)
+    command_parsers["survey"] = survey_parser
+
+    stats_parent = corpus_cli.build_stats_parser(add_help=False)
+    stats_parser = subparsers.add_parser(
+        "stats",
+        parents=[stats_parent],
+        help="Compute corpus-level statistics.",
+        description=(
+            "Compute story-level and author-level statistics for one or more "
+            "corpus directories or JSON files."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  lcats stats corpora/sherlock\n"
+            "  lcats stats data/ --no-dedupe\n"
+            "  lcats stats data/ --story-output story_stats.tsv --author-output author_stats.tsv"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    stats_parser.set_defaults(handler=_handle_stats)
+    command_parsers["stats"] = stats_parser
+
+    index_parser = subparsers.add_parser(
+        "index",
+        help="Preprocess a corpus for question answering.",
+        description="Preprocess a corpus to answer questions.",
+    )
+    index_parser.set_defaults(handler=_handle_index)
+    command_parsers["index"] = index_parser
+
+    advise_parser = subparsers.add_parser(
+        "advise",
+        help="Run the LCATS advising tool.",
+        description="Run the LCATS command-line advising tool.",
+    )
+    advise_parser.set_defaults(handler=_handle_advise)
+    command_parsers["advise"] = advise_parser
+
+    eval_parser = subparsers.add_parser(
+        "eval",
+        help="Evaluate LCATS on benchmark suites.",
+        description="Evaluate LCATS on a benchmark suite.",
+    )
+    eval_parser.set_defaults(handler=_handle_eval)
+    command_parsers["eval"] = eval_parser
+
+    def _handle_help(args):
+        if not args.topic:
+            return parser.format_help(), 0
+        topic_parser = command_parsers.get(args.topic)
+        if topic_parser is None:
+            return f"Unknown command: {args.topic}", 1
+        return topic_parser.format_help(), 0
+
+    help_parser.set_defaults(handler=_handle_help)
+    parser.command_parsers = command_parsers
+    return parser
+
+
+def usage() -> str:
+    """Return the top-level LCATS help text."""
+    return build_parser().format_help()
 
 
 def dispatch(command, args):
-    """Dispatches the command to the appropriate function.
-
-    Args:
-        command: The command to execute.
-        args: A list of additional arguments to the command.
-    Returns:
-        A tuple containing the output of the command and an exit status.
-    """
-    if command == "info":
-        return "LCATS is a literary case based reasoning system.", 0
-
-    elif command == "gather":
-        return lcats.gatherers.main.run(args)
-
-    elif command == "inspect":
-        return lcats.inspect.inspect_files(*args)
-
-    elif command == "display":
-        return lcats.inspect.display_files(*args)
-
-    elif command == "survey":
-        return "", corpus_cli.run_survey(args)
-
-    elif command == "stats":
-        return "", corpus_cli.run_stats(args)
-
-    elif command == "index":
-        return "Indexing data files is not yet implemented.", 1
-
-    elif command == "advise":
-        return "Getting advice from LCATS is not yet implemented.", 1
-
-    elif command == "eval":
-        return "Evaluating LCATS is not yet implemented.", 1
-
-    elif command == "help":
-        return usage(), 0
-
+    """Dispatch a command and list of arguments using the configured parser."""
+    parser = build_parser()
+    argv = [command, *args]
+    if command in parser.command_parsers and command != "help":
+        parsed = parser.command_parsers[command].parse_args(args)
+        parsed.command = command
     else:
-        return f"Unknown command: {command}", 1
+        parsed = parser.parse_args(argv)
+    handler = getattr(parsed, "handler", None)
+    if handler is None:
+        return parser.format_help(), 1
+    return handler(parsed)
 
 
-def main():
+def main(argv=None):
     """Main entry point for the LCATS command-line interface."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("command", nargs="?")
-    parser.add_argument("args", nargs=argparse.REMAINDER)
-    parsed = parser.parse_args()
+    parser = build_parser()
+    argv = list(argv) if argv is not None else sys.argv[1:]
 
-    if parsed.command is None:
-        print(usage())
+    if not argv:
+        print(parser.format_help())
         sys.exit(1)
-    result, status = dispatch(parsed.command, parsed.args)
+
+    if argv[0] in parser.command_parsers and argv[0] != "help":
+        parsed = parser.command_parsers[argv[0]].parse_args(argv[1:])
+        parsed.command = argv[0]
+    else:
+        parsed = parser.parse_args(argv)
+
+    result, status = parsed.handler(parsed)
     if result:
         print(result)
     sys.exit(status)

--- a/lcats/tests/cli_test.py
+++ b/lcats/tests/cli_test.py
@@ -1,7 +1,7 @@
 """Tests for the cli command-line interpreter module."""
 
 import unittest
-from unittest.mock import patch
+from unittest import mock
 
 import parameterized
 
@@ -11,8 +11,10 @@ from lcats.utils import capture
 
 class TestCli(unittest.TestCase):
 
-    def test_usage(self):
-        self.assertEqual(cli.usage(), cli.USAGE_MESSAGE)
+    def test_usage_contains_top_level_help(self):
+        usage = cli.usage()
+        self.assertIn("usage: lcats", usage)
+        self.assertIn("Run 'lcats <command> --help' for more information.", usage)
 
     def test_dispatch_info(self):
         """Ensure the dispatcher function is working."""
@@ -24,28 +26,31 @@ class TestCli(unittest.TestCase):
         self.assertEqual(result, "LCATS is a literary case based reasoning system.")
         self.assertEqual(response, 0)
 
-    @patch("lcats.gatherers.main.run")
+    @mock.patch("lcats.gatherers.main.run")
     def test_dispatch_gather(self, mock_run):
-        """Ensure the dispatcher function is working."""
+        """Ensure the gather command is routed through the gather module."""
         expected_message = "Gathering complete."
         expected_status = 0
         mock_run.return_value = (expected_message, expected_status)
 
-        actual_message, actual_status = cli.dispatch("gather", [True])
+        actual_message, actual_status = cli.dispatch(
+            "gather", ["--dry-run", "sherlock"]
+        )
         self.assertEqual(expected_message, actual_message)
         self.assertEqual(expected_status, actual_status)
+        mock_run.assert_called_once_with(["sherlock"], dry_run=True)
 
-    @patch("lcats.analysis.corpus.cli.run_survey")
-    def test_dispatch_survey(self, mock_main):
+    @mock.patch("lcats.analysis.corpus.cli.run_survey")
+    def test_dispatch_survey(self, mock_run_survey):
         """Ensure the survey command delegates to corpus cli."""
-        mock_main.return_value = 0
+        mock_run_survey.return_value = 0
 
         actual_message, actual_status = cli.dispatch("survey", ["corpora/sherlock"])
         self.assertEqual("", actual_message)
         self.assertEqual(0, actual_status)
-        mock_main.assert_called_once_with(["corpora/sherlock"])
+        mock_run_survey.assert_called_once()
 
-    @patch("lcats.analysis.corpus.cli.run_stats")
+    @mock.patch("lcats.analysis.corpus.cli.run_stats")
     def test_dispatch_stats(self, mock_run_stats):
         """Ensure the stats command delegates to corpus cli."""
         mock_run_stats.return_value = 0
@@ -53,7 +58,7 @@ class TestCli(unittest.TestCase):
         actual_message, actual_status = cli.dispatch("stats", ["corpora/sherlock"])
         self.assertEqual("", actual_message)
         self.assertEqual(0, actual_status)
-        mock_run_stats.assert_called_once_with(["corpora/sherlock"])
+        mock_run_stats.assert_called_once()
 
     @parameterized.parameterized.expand(
         [
@@ -69,30 +74,73 @@ class TestCli(unittest.TestCase):
         self.assertEqual(response, 1)
 
     def test_dispatch_unknown(self):
-        """Ensure the dispatcher function rejects unknown commands."""
-        result, response = cli.dispatch("unknown", [])
-        self.assertEqual(result, "Unknown command: unknown")
-        self.assertEqual(response, 1)
-
-    @patch("sys.argv", ["lcats", "survey", "corpora/sherlock"])
-    @patch("lcats.analysis.corpus.cli.run_survey")
-    def test_main_survey_invocation(self, mock_main):
-        """Ensure CLI main routes survey arguments via argparse."""
-        mock_main.return_value = 0
-
+        """Ensure unknown commands are rejected by the top-level parser."""
         with self.assertRaises(SystemExit) as cm:
-            cli.main()
+            cli.dispatch("unknown", [])
+        self.assertEqual(2, cm.exception.code)
 
-        self.assertEqual(0, cm.exception.code)
-        mock_main.assert_called_once_with(["corpora/sherlock"])
-
-    @patch("sys.argv", ["lcats", "--help"])
-    def test_main_help_flag_exits(self):
-        """Ensure argparse handles the built-in help flag."""
-        with capture.suppress_output():
+    @parameterized.parameterized.expand(
+        [
+            (["--help"], 0),
+            (["help"], 0),
+        ]
+    )
+    def test_top_level_help(self, argv, expected_code):
+        """Ensure top-level help works for both --help and help aliases."""
+        with capture.capture_output() as captured:
             with self.assertRaises(SystemExit) as cm:
-                cli.main()
+                cli.main(argv)
+        self.assertEqual(expected_code, cm.exception.code)
+        self.assertIn("usage: lcats", captured.stdout.getvalue())
+
+    @parameterized.parameterized.expand(
+        [
+            (["survey", "--help"], "usage: lcats survey"),
+            (["stats", "--help"], "usage: lcats stats"),
+            (["help", "survey"], "usage: lcats survey"),
+            (["help", "stats"], "usage: lcats stats"),
+        ]
+    )
+    def test_command_help(self, argv, expected_usage):
+        """Ensure command-level help is available from direct and alias paths."""
+        with capture.capture_output() as captured:
+            with self.assertRaises(SystemExit) as cm:
+                cli.main(argv)
         self.assertEqual(0, cm.exception.code)
+        self.assertIn(expected_usage, captured.stdout.getvalue())
+
+    def test_survey_help_contains_examples(self):
+        with capture.capture_output() as captured:
+            with self.assertRaises(SystemExit):
+                cli.main(["survey", "--help"])
+        output = captured.stdout.getvalue()
+        self.assertIn("Examples:", output)
+        self.assertIn("lcats survey data/ --format tsv --output findings.tsv", output)
+
+    def test_stats_help_contains_examples(self):
+        with capture.capture_output() as captured:
+            with self.assertRaises(SystemExit):
+                cli.main(["stats", "--help"])
+        output = captured.stdout.getvalue()
+        self.assertIn("Examples:", output)
+        self.assertIn("lcats stats data/ --no-dedupe", output)
+
+    @parameterized.parameterized.expand(
+        [
+            (
+                ["survey", "--format", "tsv", "--no-progress", "-foobar"],
+                "usage: lcats survey",
+            ),
+            (["stats", "--story-output", "out.tsv", "-foobar"], "usage: lcats stats"),
+        ]
+    )
+    def test_invalid_flags_show_subcommand_usage(self, argv, expected_usage):
+        with capture.capture_output() as captured:
+            with self.assertRaises(SystemExit) as cm:
+                cli.main(argv)
+        self.assertEqual(2, cm.exception.code)
+        stderr = captured.stderr.getvalue()
+        self.assertIn(expected_usage, stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Replace the old manual string-based dispatcher/help with a real `argparse`-driven CLI so top-level and per-command help/usage are consistent and discoverable.
- Make `lcats help` and `lcats help <command>` first-class convenience aliases that map to `lcats --help` and `lcats <command> --help` respectively.
- Ensure invalid flags on subcommands show the subcommand usage (e.g., `usage: lcats survey ...`) instead of only the root usage.

### Description
- Introduced a root parser builder `build_parser()` in `lcats/lcats/cli.py` and registered subparsers for `help`, `info`, `gather`, `inspect`, `display`, `survey`, `stats`, `index`, `advise`, and `eval`.
- Centralized handlers via `set_defaults(handler=...)` and wired dispatch so command-specific parsers validate their own flags (parsing subcommand args with the appropriate subparser in `main()` and `dispatch()`).
- Implemented `help` subcommand behavior so `lcats help` prints top-level help and `lcats help <command>` prints the same help as `lcats <command> --help` using each subparser's `format_help()`.
- Improved `survey` and `stats` help by reusing the canonical corpus parsers as parents, adding clear one-line summaries, richer descriptions, and realistic `Examples:` epilog text in `lcats/lcats/cli.py`.
- Updated `lcats/lcats/analysis/corpus/cli.py` to support reuse as parent parsers by adding `add_help: bool = True` to `build_survey_parser()` and `build_stats_parser()` and added optional `parsed_args` parameters for `run_survey()` and `run_stats()` so the top-level CLI can hand parsed namespaces through without double-parsing.
- Adjusted tests in `lcats/tests/cli_test.py` to validate top-level help, `help` alias, subcommand help (both `--help` and `help <command>`), presence of examples for `survey`/`stats`, and that invalid flags produce subcommand-scoped usage.

### Testing
- Ran `scripts/format` which reformatted the updated test file (`lcats/tests/cli_test.py`) and left other files unchanged.
- Ran `scripts/lint` and it completed with no errors.
- Ran the focused CLI tests with `python -m unittest tests/cli_test.py` inside the `lcats` package and they passed (command-level and alias help, example text, invalid-flag behavior, and dispatch stability were validated).
- Ran the full test suite via `scripts/test`; the suite failed with 3 errors unrelated to the CLI refactor caused by network access when `tiktoken` attempted to fetch remote encoding artifacts, not by the CLI changes.  The failure is environmental and outside the scope of this CLI-only PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11447adf88327b427863c61c03d87)