### PR TITLE
Add three-way Unicode classification to survey specials pipeline

### DIFF
--- a/lcats/lcats/analysis/corpus/output.py
+++ b/lcats/lcats/analysis/corpus/output.py
@@ -45,9 +45,9 @@ KIND_VALUE_MAP = {
     "mojibake-sequence": "mojibake",
 }
 CLASSIFICATION_VALUE_MAP = {
-    "valid-typography": "valid-typo",
-    "suspicious-unicode": "sus-unicode",
-    "mojibake-pattern": "mojibake",
+    "likely_good": "lgood",
+    "likely_repairable": "lrepair",
+    "review_needed": "review",
 }
 TSV_VALUE_LEGEND = (
     "Compact TSV values: "
@@ -55,8 +55,8 @@ TSV_VALUE_LEGEND = (
     "kind(spchar=special-character, start-contam=start-contamination, "
     "end-contam=end-contamination, rare-char=rare-review-character, "
     "mojibake=mojibake-sequence); "
-    "classification(valid-typo=valid-typography, "
-    "sus-unicode=suspicious-unicode, mojibake=mojibake-pattern)."
+    "classification("
+    "lgood=likely_good, lrepair=likely_repairable, review=review_needed)."
 )
 
 
@@ -73,9 +73,9 @@ def compact_value(value: str, mapping: Mapping[str, str]) -> str:
 def severity_from_classification(classification: str) -> str:
     """Map special-character classification to severity."""
     lowered = classification.lower()
-    if "mojibake" in lowered:
+    if lowered == "likely_repairable":
         return "error"
-    if "rare" in lowered:
+    if lowered == "likely_good":
         return "info"
     if lowered:
         return "warning"

--- a/lcats/lcats/analysis/corpus/specials.py
+++ b/lcats/lcats/analysis/corpus/specials.py
@@ -25,6 +25,15 @@ TSV_COLUMNS = [
     "evidence",
 ]
 MOJIBAKE_RE = re.compile(r"(?:Ã.|Â.|â.|ð.|�)")
+MOJIBAKE_SEQUENCES = (
+    "â€™",
+    "â€œ",
+    "â€\u009d",
+    "â€“",
+    "â€”",
+    "â€¦",
+)
+MOJIBAKE_NEIGHBOR_MARKERS = {"Ã", "Â", "â", "ð", "�"}
 
 
 @dataclass
@@ -158,23 +167,75 @@ def is_flagged(
     return not is_allowed(character, allow_smart, allowlist)
 
 
-def classify_character(text: str, offset: int, character: str) -> tuple[str, str]:
-    """Classify one character with a compact evidence string."""
-    if character in SMART_ALLOWED:
-        return ("valid-typography", "common typographic punctuation")
+def _is_latin_letter(character: str) -> bool:
+    """Return True when character is a letter with a Latin Unicode name."""
+    if not unicodedata.category(character).startswith("L"):
+        return False
+    return "LATIN" in get_unicode_name(character)
 
-    window_start = max(0, offset - 2)
-    window_end = min(len(text), offset + 3)
+
+def _is_likely_lexical_diacritic(text: str, offset: int, character: str) -> bool:
+    """Return True when a Latin diacritic appears in a word-like context."""
+    if not _is_latin_letter(character):
+        return False
+    normalized = unicodedata.normalize("NFD", character)
+    if len(normalized) <= 1:
+        return False
+    left = text[offset - 1] if offset > 0 else ""
+    right = text[offset + 1] if offset + 1 < len(text) else ""
+    return bool(left.isalpha() or right.isalpha())
+
+
+def _has_mojibake_pattern(text: str, offset: int, character: str) -> tuple[bool, str]:
+    """Return mojibake match status and deterministic evidence snippet."""
+    window_start = max(0, offset - 4)
+    window_end = min(len(text), offset + 5)
     window = text[window_start:window_end]
+
+    for sequence in MOJIBAKE_SEQUENCES:
+        if sequence in window:
+            return True, sequence
+
     match = MOJIBAKE_RE.search(window)
     if match:
-        return ("mojibake-pattern", f"matched mojibake fragment '{match.group(0)}'")
+        return True, match.group(0)
+    if character in MOJIBAKE_NEIGHBOR_MARKERS:
+        return True, character
+    return False, ""
+
+
+def classify_character(text: str, offset: int, character: str) -> tuple[str, str]:
+    """Classify one character into likely-good, repairable, or review-needed."""
+    unicode_category = unicodedata.category(character)
+    unicode_name = get_unicode_name(character)
+
+    if character in SMART_ALLOWED:
+        return (
+            "likely_good",
+            f"rule=smart-typography; unicode_category={unicode_category}",
+        )
+
+    if _is_likely_lexical_diacritic(text, offset, character):
+        return (
+            "likely_good",
+            (
+                "rule=lexical-latin-diacritic; "
+                f"unicode_name={unicode_name}; normalized={unicodedata.normalize('NFD', character)}"
+            ),
+        )
+
+    has_mojibake, fragment = _has_mojibake_pattern(text, offset, character)
+    if has_mojibake:
+        return (
+            "likely_repairable",
+            f"rule=mojibake-pattern; fragment={fragment}; unicode_category={unicode_category}",
+        )
 
     return (
-        "suspicious-unicode",
+        "review_needed",
         (
-            "unicode_category="
-            f"{unicodedata.category(character)}; non-ascii outside allowlist"
+            "rule=residual-review; "
+            f"unicode_name={unicode_name}; unicode_category={unicode_category}"
         ),
     )
 

--- a/lcats/tests/analysis_tests/corpus_survey_test.py
+++ b/lcats/tests/analysis_tests/corpus_survey_test.py
@@ -139,6 +139,7 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
         first_row = output.splitlines()[0].split("\t")
         self.assertEqual("U+221A", first_row[0])
         self.assertEqual("2", first_row[4])
+        self.assertEqual("review_needed", first_row[6])
 
     def test_run_special_characters_check_uses_nocontext_flag(self):
         output = corpus_survey.run_special_characters_check(
@@ -328,7 +329,7 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
         output = (
             "codepoint\tchar\tunicode_name\toccurrence_index\t"
             "offset\tcontext\tclassification\tevidence\n"
-            "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tmojibake-pattern\tliteral"
+            "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tlikely_repairable\tliteral"
         )
 
         rows = corpus_survey.parse_special_character_rows(
@@ -337,7 +338,7 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
 
         self.assertEqual(1, len(rows))
         self.assertEqual("U+00A9", rows[0]["codepoint"])
-        self.assertEqual("mojibake", rows[0]["classification"])
+        self.assertEqual("lrepair", rows[0]["classification"])
 
     def test_main_tsv_output_has_stable_columns_for_multiple_checks(self):
         rows = [

--- a/lcats/tests/analysis_tests/specials_test.py
+++ b/lcats/tests/analysis_tests/specials_test.py
@@ -71,6 +71,28 @@ class SpecialsTest(unittest.TestCase):
         self.assertEqual("U+00A9", lines[1].split("\t")[0])
         self.assertEqual("", lines[1].split("\t")[5])
 
+    def test_classify_character_likely_good_for_lexical_diacritic(self):
+        classification, evidence = specials.classify_character("naïve", 2, "ï")
+
+        self.assertEqual("likely_good", classification)
+        self.assertIn("lexical-latin-diacritic", evidence)
+
+    def test_classify_character_likely_repairable_for_mojibake_sequence(self):
+        text = "Broken punctuation â€™ in corpus text."
+        index = text.index("â")
+        classification, evidence = specials.classify_character(text, index, "â")
+
+        self.assertEqual("likely_repairable", classification)
+        self.assertIn("mojibake-pattern", evidence)
+
+    def test_classify_character_review_needed_for_uncommon_symbol(self):
+        classification, evidence = specials.classify_character(
+            "Contains √ symbol", 9, "√"
+        )
+
+        self.assertEqual("review_needed", classification)
+        self.assertIn("residual-review", evidence)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lcats/tests/utils_tests/extract_special_chars_test.py
+++ b/lcats/tests/utils_tests/extract_special_chars_test.py
@@ -168,8 +168,8 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
         self.assertEqual(2, len(lines))
         self.assertEqual("", lines[0].split("\t")[6])
 
-    def test_classification_distinguishes_typography_mojibake_and_suspicious(self):
-        text = "‘quote’ Ã© ©"
+    def test_classification_distinguishes_good_repairable_and_review(self):
+        text = "‘quote’ Ã©      √"
         rows = list(
             self.module.iter_special_character_rows(
                 path="stdin",
@@ -183,9 +183,9 @@ class ExtractSpecialCharsScriptTest(unittest.TestCase):
         )
 
         classifications = [row.split("\t")[7] for row in rows]
-        self.assertIn("valid-typography", classifications)
-        self.assertIn("mojibake-pattern", classifications)
-        self.assertIn("suspicious-unicode", classifications)
+        self.assertIn("likely_good", classifications)
+        self.assertIn("likely_repairable", classifications)
+        self.assertIn("review_needed", classifications)
 
     def test_allowlist_config_allows_configured_character(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
### Motivation
- Add a deterministic, auditable three-way Unicode classifier to the new corpus special-character extraction path so `lcats survey specials` can distinguish clearly between safe, repairable and review cases.
- Keep behavior conservative and inspectable: classification only, no automatic repairs or LLM adjudication.

### Description
- Implemented a first-pass classifier in `lcats.analysis.corpus.specials` with helper rules: normalization-aware lexical Latin diacritic detection, mojibake sequence/fragment detection (regex + sequence table + neighbor markers), and a residual review bucket, and return evidence strings for auditability.
- Added `MOJIBAKE_SEQUENCES` and neighbor markers and new functions `_is_latin_letter`, `_is_likely_lexical_diacritic`, `_has_mojibake_pattern`, and updated `classify_character` to emit `likely_good`, `likely_repairable`, or `review_needed` along with deterministic evidence.
- Updated reporting mappings in `lcats.analysis.corpus.output` to expose compact TSV values (`lgood`, `lrepair`, `review`) and to map the new classifications to sensible severities (`likely_repairable` -> `error`, `likely_good` -> `info`, otherwise `warning`), and updated the TSV legend text.
- Kept core logic inside the new corpus analysis modules (legacy `scripts/utils` still delegates into the new library); added/updated tests to cover lexical diacritics, mojibake patterns, residual review cases, and CLI/report integration.

### Testing
- Ran formatting and linting: `scripts/format` and `scripts/lint` completed successfully.
- Ran the full unit test suite with `scripts/test` and all tests passed (1121 tests, OK), including new/updated tests for `likely_good`, `likely_repairable`, and `review_needed` cases and CLI/report parsing.
- New/modified files exercised by tests include `lcats/analysis/corpus/specials.py`, `lcats/analysis/corpus/output.py`, and tests under `tests/analysis_tests/` and `tests/utils_tests/` which passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e599bb43c48327b4553e963782ac53)