### PR TITLE
Add reusable corpus special-character repair suggestion library

### DIFF
--- a/lcats/lcats/analysis/corpus/__init__.py
+++ b/lcats/lcats/analysis/corpus/__init__.py
@@ -5,6 +5,7 @@ from lcats.analysis.corpus import discovery
 from lcats.analysis.corpus import models
 from lcats.analysis.corpus import output
 from lcats.analysis.corpus import processing
+from lcats.analysis.corpus import repairs
 from lcats.analysis.corpus import qa
 from lcats.analysis.corpus import specials
 from lcats.analysis.corpus import stats
@@ -15,6 +16,7 @@ __all__ = [
     "models",
     "output",
     "processing",
+    "repairs",
     "qa",
     "specials",
     "stats",

--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -1,0 +1,172 @@
+"""Repair-suggestion helpers for special-character findings."""
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+from lcats.analysis.corpus import specials
+
+
+@dataclass(frozen=True)
+class RepairRule:
+    """One conservative replacement rule for known mojibake fragments."""
+
+    rule_id: str
+    source_text: str
+    replacement_text: str
+    description: str
+
+
+@dataclass(frozen=True)
+class RepairSuggestion:
+    """A proposed repair derived from a classified finding."""
+
+    rule_id: str
+    start: int
+    end: int
+    original_text: str
+    replacement_text: str
+    finding_offset: int
+    evidence: str
+
+
+DEFAULT_REPAIR_RULES = (
+    RepairRule(
+        rule_id="mojibake-right-single-quote",
+        source_text="â€™",
+        replacement_text="’",
+        description="Broken UTF-8 right single quote sequence.",
+    ),
+    RepairRule(
+        rule_id="mojibake-left-double-quote",
+        source_text="â€œ",
+        replacement_text="“",
+        description="Broken UTF-8 left double quote sequence.",
+    ),
+    RepairRule(
+        rule_id="mojibake-right-double-quote",
+        source_text="â€\u009d",
+        replacement_text="”",
+        description="Broken UTF-8 right double quote sequence.",
+    ),
+    RepairRule(
+        rule_id="mojibake-en-dash",
+        source_text="â€“",
+        replacement_text="–",
+        description="Broken UTF-8 en dash sequence.",
+    ),
+    RepairRule(
+        rule_id="mojibake-em-dash",
+        source_text="â€”",
+        replacement_text="—",
+        description="Broken UTF-8 em dash sequence.",
+    ),
+    RepairRule(
+        rule_id="mojibake-ellipsis",
+        source_text="â€¦",
+        replacement_text="…",
+        description="Broken UTF-8 ellipsis sequence.",
+    ),
+)
+
+
+def _rule_map(rules: Sequence[RepairRule]) -> dict[str, RepairRule]:
+    return {rule.source_text: rule for rule in rules}
+
+
+def _extract_evidence_fragment(evidence: str) -> str:
+    """Return fragment value from semicolon-delimited evidence string."""
+    for part in evidence.split(";"):
+        segment = part.strip()
+        if segment.startswith("fragment="):
+            return segment.split("=", 1)[1]
+    return ""
+
+
+def _find_unique_span_containing_offset(
+    text: str, fragment: str, offset: int
+) -> Optional[tuple[int, int]]:
+    """Return unique span for fragment containing offset, or None."""
+    spans = []
+    start = 0
+    while True:
+        index = text.find(fragment, start)
+        if index == -1:
+            break
+        end = index + len(fragment)
+        if index <= offset < end:
+            spans.append((index, end))
+        start = index + 1
+
+    if len(spans) != 1:
+        return None
+    return spans[0]
+
+
+def suggest_repairs(
+    text: str,
+    findings: Iterable[specials.SpecialCharacter],
+    rules: Sequence[RepairRule] = DEFAULT_REPAIR_RULES,
+) -> list[RepairSuggestion]:
+    """Convert likely-repairable findings into conservative suggestions.
+
+    Args:
+        text: Original story text.
+        findings: Classified special-character findings.
+        rules: Supported high-confidence replacement rules.
+
+    Returns:
+        Repair suggestions with explicit original/proposed text and source rule.
+    """
+    repair_rules = _rule_map(rules)
+    suggestions: list[RepairSuggestion] = []
+    seen_spans: set[tuple[int, int]] = set()
+
+    for finding in findings:
+        if finding.classification != "likely_repairable":
+            continue
+
+        fragment = _extract_evidence_fragment(finding.evidence)
+        if not fragment:
+            continue
+
+        rule = repair_rules.get(fragment)
+        if not rule:
+            continue
+
+        span = _find_unique_span_containing_offset(text, fragment, finding.offset)
+        if span is None or span in seen_spans:
+            continue
+
+        start, end = span
+        seen_spans.add(span)
+        suggestions.append(
+            RepairSuggestion(
+                rule_id=rule.rule_id,
+                start=start,
+                end=end,
+                original_text=text[start:end],
+                replacement_text=rule.replacement_text,
+                finding_offset=finding.offset,
+                evidence=finding.evidence,
+            )
+        )
+
+    suggestions.sort(key=lambda suggestion: (suggestion.start, suggestion.end))
+    return suggestions
+
+
+def apply_repair_suggestions(text: str, suggestions: Sequence[RepairSuggestion]) -> str:
+    """Apply suggestions in reverse order when original spans still match."""
+    updated = text
+    for suggestion in sorted(
+        suggestions, key=lambda current: (current.start, current.end), reverse=True
+    ):
+        current_original = updated[suggestion.start : suggestion.end]
+        if current_original != suggestion.original_text:
+            continue
+        updated = (
+            updated[: suggestion.start]
+            + suggestion.replacement_text
+            + updated[suggestion.end :]
+        )
+    return updated

--- a/lcats/tests/analysis_tests/repairs_test.py
+++ b/lcats/tests/analysis_tests/repairs_test.py
@@ -1,0 +1,131 @@
+"""Unit tests for lcats.analysis.corpus.repairs."""
+
+import unittest
+
+from parameterized import parameterized
+
+from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import specials
+
+
+class RepairsTest(unittest.TestCase):
+    """Tests for repair suggestions built from classified findings."""
+
+    @parameterized.expand(
+        [
+            ("â€™", "’", "mojibake-right-single-quote"),
+            ("â€œ", "“", "mojibake-left-double-quote"),
+            ("â€\u009d", "”", "mojibake-right-double-quote"),
+            ("â€“", "–", "mojibake-en-dash"),
+            ("â€”", "—", "mojibake-em-dash"),
+            ("â€¦", "…", "mojibake-ellipsis"),
+        ]
+    )
+    def test_suggest_repairs_maps_known_fragments(self, fragment, replacement, rule_id):
+        text = f"A {fragment} B"
+        findings = list(
+            specials.iter_special_characters(
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=3,
+                name_width=0,
+            )
+        )
+
+        suggestions = repairs.suggest_repairs(text, findings)
+
+        self.assertEqual(1, len(suggestions))
+        suggestion = suggestions[0]
+        self.assertEqual(rule_id, suggestion.rule_id)
+        self.assertEqual(fragment, suggestion.original_text)
+        self.assertEqual(replacement, suggestion.replacement_text)
+
+    def test_suggest_repairs_preserves_audit_fields(self):
+        text = "Broken â€™ punctuation"
+        findings = list(
+            specials.iter_special_characters(
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=4,
+                name_width=0,
+            )
+        )
+
+        suggestions = repairs.suggest_repairs(text, findings)
+
+        self.assertEqual(1, len(suggestions))
+        suggestion = suggestions[0]
+        self.assertEqual("â€™", suggestion.original_text)
+        self.assertEqual("’", suggestion.replacement_text)
+        self.assertEqual(
+            text[suggestion.start : suggestion.end], suggestion.original_text
+        )
+        self.assertIn("rule=mojibake-pattern", suggestion.evidence)
+
+    def test_suggest_repairs_ignores_likely_good_cases(self):
+        text = "A naïve sentence"
+        findings = list(
+            specials.iter_special_characters(
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=4,
+                name_width=0,
+            )
+        )
+
+        suggestions = repairs.suggest_repairs(text, findings)
+
+        self.assertEqual([], suggestions)
+
+    def test_suggest_repairs_ignores_unsupported_fragments(self):
+        finding = specials.SpecialCharacter(
+            character="â",
+            codepoint="U+00E2",
+            unicode_name="LATIN SMALL LETTER A WITH CIRCUMFLEX",
+            occurrence_index=1,
+            offset=4,
+            context="aaâbb",
+            classification="likely_repairable",
+            evidence="rule=mojibake-pattern; fragment=â‚¬",
+        )
+
+        suggestions = repairs.suggest_repairs("aaâ‚¬bb", [finding])
+
+        self.assertEqual([], suggestions)
+
+    def test_apply_repair_suggestions_applies_only_matching_spans(self):
+        text = "Broken â€™ and â€¦"
+        suggestions = [
+            repairs.RepairSuggestion(
+                rule_id="first",
+                start=7,
+                end=10,
+                original_text="â€™",
+                replacement_text="’",
+                finding_offset=7,
+                evidence="rule=mojibake-pattern; fragment=â€™",
+            ),
+            repairs.RepairSuggestion(
+                rule_id="mismatch",
+                start=15,
+                end=18,
+                original_text="BAD",
+                replacement_text="X",
+                finding_offset=15,
+                evidence="rule=mojibake-pattern; fragment=â€¦",
+            ),
+        ]
+
+        updated = repairs.apply_repair_suggestions(text, suggestions)
+
+        self.assertEqual("Broken ’ and â€¦", updated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a focused, reusable library to generate conservative repair suggestions for classified special-character findings without changing default corpus workflows.
- Keep repair logic separate from extraction/classification so future tools or human reviewers can opt in to apply deterministic fixes under review.

### Description
- Add `lcats.analysis.corpus.repairs` implementing `RepairRule` and `RepairSuggestion` dataclasses and a `DEFAULT_REPAIR_RULES` mapping for known high-confidence mojibake fragments.
- Implement `suggest_repairs(text, findings, rules=...)` which converts `likely_repairable` `SpecialCharacter` findings into deterministic suggestions that preserve original text, replacement, span, rule id, and evidence.
- Add `apply_repair_suggestions(text, suggestions)` helper that applies suggestions safely by checking the original span still matches before mutating text.
- Export the new module via `lcats.analysis.corpus.__init__` and add unit tests in `lcats/tests/analysis_tests/repairs_test.py` covering mapping, audit fields, safety, and application semantics.

### Testing
- Ran formatting with `scripts/format` and linting with `scripts/lint`, both completed successfully. 
- Ran the full test suite with `scripts/test`, which completed successfully (unit suite ran and reported OK). 
- New unit tests exercise rule mapping, auditability, ignoring of `likely_good`/unsupported cases, and safe application behavior and passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c5d97754832795770ef2e8112aa6)