### PR TITLE
Retire scripts/utils special-character logic into canonical corpus CLI

### DIFF
--- a/lcats/lcats/analysis/corpus/__init__.py
+++ b/lcats/lcats/analysis/corpus/__init__.py
@@ -8,6 +8,7 @@ from lcats.analysis.corpus import processing
 from lcats.analysis.corpus import repairs
 from lcats.analysis.corpus import qa
 from lcats.analysis.corpus import specials
+from lcats.analysis.corpus import specials_cli
 from lcats.analysis.corpus import stats
 
 __all__ = [
@@ -19,5 +20,6 @@ __all__ = [
     "repairs",
     "qa",
     "specials",
+    "specials_cli",
     "stats",
 ]

--- a/lcats/lcats/analysis/corpus/cli.py
+++ b/lcats/lcats/analysis/corpus/cli.py
@@ -145,8 +145,11 @@ def build_survey_parser(add_help: bool = True) -> argparse.ArgumentParser:
     parser.add_argument("--print-clean-filenames", action="store_true")
     parser.add_argument(
         "--extract-script",
-        default="scripts/utils/extract_special_chars.py",
-        help="Legacy compatibility option; modern survey uses in-process extraction.",
+        default="lcats.analysis.corpus.specials_cli",
+        help=(
+            "Legacy compatibility option; special-character extraction now lives "
+            "in lcats.analysis.corpus.specials_cli and survey runs in-process."
+        ),
     )
     parser.add_argument("--allowlist-config", default="")
     parser.add_argument("--allow-smart", dest="allow_smart", action="store_true")

--- a/lcats/lcats/analysis/corpus/specials_cli.py
+++ b/lcats/lcats/analysis/corpus/specials_cli.py
@@ -1,0 +1,108 @@
+"""CLI wrapper for special-character extraction from plain text inputs."""
+
+import argparse
+import sys
+
+from lcats.analysis.corpus import specials
+
+TSV_COLUMNS = ["path", *specials.TSV_COLUMNS]
+
+
+def iter_input(files):
+    """Yield (label, file handle) pairs for input files or stdin."""
+    if not files:
+        yield "stdin", sys.stdin
+        return
+
+    for path in files:
+        yield path, open(path, "r", encoding="utf-8")
+
+
+def iter_special_character_rows(
+    path: str,
+    text: str,
+    allow_smart: bool,
+    excluded: set[str],
+    allowlist: specials.AllowlistConfig,
+    context: int,
+    name_width: int,
+):
+    """Yield per-occurrence TSV rows for each flagged character."""
+    for row in specials.iter_special_character_rows(
+        text=text,
+        allow_smart=allow_smart,
+        excluded=excluded,
+        allowlist=allowlist,
+        context=context,
+        name_width=name_width,
+    ):
+        yield f"{path}\t{row}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build and return the CLI parser for special-character extraction."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract suspicious or non-standard characters from text as TSV rows. "
+            "Each row is one occurrence."
+        )
+    )
+    parser.add_argument("files", nargs="*")
+    parser.add_argument("--allowlist-config", default="")
+    parser.add_argument("--allow-smart", action="store_true")
+    parser.add_argument("--names", action="store_true")
+    parser.add_argument("--counts", action="store_true")
+    parser.add_argument("--lines", action="store_true")
+    parser.add_argument("--header", action="store_true")
+    parser.add_argument("--context", type=int, default=10)
+    parser.add_argument("--nocontext", action="store_true")
+    parser.add_argument("--name-width", type=int, default=0)
+    parser.add_argument("--exclude-char", action="append", default=[])
+    parser.add_argument("--exclude-codepoint", action="append", default=[])
+    return parser
+
+
+def main(argv=None) -> int:
+    """Run the special-character extractor CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.nocontext:
+        args.context = 0
+    if args.context < 0:
+        parser.error("--context must be >= 0")
+    if args.name_width < 0:
+        parser.error("--name-width must be >= 0")
+
+    excluded = specials.build_excluded_set(args.exclude_char, args.exclude_codepoint)
+    allowlist = specials.load_allowlist_config(args.allowlist_config)
+
+    try:
+        if args.header:
+            print("\t".join(TSV_COLUMNS))
+
+        for label, handle in iter_input(args.files):
+            try:
+                text = handle.read()
+            finally:
+                if handle is not sys.stdin:
+                    handle.close()
+
+            for row in iter_special_character_rows(
+                path=label,
+                text=text,
+                allow_smart=args.allow_smart,
+                excluded=excluded,
+                allowlist=allowlist,
+                context=args.context,
+                name_width=args.name_width,
+            ):
+                print(row)
+
+        return 0
+    except BrokenPipeError:
+        return 141
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lcats/scripts/utils/extract_special_chars.py
+++ b/lcats/scripts/utils/extract_special_chars.py
@@ -1,123 +1,12 @@
 #!/usr/bin/env python3
-"""Legacy wrapper around lcats.analysis.corpus.specials."""
+"""Legacy wrapper that delegates to lcats.analysis.corpus.specials_cli."""
 
-import argparse
-import sys
-
-from lcats.analysis.corpus import specials
-
-
-SMART_ALLOWED = specials.SMART_ALLOWED
-ASCII_PUNCT = specials.ASCII_PUNCT
-TSV_COLUMNS = ["path", *specials.TSV_COLUMNS]
-AllowlistConfig = specials.AllowlistConfig
-
-parse_codepoint = specials.parse_codepoint
-split_csv_items = specials.split_csv_items
-build_excluded_set = specials.build_excluded_set
-load_allowlist_config = specials.load_allowlist_config
-is_allowed = specials.is_allowed
-is_flagged = specials.is_flagged
-classify_character = specials.classify_character
-escape_for_tsv = specials.escape_for_tsv
-get_unicode_name = specials.get_unicode_name
-truncate_text = specials.truncate_text
-get_context_snippet = specials.get_context_snippet
-
-
-def iter_input(files):
-    """Yield (label, file handle) pairs for input files or stdin."""
-    if not files:
-        yield "stdin", sys.stdin
-    else:
-        for path in files:
-            yield path, open(path, "r", encoding="utf-8")
-
-
-def iter_special_character_rows(
-    path: str,
-    text: str,
-    allow_smart: bool,
-    excluded: set[str],
-    allowlist: AllowlistConfig,
-    context: int,
-    name_width: int,
-):
-    """Yield per-occurrence TSV rows for each flagged character."""
-    for row in specials.iter_special_character_rows(
-        text=text,
-        allow_smart=allow_smart,
-        excluded=excluded,
-        allowlist=allowlist,
-        context=context,
-        name_width=name_width,
-    ):
-        yield f"{path}\t{row}"
-
-
-def build_parser() -> argparse.ArgumentParser:
-    """Build and return the CLI parser for special-character extraction."""
-    parser = argparse.ArgumentParser(
-        description=(
-            "Extract suspicious or non-standard characters from text as TSV rows. "
-            "Each row is one occurrence."
-        )
-    )
-    parser.add_argument("files", nargs="*")
-    parser.add_argument("--allowlist-config", default="")
-    parser.add_argument("--allow-smart", action="store_true")
-    parser.add_argument("--names", action="store_true")
-    parser.add_argument("--counts", action="store_true")
-    parser.add_argument("--lines", action="store_true")
-    parser.add_argument("--header", action="store_true")
-    parser.add_argument("--context", type=int, default=10)
-    parser.add_argument("--nocontext", action="store_true")
-    parser.add_argument("--name-width", type=int, default=0)
-    parser.add_argument("--exclude-char", action="append", default=[])
-    parser.add_argument("--exclude-codepoint", action="append", default=[])
-    return parser
+from lcats.analysis.corpus import specials_cli
 
 
 def main(argv=None) -> int:
-    """Run the special-character extractor CLI."""
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    if args.nocontext:
-        args.context = 0
-    if args.context < 0:
-        parser.error("--context must be >= 0")
-    if args.name_width < 0:
-        parser.error("--name-width must be >= 0")
-
-    excluded = build_excluded_set(args.exclude_char, args.exclude_codepoint)
-    allowlist = load_allowlist_config(args.allowlist_config)
-
-    try:
-        if args.header:
-            print("\t".join(TSV_COLUMNS))
-
-        for label, handle in iter_input(args.files):
-            try:
-                text = handle.read()
-            finally:
-                if handle is not sys.stdin:
-                    handle.close()
-
-            for row in iter_special_character_rows(
-                path=label,
-                text=text,
-                allow_smart=args.allow_smart,
-                excluded=excluded,
-                allowlist=allowlist,
-                context=args.context,
-                name_width=args.name_width,
-            ):
-                print(row)
-
-        return 0
-    except BrokenPipeError:
-        return 141
+    """Run special-character extraction through the canonical CLI module."""
+    return specials_cli.main(argv)
 
 
 if __name__ == "__main__":

--- a/lcats/tests/analysis_tests/corpus_survey_test.py
+++ b/lcats/tests/analysis_tests/corpus_survey_test.py
@@ -125,7 +125,7 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
     def test_run_special_characters_check_forwards_context(self):
         output = corpus_survey.run_special_characters_check(
             displayed_text="pi√©ce",
-            extract_script="scripts/utils/extract_special_chars.py",
+            extract_script="lcats.analysis.corpus.specials_cli",
             allow_smart=True,
             allowlist_config="",
             excluded_codepoints=["00A0"],
@@ -144,7 +144,7 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
     def test_run_special_characters_check_uses_nocontext_flag(self):
         output = corpus_survey.run_special_characters_check(
             displayed_text="pi√©ce",
-            extract_script="scripts/utils/extract_special_chars.py",
+            extract_script="lcats.analysis.corpus.specials_cli",
             allow_smart=True,
             allowlist_config="",
             excluded_codepoints=[],

--- a/lcats/tests/analysis_tests/specials_cli_test.py
+++ b/lcats/tests/analysis_tests/specials_cli_test.py
@@ -1,0 +1,221 @@
+"""Unit tests for lcats.analysis.corpus.specials_cli."""
+
+import io
+import pathlib
+import tempfile
+import unittest
+import unittest.mock
+
+from lcats.analysis.corpus import specials
+from lcats.analysis.corpus import specials_cli
+
+
+class SpecialsCliTest(unittest.TestCase):
+    def test_default_context_extracts_left_and_right_characters(self):
+        text = "0123456789pi√©ce"
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=10,
+                name_width=0,
+            )
+        )
+
+        self.assertEqual(2, len(rows))
+        first = rows[0].split("\t")
+        second = rows[1].split("\t")
+
+        self.assertEqual("U+221A", first[1])
+        self.assertEqual("23456789pi√©ce", first[6])
+        self.assertEqual("U+00A9", second[1])
+        self.assertEqual("3456789pi√©ce", second[6])
+
+    def test_context_zero_suppresses_context_column_value(self):
+        text = "pi√©ce"
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=0,
+                name_width=0,
+            )
+        )
+
+        for row in rows:
+            parts = row.split("\t")
+            self.assertEqual("", parts[6])
+
+    def test_occurrence_reporting_counts_repeated_character(self):
+        text = "x©y©z"
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=10,
+                name_width=0,
+            )
+        )
+
+        self.assertEqual(2, len(rows))
+        self.assertEqual("1", rows[0].split("\t")[4])
+        self.assertEqual("2", rows[1].split("\t")[4])
+        self.assertEqual("1", rows[0].split("\t")[5])
+        self.assertEqual("3", rows[1].split("\t")[5])
+
+    def test_tsv_escaping_and_target_character_present(self):
+        text = "a\t©\n\rb"
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=10,
+                name_width=0,
+            )
+        )
+
+        fields = rows[0].split("\t")
+        self.assertEqual("©", fields[2])
+        self.assertIn("\\t", fields[6])
+        self.assertIn("\\n", fields[6])
+        self.assertIn("\\r", fields[6])
+        self.assertIn("©", fields[6])
+
+    def test_unicode_name_fallback_for_unnamed_char(self):
+        unnamed_char = chr(0x0378)
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text=unnamed_char,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=10,
+                name_width=0,
+            )
+        )
+
+        fields = rows[0].split("\t")
+        self.assertEqual("UNKNOWN", fields[3])
+
+    def test_name_width_truncates_unicode_name(self):
+        text = "√"
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=10,
+                name_width=6,
+            )
+        )
+
+        self.assertEqual("SQUAR…", rows[0].split("\t")[3])
+
+    def test_deterministic_ordering_is_by_offset(self):
+        text = "©√"
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=10,
+                name_width=0,
+            )
+        )
+
+        self.assertEqual("U+00A9", rows[0].split("\t")[1])
+        self.assertEqual("U+221A", rows[1].split("\t")[1])
+
+    def test_cli_nocontext_sets_context_to_zero(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = pathlib.Path(tmpdir) / "sample.txt"
+            file_path.write_text("pi√©ce", encoding="utf-8")
+            output = io.StringIO()
+            with unittest.mock.patch("sys.stdout", output):
+                exit_code = specials_cli.main(["--nocontext", str(file_path)])
+
+        self.assertEqual(0, exit_code)
+        lines = [line for line in output.getvalue().splitlines() if line.strip()]
+        self.assertEqual(2, len(lines))
+        self.assertEqual("", lines[0].split("\t")[6])
+
+    def test_classification_distinguishes_good_repairable_and_review(self):
+        text = "‘quote’ Ã©      √"
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text=text,
+                allow_smart=False,
+                excluded=set(),
+                allowlist=specials.AllowlistConfig(),
+                context=10,
+                name_width=0,
+            )
+        )
+
+        classifications = [row.split("\t")[7] for row in rows]
+        self.assertIn("likely_good", classifications)
+        self.assertIn("likely_repairable", classifications)
+        self.assertIn("review_needed", classifications)
+
+    def test_allowlist_config_allows_configured_character(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = pathlib.Path(tmpdir) / "allowlist.json"
+            config_path.write_text(
+                '{"allowed_codepoints":["00A9"]}',
+                encoding="utf-8",
+            )
+            allowlist = specials.load_allowlist_config(str(config_path))
+
+        rows = list(
+            specials_cli.iter_special_character_rows(
+                path="stdin",
+                text="©",
+                allow_smart=False,
+                excluded=set(),
+                allowlist=allowlist,
+                context=10,
+                name_width=0,
+            )
+        )
+        self.assertEqual([], rows)
+
+    def test_rows_delegate_to_specials_library(self):
+        with unittest.mock.patch.object(
+            specials, "iter_special_character_rows", return_value=["x\ty"]
+        ) as mock_rows:
+            rows = list(
+                specials_cli.iter_special_character_rows(
+                    path="stdin",
+                    text="©",
+                    allow_smart=False,
+                    excluded=set(),
+                    allowlist=specials.AllowlistConfig(),
+                    context=10,
+                    name_width=0,
+                )
+            )
+
+        self.assertEqual(["stdin\tx\ty"], rows)
+        mock_rows.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/utils_tests/extract_special_chars_test.py
+++ b/lcats/tests/utils_tests/extract_special_chars_test.py
@@ -1,232 +1,28 @@
 import importlib.util
-import io
 import pathlib
-import tempfile
 import unittest
 import unittest.mock
 
 
-def load_module(module_path: pathlib.Path, module_name: str):
-    spec = importlib.util.spec_from_file_location(module_name, module_path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
-
 class ExtractSpecialCharsScriptTest(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         root = pathlib.Path(__file__).resolve().parents[2]
-        cls.module = load_module(
-            root / "scripts" / "utils" / "extract_special_chars.py",
-            "extract_special_chars_script",
+        module_path = root / "scripts" / "utils" / "extract_special_chars.py"
+        spec = importlib.util.spec_from_file_location(
+            "extract_special_chars_script", module_path
         )
+        cls.module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.module)
 
-    def test_default_context_extracts_left_and_right_characters(self):
-        text = "0123456789pi√©ce"
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text=text,
-                allow_smart=False,
-                excluded=set(),
-                allowlist=self.module.AllowlistConfig(),
-                context=10,
-                name_width=0,
-            )
-        )
-
-        self.assertEqual(2, len(rows))
-        first = rows[0].split("\t")
-        second = rows[1].split("\t")
-
-        self.assertEqual("U+221A", first[1])
-        self.assertEqual("23456789pi√©ce", first[6])
-        self.assertEqual("U+00A9", second[1])
-        self.assertEqual("3456789pi√©ce", second[6])
-
-    def test_context_zero_suppresses_context_column_value(self):
-        text = "pi√©ce"
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text=text,
-                allow_smart=False,
-                excluded=set(),
-                allowlist=self.module.AllowlistConfig(),
-                context=0,
-                name_width=0,
-            )
-        )
-
-        for row in rows:
-            parts = row.split("\t")
-            self.assertEqual("", parts[6])
-
-    def test_occurrence_reporting_counts_repeated_character(self):
-        text = "x©y©z"
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text=text,
-                allow_smart=False,
-                excluded=set(),
-                allowlist=self.module.AllowlistConfig(),
-                context=10,
-                name_width=0,
-            )
-        )
-
-        self.assertEqual(2, len(rows))
-        self.assertEqual("1", rows[0].split("\t")[4])
-        self.assertEqual("2", rows[1].split("\t")[4])
-        self.assertEqual("1", rows[0].split("\t")[5])
-        self.assertEqual("3", rows[1].split("\t")[5])
-
-    def test_tsv_escaping_and_target_character_present(self):
-        text = "a\t©\n\rb"
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text=text,
-                allow_smart=False,
-                excluded=set(),
-                allowlist=self.module.AllowlistConfig(),
-                context=10,
-                name_width=0,
-            )
-        )
-
-        fields = rows[0].split("\t")
-        self.assertEqual("©", fields[2])
-        self.assertIn("\\t", fields[6])
-        self.assertIn("\\n", fields[6])
-        self.assertIn("\\r", fields[6])
-        self.assertIn("©", fields[6])
-
-    def test_unicode_name_fallback_for_unnamed_char(self):
-        unnamed_char = chr(0x0378)
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text=unnamed_char,
-                allow_smart=False,
-                excluded=set(),
-                allowlist=self.module.AllowlistConfig(),
-                context=10,
-                name_width=0,
-            )
-        )
-
-        fields = rows[0].split("\t")
-        self.assertEqual("UNKNOWN", fields[3])
-
-    def test_name_width_truncates_unicode_name(self):
-        text = "√"
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text=text,
-                allow_smart=False,
-                excluded=set(),
-                allowlist=self.module.AllowlistConfig(),
-                context=10,
-                name_width=6,
-            )
-        )
-
-        self.assertEqual("SQUAR…", rows[0].split("\t")[3])
-
-    def test_deterministic_ordering_is_by_offset(self):
-        text = "©√"
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text=text,
-                allow_smart=False,
-                excluded=set(),
-                allowlist=self.module.AllowlistConfig(),
-                context=10,
-                name_width=0,
-            )
-        )
-
-        self.assertEqual("U+00A9", rows[0].split("\t")[1])
-        self.assertEqual("U+221A", rows[1].split("\t")[1])
-
-    def test_cli_nocontext_sets_context_to_zero(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            file_path = pathlib.Path(tmpdir) / "sample.txt"
-            file_path.write_text("pi√©ce", encoding="utf-8")
-            output = io.StringIO()
-            with unittest.mock.patch("sys.stdout", output):
-                exit_code = self.module.main(["--nocontext", str(file_path)])
-
-        self.assertEqual(0, exit_code)
-        lines = [line for line in output.getvalue().splitlines() if line.strip()]
-        self.assertEqual(2, len(lines))
-        self.assertEqual("", lines[0].split("\t")[6])
-
-    def test_classification_distinguishes_good_repairable_and_review(self):
-        text = "‘quote’ Ã©      √"
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text=text,
-                allow_smart=False,
-                excluded=set(),
-                allowlist=self.module.AllowlistConfig(),
-                context=10,
-                name_width=0,
-            )
-        )
-
-        classifications = [row.split("\t")[7] for row in rows]
-        self.assertIn("likely_good", classifications)
-        self.assertIn("likely_repairable", classifications)
-        self.assertIn("review_needed", classifications)
-
-    def test_allowlist_config_allows_configured_character(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            config_path = pathlib.Path(tmpdir) / "allowlist.json"
-            config_path.write_text(
-                '{"allowed_codepoints":["00A9"]}',
-                encoding="utf-8",
-            )
-            allowlist = self.module.load_allowlist_config(str(config_path))
-
-        rows = list(
-            self.module.iter_special_character_rows(
-                path="stdin",
-                text="©",
-                allow_smart=False,
-                excluded=set(),
-                allowlist=allowlist,
-                context=10,
-                name_width=0,
-            )
-        )
-        self.assertEqual([], rows)
-
-    def test_legacy_wrapper_delegates_to_corpus_specials_library(self):
+    def test_main_delegates_to_canonical_specials_cli(self):
         with unittest.mock.patch.object(
-            self.module.specials, "iter_special_character_rows", return_value=["x\ty"]
-        ) as mock_rows:
-            rows = list(
-                self.module.iter_special_character_rows(
-                    path="stdin",
-                    text="©",
-                    allow_smart=False,
-                    excluded=set(),
-                    allowlist=self.module.AllowlistConfig(),
-                    context=10,
-                    name_width=0,
-                )
-            )
+            self.module.specials_cli, "main", return_value=7
+        ) as mock_main:
+            result = self.module.main(["--header"])
 
-        self.assertEqual(["stdin\tx\ty"], rows)
-        mock_rows.assert_called_once()
+        self.assertEqual(7, result)
+        mock_main.assert_called_once_with(["--header"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Remove duplicated special-character extraction logic from legacy `scripts/utils` and make the corpus analysis tree the canonical implementation home.
- Preserve backward compatibility with a minimal transitional wrapper while ensuring new code paths and tests target the library/CLI in `lcats.analysis.corpus`.
- Prevent future implementation drift by ensuring any legacy entry points delegate to the new canonical module rather than reimplementing logic.

### Description
- Add a canonical CLI module `lcats.analysis.corpus.specials_cli` that implements the special-character extractor CLI and delegates core work to `lcats.analysis.corpus.specials`.
- Replace the active implementation in `scripts/utils/extract_special_chars.py` with a thin wrapper that calls `specials_cli.main(...)` and no longer contains extraction logic.
- Update `lcats.analysis.corpus.cli` to default `--extract-script` to `lcats.analysis.corpus.specials_cli` and clarify the help text to reflect the canonical in-process path.
- Export `specials_cli` from the `lcats.analysis.corpus` package and migrate/adjust tests so behavior tests exercise `specials_cli` and the legacy script test only verifies delegation.

### Testing
- Ran formatting with `scripts/format` which completed successfully.
- Ran linting with `scripts/lint` and all checks passed.
- Ran the full test suite with `scripts/test` and all tests passed (`1132 tests` ran and reported `OK`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c9e59b248327a27a7e896e5d7229)