### PR TITLE
Represent Unicode/special-character repairs as explicit span operations

### DIFF
--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -221,7 +221,10 @@ def apply_span_operations(text: str, operations: Sequence[SpanRepairOperation]) 
     Operations are treated as spans into the original input text. If any spans
     overlap, no changes are applied and the original text is returned.
     """
-    ordered = sorted(operations, key=lambda current: (current.start, current.end))
+    ordered = sorted(
+        (operation for operation in operations if operation.operation == "replace"),
+        key=lambda current: (current.start, current.end),
+    )
     if _has_overlapping_spans(ordered):
         return text
 

--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -31,6 +31,21 @@ class RepairSuggestion:
     rationale: str = ""
 
 
+@dataclass(frozen=True)
+class SpanRepairOperation:
+    """Explicit span-based text operation for conservative repair workflows."""
+
+    operation: str
+    start: int
+    end: int
+    original_text: str
+    replacement_text: str
+    rule_id: str
+    evidence: str
+    rationale: str = ""
+    confidence: str = "high"
+
+
 DEFAULT_REPAIR_RULES = (
     RepairRule(
         rule_id="mojibake-right-single-quote",
@@ -160,18 +175,67 @@ def suggest_repairs(
 
 
 def apply_repair_suggestions(text: str, suggestions: Sequence[RepairSuggestion]) -> str:
-    """Apply suggestions in reverse order when original spans still match."""
+    """Apply suggestions using explicit span operations."""
+    operations = suggestions_to_span_operations(suggestions)
+    return apply_span_operations(text, operations)
+
+
+def suggestions_to_span_operations(
+    suggestions: Sequence[RepairSuggestion],
+) -> list[SpanRepairOperation]:
+    """Convert suggestions to explicit span-replace operations."""
+    operations = [
+        SpanRepairOperation(
+            operation="replace",
+            start=suggestion.start,
+            end=suggestion.end,
+            original_text=suggestion.original_text,
+            replacement_text=suggestion.replacement_text,
+            rule_id=suggestion.rule_id,
+            evidence=suggestion.evidence,
+            rationale=suggestion.rationale,
+            confidence=suggestion.confidence,
+        )
+        for suggestion in suggestions
+    ]
+    operations.sort(
+        key=lambda operation: (operation.start, operation.end, operation.rule_id)
+    )
+    return operations
+
+
+def _has_overlapping_spans(operations: Sequence[SpanRepairOperation]) -> bool:
+    """Return True when any sorted operation span overlaps."""
+    sorted_operations = sorted(
+        operations, key=lambda current: (current.start, current.end)
+    )
+    for left, right in zip(sorted_operations, sorted_operations[1:]):
+        if left.end > right.start:
+            return True
+    return False
+
+
+def apply_span_operations(text: str, operations: Sequence[SpanRepairOperation]) -> str:
+    """Apply non-overlapping span operations in deterministic order.
+
+    Operations are treated as spans into the original input text. If any spans
+    overlap, no changes are applied and the original text is returned.
+    """
+    ordered = sorted(operations, key=lambda current: (current.start, current.end))
+    if _has_overlapping_spans(ordered):
+        return text
+
     updated = text
-    for suggestion in sorted(
-        suggestions, key=lambda current: (current.start, current.end), reverse=True
-    ):
-        current_original = updated[suggestion.start : suggestion.end]
-        if current_original != suggestion.original_text:
+    for operation in reversed(ordered):
+        if operation.operation != "replace":
+            continue
+        current_original = updated[operation.start : operation.end]
+        if current_original != operation.original_text:
             continue
         updated = (
-            updated[: suggestion.start]
-            + suggestion.replacement_text
-            + updated[suggestion.end :]
+            updated[: operation.start]
+            + operation.replacement_text
+            + updated[operation.end :]
         )
     return updated
 

--- a/lcats/tests/analysis_tests/repairs_test.py
+++ b/lcats/tests/analysis_tests/repairs_test.py
@@ -222,6 +222,33 @@ class RepairsTest(unittest.TestCase):
 
         self.assertEqual(text, updated)
 
+    def test_apply_span_operations_ignores_non_replace_in_overlap_precheck(self):
+        text = "â€™"
+        operations = [
+            repairs.SpanRepairOperation(
+                operation="delete",
+                start=0,
+                end=2,
+                original_text="â€",
+                replacement_text="",
+                rule_id="unsupported-delete",
+                evidence="unsupported-op",
+            ),
+            repairs.SpanRepairOperation(
+                operation="replace",
+                start=0,
+                end=3,
+                original_text="â€™",
+                replacement_text="’",
+                rule_id="mojibake-right-single-quote",
+                evidence="rule=mojibake-pattern; fragment=â€™",
+            ),
+        ]
+
+        updated = repairs.apply_span_operations(text, operations)
+
+        self.assertEqual("’", updated)
+
     def test_suggest_repairs_for_text_uses_classifier_and_rules(self):
         suggestions = repairs.suggest_repairs_for_text("Text â€” sample")
 

--- a/lcats/tests/analysis_tests/repairs_test.py
+++ b/lcats/tests/analysis_tests/repairs_test.py
@@ -142,6 +142,86 @@ class RepairsTest(unittest.TestCase):
 
         self.assertEqual("Broken ’ and â€¦", updated)
 
+    def test_suggestions_to_span_operations_exposes_explicit_fields(self):
+        suggestion = repairs.RepairSuggestion(
+            rule_id="mojibake-right-single-quote",
+            start=2,
+            end=5,
+            original_text="â€™",
+            replacement_text="’",
+            finding_offset=2,
+            evidence="rule=mojibake-pattern; fragment=â€™",
+            confidence="high",
+            rationale="Broken UTF-8 right single quote sequence.",
+        )
+
+        operations = repairs.suggestions_to_span_operations([suggestion])
+
+        self.assertEqual(1, len(operations))
+        operation = operations[0]
+        self.assertEqual("replace", operation.operation)
+        self.assertEqual(2, operation.start)
+        self.assertEqual(5, operation.end)
+        self.assertEqual("â€™", operation.original_text)
+        self.assertEqual("’", operation.replacement_text)
+        self.assertEqual("mojibake-right-single-quote", operation.rule_id)
+        self.assertIn("fragment=â€™", operation.evidence)
+        self.assertEqual("high", operation.confidence)
+
+    def test_apply_span_operations_applies_in_deterministic_order(self):
+        text = "â€™-â€¦"
+        operations = [
+            repairs.SpanRepairOperation(
+                operation="replace",
+                start=4,
+                end=7,
+                original_text="â€¦",
+                replacement_text="…",
+                rule_id="mojibake-ellipsis",
+                evidence="rule=mojibake-pattern; fragment=â€¦",
+            ),
+            repairs.SpanRepairOperation(
+                operation="replace",
+                start=0,
+                end=3,
+                original_text="â€™",
+                replacement_text="’",
+                rule_id="mojibake-right-single-quote",
+                evidence="rule=mojibake-pattern; fragment=â€™",
+            ),
+        ]
+
+        updated = repairs.apply_span_operations(text, operations)
+
+        self.assertEqual("’-…", updated)
+
+    def test_apply_span_operations_returns_original_for_overlap(self):
+        text = "abcdef"
+        operations = [
+            repairs.SpanRepairOperation(
+                operation="replace",
+                start=1,
+                end=4,
+                original_text="bcd",
+                replacement_text="X",
+                rule_id="rule-a",
+                evidence="overlap-test-a",
+            ),
+            repairs.SpanRepairOperation(
+                operation="replace",
+                start=3,
+                end=5,
+                original_text="de",
+                replacement_text="Y",
+                rule_id="rule-b",
+                evidence="overlap-test-b",
+            ),
+        ]
+
+        updated = repairs.apply_span_operations(text, operations)
+
+        self.assertEqual(text, updated)
+
     def test_suggest_repairs_for_text_uses_classifier_and_rules(self):
         suggestions = repairs.suggest_repairs_for_text("Text â€” sample")
 


### PR DESCRIPTION
### Motivation
- Make Unicode/mojibake repair proposals explicit, auditable, and composable by representing them as span-based operations rather than ad-hoc replacement tuples.
- Preserve the existing conservative repair semantics while enabling deterministic ordering, review, serialization, and safe composition for future workflows.
- Keep write behavior conservative so proposals remain non-destructive by default and overlapping/conflicting edits are rejected.

### Description
- Added a new dataclass `SpanRepairOperation` in `lcats.analysis.corpus.repairs` that includes `operation`, `start`, `end`, `original_text`, `replacement_text`, `rule_id`, `evidence`, `rationale`, and `confidence`.
- Introduced `suggestions_to_span_operations(...)` to convert existing `RepairSuggestion` objects into deterministic, sorted span operations without changing repair meaning.
- Implemented `apply_span_operations(...)` which applies non-overlapping `replace` operations in a deterministic order, verifies original-text matches before applying, and returns the original text unchanged if any spans overlap.
- Updated `apply_repair_suggestions(...)` to delegate through the conversion layer and span-application helpers, and added unit tests in `tests/analysis_tests/repairs_test.py` that verify representation fields, deterministic ordering, and safe overlap handling.

### Testing
- Ran project formatting with `scripts/format` and lint checks with `scripts/lint`, both completed cleanly.
- Executed the full test suite with `scripts/test`, which ran successfully and included the new tests (all tests passed).
- New unit tests exercise `suggestions_to_span_operations(...)`, `apply_span_operations(...)` ordering semantics, and overlap safety and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e672d02ef083278eeb030db324649d)