### PR TITLE
Prioritize mojibake detection over lexical diacritics

### DIFF
--- a/lcats/lcats/analysis/corpus/specials.py
+++ b/lcats/lcats/analysis/corpus/specials.py
@@ -209,6 +209,13 @@ def classify_character(text: str, offset: int, character: str) -> tuple[str, str
     unicode_category = unicodedata.category(character)
     unicode_name = get_unicode_name(character)
 
+    has_mojibake, fragment = _has_mojibake_pattern(text, offset, character)
+    if has_mojibake:
+        return (
+            "likely_repairable",
+            f"rule=mojibake-pattern; fragment={fragment}; unicode_category={unicode_category}",
+        )
+
     if character in SMART_ALLOWED:
         return (
             "likely_good",
@@ -222,13 +229,6 @@ def classify_character(text: str, offset: int, character: str) -> tuple[str, str
                 "rule=lexical-latin-diacritic; "
                 f"unicode_name={unicode_name}; normalized={unicodedata.normalize('NFD', character)}"
             ),
-        )
-
-    has_mojibake, fragment = _has_mojibake_pattern(text, offset, character)
-    if has_mojibake:
-        return (
-            "likely_repairable",
-            f"rule=mojibake-pattern; fragment={fragment}; unicode_category={unicode_category}",
         )
 
     return (

--- a/lcats/tests/analysis_tests/specials_test.py
+++ b/lcats/tests/analysis_tests/specials_test.py
@@ -85,6 +85,45 @@ class SpecialsTest(unittest.TestCase):
         self.assertEqual("likely_repairable", classification)
         self.assertIn("mojibake-pattern", evidence)
 
+    def test_classify_character_mojibake_sequences_out_rank_lexical_diacritics(self):
+        cases = [
+            ("ÃŸ", "Ã"),
+            ("Ã©", "Ã"),
+            ("seÃ±or", "Ã"),
+            ("coÃ¶rdinate", "Ã"),
+        ]
+        for text, character in cases:
+            with self.subTest(text=text):
+                index = text.index(character)
+                classification, evidence = specials.classify_character(
+                    text, index, character
+                )
+                self.assertEqual("likely_repairable", classification)
+                self.assertIn("mojibake-pattern", evidence)
+
+    def test_classify_character_valid_lexical_diacritics_remain_likely_good(self):
+        cases = [
+            ("Muñoz", "ñ"),
+            ("façade", "ç"),
+            ("naïve", "ï"),
+            ("Zoë", "ë"),
+        ]
+        for text, character in cases:
+            with self.subTest(text=text):
+                index = text.index(character)
+                classification, evidence = specials.classify_character(
+                    text, index, character
+                )
+                self.assertEqual("likely_good", classification)
+                self.assertIn("lexical-latin-diacritic", evidence)
+
+    def test_classify_character_prefers_mojibake_over_lexical_rule(self):
+        classification, evidence = specials.classify_character("ÃŸ", 0, "Ã")
+
+        self.assertEqual("likely_repairable", classification)
+        self.assertIn("mojibake-pattern", evidence)
+        self.assertNotIn("lexical-latin-diacritic", evidence)
+
     def test_classify_character_review_needed_for_uncommon_symbol(self):
         classification, evidence = specials.classify_character(
             "Contains √ symbol", 9, "√"


### PR DESCRIPTION
### Motivation
- The lexical-diacritic heuristic ran before mojibake detection, allowing mojibake-like Latin sequences (e.g., `ÃŸ`) to be misclassified as `likely_good` instead of `likely_repairable`.
- Specific repairable/encoding-corruption patterns must take precedence over broad lexical acceptance to surface actionable repair suggestions.

### Description
- Reordered `classify_character(...)` so `_has_mojibake_pattern(...)` is evaluated first and returns `likely_repairable` when matched, preventing mojibake fragments from being masked by lexical rules (`lcats/analysis/corpus/specials.py`).
- Preserved `SMART_ALLOWED` and the `_is_likely_lexical_diacritic(...)` path so genuine lexical diacritic uses still classify as `likely_good` when no mojibake evidence is present.
- Added regression tests that assert mojibake precedence and protect valid lexical diacritics: new tests in `tests/analysis_tests/specials_test.py` cover `ÃŸ`, `Ã©`, `seÃ±or`, `coÃ¶rdinate` and legitimate words like `Muñoz`, `façade`, `naïve`, `Zoë`.
- Change is minimal and focused on ordering/precedence only; no broader pipeline redesign was introduced.

### Testing
- Ran formatting with `scripts/format` and linting with `scripts/lint` with no issues.
- Ran the full test suite with `scripts/test`, which executed the automated tests (including the new regression cases) and completed successfully: `Ran 1135 tests` — `OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cbb639908327a460e19a308b2824)