### PR TITLE
[codex] Clean up issue 19 encoding follow-up

### DIFF
--- a/lcats/environment.yml
+++ b/lcats/environment.yml
@@ -234,7 +234,6 @@ dependencies:
       - build==1.2.1
       - certifi==2024.7.4
       - cffi==1.17.1
-      - chardet==5.2.0
       - charset-normalizer==3.3.2
       - click==8.3.1
       - construct==2.5.3

--- a/lcats/notebooks/01_gatherers.ipynb
+++ b/lcats/notebooks/01_gatherers.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "downloaders.detect_url_encoding('https://www.gutenberg.org/cache/epub/68283/pg68283-images.html')"
+    "response = requests.head('https://www.gutenberg.org/cache/epub/68283/pg68283-images.html')\nresponse.encoding\n"
    ]
   },
   {
@@ -188,7 +188,7 @@
     "print(f\"Detected encoding: {response.encoding}\")\n",
     "story_encoding = response.encoding\n",
     "\n",
-    "story_content = downloaders.load_page(story_url, encoding=story_encoding)\n",
+    "story_content = downloaders.load_page(story_url, preferred_encoding=story_encoding)\n",
     "story_callback = lovecraft.create_download_callback(\n",
     "    story_name=story_title,\n",
     "    url=story_url,\n",

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 license = {text = "MIT"}
 dependencies = [
    "unidecode",
-   "chardet",
    "beautifulsoup4",
    "PyYAML",
    "tiktoken",

--- a/lcats/scripts/README.md
+++ b/lcats/scripts/README.md
@@ -224,12 +224,12 @@ scripts/test tests.gatherers.downloaders_test
 
 _Run a specific test class:_
 ```bash
-scripts/test tests.gatherers.downloaders_test.TestDownloader
+scripts/test tests.gatherers.downloaders_test.TestLoadPage
 ```
 
 _Run a single test method:_
 ```bash
-scripts/test tests.gatherers.downloaders_test.TestDownloader.test_detect_encoding
+scripts/test tests.gatherers.downloaders_test.TestLoadPage.test_load_page_success_utf8
 ```
 
 **Test Discovery:**

--- a/lcats/tests/gatherers_tests/downloaders_test.py
+++ b/lcats/tests/gatherers_tests/downloaders_test.py
@@ -141,6 +141,25 @@ class TestLoadPage(unittest.TestCase):
         mock_get.assert_called_once_with("http://example.com", timeout=10)
         mock_response.raise_for_status.assert_called_once_with()
 
+    @patch("lcats.gatherers.downloaders.requests.get")
+    def test_load_page_prefers_apparent_encoding_over_response_encoding(self, mock_get):
+        """Test load_page prefers apparent_encoding over response.encoding."""
+        raw = "Price €10".encode("cp1252")
+
+        mock_response = Mock()
+        mock_response.content = raw
+        mock_response.raise_for_status = Mock()
+        mock_response.apparent_encoding = "cp1252"
+        mock_response.encoding = "iso-8859-1"
+        mock_get.return_value = mock_response
+
+        with capture.suppress_output():
+            result = downloaders.load_page("http://example.com")
+
+        self.assertEqual(result, "Price €10")
+        mock_get.assert_called_once_with("http://example.com", timeout=10)
+        mock_response.raise_for_status.assert_called_once_with()
+
 
 class TestLambdaResourceCache(test_utils.TestCaseWithData):
 
@@ -189,7 +208,7 @@ class TestLambdaResourceCache(test_utils.TestCaseWithData):
     def test_ensure(self):
         """Test the ensure method."""
         cache = downloaders.LambdaResourceCache(
-            canonicalizer=lambda x: x, acquirer=lambda x: x
+            canonicalizer=lambda x: x, acquirer=lambda x: x, root=self.test_temp_dir
         )
         file_name = "bar.baz"
         full_path = cache.full_path(file_name)


### PR DESCRIPTION
## Summary
- remove stale `chardet` dependency declarations from project metadata
- update stale README and notebook references to removed downloader encoding APIs
- add deterministic downloader coverage for fallback precedence and keep the downloader test module sandbox-safe

## Why
Issue #19 was caused by a broken `detect_encoding(str)` path that re-encoded already-decoded text and produced nondeterministic results across environments. That bug path is already gone in the codebase, but the repo still had stale dependency and documentation references that implied the old model still existed.

This PR aligns the repo with the current byte-first downloader behavior and the commit history that resolved the bug:
- `47db525` refactored `load_page` to decode `response.content` bytes directly
- `03437cc` fixed downstream gatherers that had relied on mojibake-corrupted text
- `55046d3` removed the broken encoder detector APIs entirely

## Validation
- `cd lcats && python -m unittest tests.gatherers_tests.downloaders_test`

## Issue
- follow-up cleanup for #19
- issue #19 has been closed based on the existing fix path plus this repo cleanup