### PR TITLE
Add conservative Unicode repair proposal engine and non-destructive dry-run CLI

### DIFF
--- a/lcats/lcats/analysis/corpus/__init__.py
+++ b/lcats/lcats/analysis/corpus/__init__.py
@@ -6,6 +6,7 @@ from lcats.analysis.corpus import models
 from lcats.analysis.corpus import output
 from lcats.analysis.corpus import processing
 from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import repairs_cli
 from lcats.analysis.corpus import qa
 from lcats.analysis.corpus import specials
 from lcats.analysis.corpus import specials_cli
@@ -18,6 +19,7 @@ __all__ = [
     "output",
     "processing",
     "repairs",
+    "repairs_cli",
     "qa",
     "specials",
     "specials_cli",

--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -1,4 +1,4 @@
-"""Repair-suggestion helpers for special-character findings."""
+"""Conservative repair proposal helpers for special-character findings."""
 
 from dataclasses import dataclass
 from typing import Iterable, Optional, Sequence
@@ -27,6 +27,8 @@ class RepairSuggestion:
     replacement_text: str
     finding_offset: int
     evidence: str
+    confidence: str = "high"
+    rationale: str = ""
 
 
 DEFAULT_REPAIR_RULES = (
@@ -148,6 +150,8 @@ def suggest_repairs(
                 replacement_text=rule.replacement_text,
                 finding_offset=finding.offset,
                 evidence=finding.evidence,
+                confidence="high",
+                rationale=rule.description,
             )
         )
 
@@ -170,3 +174,54 @@ def apply_repair_suggestions(text: str, suggestions: Sequence[RepairSuggestion])
             + updated[suggestion.end :]
         )
     return updated
+
+
+def suggest_repairs_for_text(
+    text: str,
+    *,
+    allow_smart: bool = False,
+    excluded: Optional[set[str]] = None,
+    allowlist: Optional[specials.AllowlistConfig] = None,
+    context: int = 12,
+    name_width: int = 0,
+    rules: Sequence[RepairRule] = DEFAULT_REPAIR_RULES,
+) -> list[RepairSuggestion]:
+    """Extract findings from text and propose conservative repairs.
+
+    This is a non-destructive workflow helper. It only returns proposals and does
+    not apply replacements.
+    """
+    effective_allowlist = (
+        allowlist if allowlist is not None else specials.AllowlistConfig()
+    )
+    findings = specials.iter_special_characters(
+        text=text,
+        allow_smart=allow_smart,
+        excluded=excluded or set(),
+        allowlist=effective_allowlist,
+        context=context,
+        name_width=name_width,
+    )
+    return suggest_repairs(text, findings, rules=rules)
+
+
+def build_dry_run_report(
+    suggestions: Sequence[RepairSuggestion],
+    *,
+    file_label: str = "",
+) -> str:
+    """Return a deterministic dry-run report for review/audit."""
+    lines = []
+    for suggestion in suggestions:
+        prefix = f"{file_label}:" if file_label else ""
+        lines.append(
+            (
+                f"{prefix}{suggestion.start}-{suggestion.end}\t"
+                f"{suggestion.rule_id}\t"
+                f"confidence={suggestion.confidence}\t"
+                f"before={suggestion.original_text}\t"
+                f"after={suggestion.replacement_text}\t"
+                f"reason={suggestion.rationale}"
+            )
+        )
+    return "\n".join(lines)

--- a/lcats/lcats/analysis/corpus/repairs_cli.py
+++ b/lcats/lcats/analysis/corpus/repairs_cli.py
@@ -1,0 +1,57 @@
+"""CLI wrapper for conservative Unicode/special-character repair proposals."""
+
+import argparse
+import pathlib
+import sys
+
+from lcats.analysis.corpus import repairs
+
+
+def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
+    """Build parser for dry-run repair proposal generation."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate conservative dry-run repair proposals for known "
+            "Unicode/mojibake findings. This command is non-destructive and "
+            "never modifies files."
+        ),
+        add_help=add_help,
+    )
+    parser.add_argument("files", nargs="+")
+    parser.add_argument("--header", action="store_true")
+    return parser
+
+
+def run(argv=None, parsed_args=None) -> int:
+    """Run dry-run repair proposal generation for one or more text files."""
+    parser = build_parser()
+    args = parsed_args if parsed_args is not None else parser.parse_args(argv)
+
+    if args.header:
+        print("path\tstart\tend\trule\tconfidence\tbefore\tafter\treason")
+
+    for file_name in args.files:
+        file_path = pathlib.Path(file_name)
+        text = file_path.read_text(encoding="utf-8")
+        suggestions = repairs.suggest_repairs_for_text(text)
+        for suggestion in suggestions:
+            print(
+                "\t".join(
+                    [
+                        str(file_path),
+                        str(suggestion.start),
+                        str(suggestion.end),
+                        suggestion.rule_id,
+                        suggestion.confidence,
+                        suggestion.original_text,
+                        suggestion.replacement_text,
+                        suggestion.rationale,
+                    ]
+                )
+            )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 
 from lcats.analysis.corpus import cli as corpus_cli
+from lcats.analysis.corpus import repairs_cli
 import lcats.gatherers.main
 import lcats.inspect
 
@@ -40,6 +41,10 @@ def _handle_survey(args):
 
 def _handle_stats(args):
     return "", corpus_cli.run_stats(parsed_args=args)
+
+
+def _handle_repair_specials(args):
+    return "", repairs_cli.run(parsed_args=args)
 
 
 def _handle_index(_args):
@@ -163,6 +168,19 @@ def build_parser() -> argparse.ArgumentParser:
     )
     stats_parser.set_defaults(handler=_handle_stats)
     command_parsers["stats"] = stats_parser
+
+    repair_specials_parent = repairs_cli.build_parser(add_help=False)
+    repair_specials_parser = subparsers.add_parser(
+        "repair-specials",
+        parents=[repair_specials_parent],
+        help="Generate dry-run Unicode/special-character repair proposals.",
+        description=(
+            "Generate conservative repair proposals for known mojibake "
+            "fragments. This command is non-destructive."
+        ),
+    )
+    repair_specials_parser.set_defaults(handler=_handle_repair_specials)
+    command_parsers["repair-specials"] = repair_specials_parser
 
     index_parser = subparsers.add_parser(
         "index",

--- a/lcats/tests/analysis_tests/repairs_cli_test.py
+++ b/lcats/tests/analysis_tests/repairs_cli_test.py
@@ -1,0 +1,65 @@
+"""Unit tests for lcats.analysis.corpus.repairs_cli."""
+
+import io
+import pathlib
+import tempfile
+import unittest
+import unittest.mock
+
+from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import repairs_cli
+
+
+class RepairsCliTest(unittest.TestCase):
+    """Tests for non-destructive dry-run repair proposal workflow."""
+
+    def test_dry_run_does_not_modify_source_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = pathlib.Path(tmpdir) / "sample.txt"
+            original_text = "A broken token: â€™\n"
+            file_path.write_text(original_text, encoding="utf-8")
+
+            output = io.StringIO()
+            with unittest.mock.patch("sys.stdout", output):
+                exit_code = repairs_cli.run(["--header", str(file_path)])
+
+            self.assertEqual(0, exit_code)
+            self.assertEqual(original_text, file_path.read_text(encoding="utf-8"))
+
+    def test_dry_run_output_includes_before_after_and_rule(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = pathlib.Path(tmpdir) / "sample.txt"
+            file_path.write_text("Example â€¦ token", encoding="utf-8")
+
+            output = io.StringIO()
+            with unittest.mock.patch("sys.stdout", output):
+                repairs_cli.run([str(file_path)])
+
+            report = output.getvalue().strip()
+            self.assertIn("mojibake-ellipsis", report)
+            self.assertIn("â€¦", report)
+            self.assertIn("…", report)
+
+    def test_build_dry_run_report_is_deterministic_and_auditable(self):
+        suggestion = repairs.RepairSuggestion(
+            rule_id="mojibake-right-single-quote",
+            start=9,
+            end=12,
+            original_text="â€™",
+            replacement_text="’",
+            finding_offset=9,
+            evidence="rule=mojibake-pattern; fragment=â€™",
+            confidence="high",
+            rationale="Broken UTF-8 right single quote sequence.",
+        )
+
+        report = repairs.build_dry_run_report([suggestion], file_label="story.txt")
+
+        self.assertIn("story.txt:9-12", report)
+        self.assertIn("before=â€™", report)
+        self.assertIn("after=’", report)
+        self.assertIn("confidence=high", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/analysis_tests/repairs_test.py
+++ b/lcats/tests/analysis_tests/repairs_test.py
@@ -99,6 +99,22 @@ class RepairsTest(unittest.TestCase):
 
         self.assertEqual([], suggestions)
 
+    def test_suggest_repairs_ignores_review_needed_cases(self):
+        finding = specials.SpecialCharacter(
+            character="√",
+            codepoint="U+221A",
+            unicode_name="SQUARE ROOT",
+            occurrence_index=1,
+            offset=3,
+            context="a√b",
+            classification="review_needed",
+            evidence="rule=residual-review; unicode_name=SQUARE ROOT",
+        )
+
+        suggestions = repairs.suggest_repairs("a√b", [finding])
+
+        self.assertEqual([], suggestions)
+
     def test_apply_repair_suggestions_applies_only_matching_spans(self):
         text = "Broken â€™ and â€¦"
         suggestions = [
@@ -125,6 +141,15 @@ class RepairsTest(unittest.TestCase):
         updated = repairs.apply_repair_suggestions(text, suggestions)
 
         self.assertEqual("Broken ’ and â€¦", updated)
+
+    def test_suggest_repairs_for_text_uses_classifier_and_rules(self):
+        suggestions = repairs.suggest_repairs_for_text("Text â€” sample")
+
+        self.assertEqual(1, len(suggestions))
+        suggestion = suggestions[0]
+        self.assertEqual("â€”", suggestion.original_text)
+        self.assertEqual("—", suggestion.replacement_text)
+        self.assertEqual("high", suggestion.confidence)
 
 
 if __name__ == "__main__":

--- a/lcats/tests/cli_test.py
+++ b/lcats/tests/cli_test.py
@@ -60,6 +60,18 @@ class TestCli(unittest.TestCase):
         self.assertEqual(0, actual_status)
         mock_run_stats.assert_called_once()
 
+    @mock.patch("lcats.analysis.corpus.repairs_cli.run")
+    def test_dispatch_repair_specials(self, mock_run):
+        """Ensure the repair-specials command delegates to repairs_cli."""
+        mock_run.return_value = 0
+
+        actual_message, actual_status = cli.dispatch(
+            "repair-specials", ["--header", "sample.txt"]
+        )
+        self.assertEqual("", actual_message)
+        self.assertEqual(0, actual_status)
+        mock_run.assert_called_once()
+
     @parameterized.parameterized.expand(
         [
             ("index", "Indexing data files is not yet implemented."),
@@ -98,8 +110,10 @@ class TestCli(unittest.TestCase):
         [
             (["survey", "--help"], "usage: lcats survey"),
             (["stats", "--help"], "usage: lcats stats"),
+            (["repair-specials", "--help"], "usage: lcats repair-specials"),
             (["help", "survey"], "usage: lcats survey"),
             (["help", "stats"], "usage: lcats stats"),
+            (["help", "repair-specials"], "usage: lcats repair-specials"),
         ]
     )
     def test_command_help(self, argv, expected_usage):


### PR DESCRIPTION
### Motivation
- Provide a small, reusable repair engine that converts existing `likely_repairable` Unicode/special-character findings into deterministic, conservative repair proposals for later review.  
- Make dry-run the primary workflow so users can inspect proposed repairs without changing corpus files and preserve auditability for each proposal.  
- Keep logic in the corpus analysis tree and leave destructive apply/clean flows out of default behavior.

### Description
- Extended `lcats.analysis.corpus.repairs` to produce structured proposals by adding `confidence` and `rationale` to `RepairSuggestion` and keeping all audit fields (`start`, `end`, `original_text`, `replacement_text`, `rule_id`, `evidence`).  
- Added `suggest_repairs_for_text(...)` which runs the existing classifier (`specials.iter_special_characters`) and returns conservative proposals without modifying text, and `build_dry_run_report(...)` to produce deterministic, reviewable report lines.  
- Introduced a thin, non-destructive CLI `lcats.analysis.corpus.repairs_cli` to print dry-run proposal rows for files and wired a top-level `lcats repair-specials` command to delegate to that CLI; the CLI wraps the library and does not embed repair logic.  
- Added and adjusted unit tests in `tests/analysis_tests/repairs_test.py`, new `tests/analysis_tests/repairs_cli_test.py`, and `tests/cli_test.py` coverage for dispatch/help; kept mapping rules conservative and deterministic (no speculative repairs).

### Testing
- Ran formatter and linters with `scripts/format` and `scripts/lint`, and ensured formatting/lint checks passed.  
- Ran the full unit test suite with `scripts/test`, which executed the updated and new tests and returned `OK` (all tests passed).  
- New unit tests cover mapping known `likely_repairable` fragments to proposals, safety cases (`likely_good` / `review_needed` produce no proposals), audit fields (including `confidence`/`rationale`), dry-run report content, and that dry-run does not modify source files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6707613288327a6e9fcecde06bc66)