### PR TITLE
Improve `lcats survey` TSV readability with compact values and story identifiers

### DIFF
--- a/lcats/lcats/analysis/corpus/cli.py
+++ b/lcats/lcats/analysis/corpus/cli.py
@@ -22,10 +22,34 @@ from lcats.analysis.corpus.detectors import unicode
 
 def run_lcats_display(file_path: pathlib.Path) -> str:
     """Render one corpus JSON file using the same formatter as lcats display."""
+    rendered, _ = run_lcats_display_and_title(file_path)
+    return rendered
+
+
+def read_story_title(file_path: pathlib.Path) -> str:
+    """Read one corpus JSON file and return a display title."""
     with file_path.open("r", encoding="utf-8") as json_file:
         data = json.load(json_file)
+    return infer_story_title(data, file_path)
+
+
+def infer_story_title(data: dict, file_path: pathlib.Path) -> str:
+    """Infer stable title from story data, falling back to filename stem."""
+    story_title = (
+        data.get("name") or data.get("metadata", {}).get("name") or ""
+    ).strip()
+    if not story_title:
+        return file_path.stem
+    return story_title
+
+
+def run_lcats_display_and_title(file_path: pathlib.Path) -> tuple[str, str]:
+    """Render one corpus JSON file and return display text plus story title."""
+    with file_path.open("r", encoding="utf-8") as json_file:
+        data = json.load(json_file)
+    story_title = infer_story_title(data, file_path)
     rendered = lcats.inspect.format_story_json(data, max_body_chars=None, width=80)
-    return f"{rendered}\n"
+    return f"{rendered}\n", story_title
 
 
 def run_special_characters_check(
@@ -91,6 +115,8 @@ def build_survey_parser(add_help: bool = True) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Survey LCATS corpora files for issues.",
         add_help=add_help,
+        epilog=output.TSV_VALUE_LEGEND,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "directories",
@@ -156,7 +182,7 @@ def _show_progress(progress_arg: Optional[bool]) -> bool:
 
 def survey_file(file_path: pathlib.Path, args) -> list[dict[str, str]]:
     """Run enabled checks on a single corpus file and return report rows."""
-    displayed_text = run_lcats_display(file_path)
+    displayed_text, story_title = run_lcats_display_and_title(file_path)
     rows = []
     for check_name in args.check_for:
         if check_name == "special-characters":
@@ -174,6 +200,7 @@ def survey_file(file_path: pathlib.Path, args) -> list[dict[str, str]]:
                     header=False,
                 ),
                 file_path,
+                story_title,
             )
             rows.extend(parsed)
         elif check_name == "boundary-contamination":
@@ -184,7 +211,7 @@ def survey_file(file_path: pathlib.Path, args) -> list[dict[str, str]]:
                 },
             )
             rows.extend(
-                output.finding_to_row(file_path, check_name, finding)
+                output.finding_to_row(file_path, story_title, check_name, finding)
                 for finding in findings
             )
         else:
@@ -248,7 +275,9 @@ def run_survey(
                     output.write_human_rows(output_stream, file_path, rows)
             elif args.print_clean_filenames:
                 if args.format == "tsv":
-                    tsv_writer.writerow(output.clean_row(file_path))
+                    tsv_writer.writerow(
+                        output.clean_row(file_path, read_story_title(file_path))
+                    )
                 else:
                     print(f"{file_path} [clean]", file=output_stream)
 

--- a/lcats/lcats/analysis/corpus/output.py
+++ b/lcats/lcats/analysis/corpus/output.py
@@ -10,6 +10,8 @@ from lcats.analysis.corpus import models
 
 DEFAULT_OUTPUT_FORMAT = "human"
 TSV_COLUMNS = [
+    "story_title",
+    "story_file",
     "path",
     "check",
     "kind",
@@ -27,10 +29,41 @@ TSV_COLUMNS = [
     "message",
 ]
 
+CHECK_VALUE_MAP = {
+    "special-characters": "spchar",
+    "boundary-contamination": "boundary",
+}
+KIND_VALUE_MAP = {
+    "special-character": "spchar",
+    "start-contamination": "start-contam",
+    "end-contamination": "end-contam",
+    "rare-review-character": "rare-char",
+    "mojibake-sequence": "mojibake",
+}
+CLASSIFICATION_VALUE_MAP = {
+    "valid-typography": "valid-typo",
+    "suspicious-unicode": "sus-unicode",
+    "mojibake-pattern": "mojibake",
+}
+TSV_VALUE_LEGEND = (
+    "Compact TSV values: "
+    "check(spchar=special-characters, boundary=boundary-contamination); "
+    "kind(spchar=special-character, start-contam=start-contamination, "
+    "end-contam=end-contamination, rare-char=rare-review-character, "
+    "mojibake=mojibake-sequence); "
+    "classification(valid-typo=valid-typography, "
+    "sus-unicode=suspicious-unicode, mojibake=mojibake-pattern)."
+)
+
 
 def empty_tsv_row() -> dict[str, str]:
     """Return a blank TSV row with all stable fields present."""
     return {column: "" for column in TSV_COLUMNS}
+
+
+def compact_value(value: str, mapping: Mapping[str, str]) -> str:
+    """Return compact TSV value for known verbose labels."""
+    return mapping.get(value, value)
 
 
 def severity_from_classification(classification: str) -> str:
@@ -46,7 +79,7 @@ def severity_from_classification(classification: str) -> str:
 
 
 def parse_special_character_rows(
-    tsv_output: str, file_path: pathlib.Path
+    tsv_output: str, file_path: pathlib.Path, story_title: str = ""
 ) -> list[dict[str, str]]:
     """Parse extractor TSV output into stable report rows."""
     if not tsv_output.strip():
@@ -64,9 +97,11 @@ def parse_special_character_rows(
         row = empty_tsv_row()
         row.update(
             {
+                "story_title": story_title,
+                "story_file": file_path.name,
                 "path": str(file_path),
-                "check": "special-characters",
-                "kind": "special-character",
+                "check": compact_value("special-characters", CHECK_VALUE_MAP),
+                "kind": compact_value("special-character", KIND_VALUE_MAP),
                 "severity": severity_from_classification(padded[6]),
                 "codepoint": padded[0],
                 "char": padded[1],
@@ -74,7 +109,7 @@ def parse_special_character_rows(
                 "occurrence_index": padded[3],
                 "offset": padded[4],
                 "context": padded[5],
-                "classification": padded[6],
+                "classification": compact_value(padded[6], CLASSIFICATION_VALUE_MAP),
                 "evidence": padded[7],
                 "message": "Special character finding.",
             }
@@ -85,15 +120,20 @@ def parse_special_character_rows(
 
 
 def finding_to_row(
-    file_path: pathlib.Path, check_name: str, finding: models.Finding
+    file_path: pathlib.Path,
+    story_title: str,
+    check_name: str,
+    finding: models.Finding,
 ) -> dict[str, str]:
     """Convert one finding into a stable TSV row."""
     row = empty_tsv_row()
     row.update(
         {
+            "story_title": story_title,
+            "story_file": file_path.name,
             "path": str(file_path),
-            "check": check_name,
-            "kind": finding.kind,
+            "check": compact_value(check_name, CHECK_VALUE_MAP),
+            "kind": compact_value(finding.kind, KIND_VALUE_MAP),
             "severity": finding.severity,
             "span_start": str(finding.span[0]),
             "span_end": str(finding.span[1]),
@@ -104,11 +144,13 @@ def finding_to_row(
     return row
 
 
-def clean_row(file_path: pathlib.Path) -> dict[str, str]:
+def clean_row(file_path: pathlib.Path, story_title: str = "") -> dict[str, str]:
     """Build a summary row for files with no findings."""
     row = empty_tsv_row()
     row.update(
         {
+            "story_title": story_title,
+            "story_file": file_path.name,
             "path": str(file_path),
             "check": "summary",
             "kind": "clean",

--- a/lcats/tests/analysis_tests/corpus_survey_test.py
+++ b/lcats/tests/analysis_tests/corpus_survey_test.py
@@ -302,36 +302,42 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
         output = "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tspecial\tliteral"
 
         rows = corpus_survey.parse_special_character_rows(
-            output, pathlib.Path("story.json")
+            output, pathlib.Path("story.json"), "Story Title"
         )
 
         self.assertEqual(1, len(rows))
         row = rows[0]
         self.assertEqual(corpus_survey.TSV_COLUMNS, list(row.keys()))
+        self.assertEqual("Story Title", row["story_title"])
+        self.assertEqual("story.json", row["story_file"])
         self.assertEqual("story.json", row["path"])
-        self.assertEqual("special-characters", row["check"])
+        self.assertEqual("spchar", row["check"])
+        self.assertEqual("spchar", row["kind"])
         self.assertEqual("U+00A9", row["codepoint"])
 
     def test_parse_special_character_rows_skips_header_line(self):
         output = (
             "codepoint\tchar\tunicode_name\toccurrence_index\t"
             "offset\tcontext\tclassification\tevidence\n"
-            "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tspecial\tliteral"
+            "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tmojibake-pattern\tliteral"
         )
 
         rows = corpus_survey.parse_special_character_rows(
-            output, pathlib.Path("story.json")
+            output, pathlib.Path("story.json"), "Story Title"
         )
 
         self.assertEqual(1, len(rows))
         self.assertEqual("U+00A9", rows[0]["codepoint"])
+        self.assertEqual("mojibake", rows[0]["classification"])
 
     def test_main_tsv_output_has_stable_columns_for_multiple_checks(self):
         rows = [
             {
+                "story_title": "The Story",
+                "story_file": "story.json",
                 "path": "story.json",
-                "check": "special-characters",
-                "kind": "special-character",
+                "check": "spchar",
+                "kind": "spchar",
                 "severity": "warning",
                 "codepoint": "U+00A9",
                 "char": "©",
@@ -346,9 +352,11 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
                 "message": "Special character finding.",
             },
             {
+                "story_title": "The Story",
+                "story_file": "story.json",
                 "path": "story.json",
-                "check": "boundary-contamination",
-                "kind": "start-contamination",
+                "check": "boundary",
+                "kind": "start-contam",
                 "severity": "warning",
                 "codepoint": "",
                 "char": "",
@@ -428,7 +436,16 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
             written = output_path.read_text(encoding="utf-8")
             self.assertIn("\t".join(corpus_survey.TSV_COLUMNS), written)
             self.assertIn("summary\tclean\tinfo", written)
+            self.assertIn("story.json", written)
             self.assertEqual("summary", row["check"])
+
+    def test_parser_help_includes_compact_value_legend(self):
+        parser = corpus_survey.build_parser()
+
+        help_text = parser.format_help()
+
+        self.assertIn("Compact TSV values:", help_text)
+        self.assertIn("spchar=special-characters", help_text)
 
     def test_main_tsv_no_header_is_deterministic(self):
         rows = [corpus_survey._clean_row(pathlib.Path("story.json"))]


### PR DESCRIPTION
### Motivation
- TSV rows from `lcats survey` were often too wide for comfortable human review due to verbose check/kind/classification labels and long file path placement.  
- The goal is to make terminal/editor scans easier while keeping a stable, tab-separated schema and full auditability for machines.  

### Description
- Added two leading identifying columns to the stable TSV schema: `story_title` and `story_file`, while preserving the original `path` column; schema is exposed via `TSV_COLUMNS` in `lcats.analysis.corpus.output`.  
- Introduced compact canonical mappings for verbose labels with explicit maps: `CHECK_VALUE_MAP`, `KIND_VALUE_MAP`, and `CLASSIFICATION_VALUE_MAP`, and a documented `TSV_VALUE_LEGEND` explaining abbreviations; compaction is applied via `compact_value()`.  
- Propagated story title extraction through survey flow by adding `read_story_title` / `infer_story_title` and `run_lcats_display_and_title` in `lcats.analysis.corpus.cli`, and changed `survey_file`, `parse_special_character_rows`, `finding_to_row`, and `clean_row` signatures to include/emit `story_title` and `story_file`.  
- Documented the compact values by adding the legend to the survey parser epilog (`build_survey_parser`) so `lcats survey --help` contains the abbreviations.  
- Kept TSV output stable and machine-friendly: output remains tab-separated, fieldnames are stable (new columns are added at the front), and the full `path` remains present for auditability.  
- Updated tests in `lcats/tests/analysis_tests/corpus_survey_test.py` to assert the new columns, compact values, classification compaction, presence of `story_file` in outputs, and the presence of the legend in help text.  

### Testing
- Ran formatting and linting: `./scripts/format` and `./scripts/lint` succeeded.  
- Ran targeted unit tests: `python -m unittest tests.cli_test tests.analysis_tests.corpus_package_test tests.analysis_tests.corpus_survey_test` and these tests passed.  
- Ran the full test driver `./scripts/test`; it reported failures unrelated to these changes caused by network access errors when `tiktoken` attempted to fetch encoder files in unrelated corpus stats tests (environment blocked the external download), so the unrelated test errors remain external to the survey output changes.  
- Updated/added unit assertions in `lcats/tests/analysis_tests/corpus_survey_test.py` to validate schema stability, compact-value emission, and help legend presence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11a9d99a08327953ae0ed747e8e66)