### PR TITLE
Add human review decision loop foundations for Unicode/special-char repair flow

### DIFF
--- a/lcats/README.md
+++ b/lcats/README.md
@@ -33,6 +33,74 @@ lcats gather
 ```
 Publishing this package to PyPI is not yet supported because we don't yet have extensive enough tests.
 
+## Unicode / special-character human review decisions (library usage)
+
+The corpus analysis package now includes a library-first decision model for
+human-reviewed Unicode/special-character findings and conservative repair
+proposals.
+
+### What this supports
+
+- Mark a repair proposal as:
+  - `approved`
+  - `rejected`
+  - `unresolved`
+- Mark repeated special-character findings as allowed/expected so they are
+  suppressed in later reporting/proposal generation.
+- Keep decisions serializable (`to_dict` / `from_dict`) for future config or
+  persistence workflows.
+
+### Modules
+
+- `lcats.analysis.corpus.review`: decision model + application helpers
+- `lcats.analysis.corpus.specials`: optional decision-aware suppression in
+  reporting helpers
+- `lcats.analysis.corpus.repairs`: optional decision-aware suppression and
+  reviewed suggestion grouping
+
+### Minimal example
+
+```python
+from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import review
+
+text = "Broken token â€™ and accepted symbol √"
+
+decision_store = review.ReviewDecisionStore(
+    repair_decisions=(
+        review.RepairReviewDecision(
+            rule_id="mojibake-right-single-quote",
+            original_text="â€™",
+            replacement_text="’",
+            decision=review.APPROVED,
+            rationale="Known encoding fix in this corpus.",
+        ),
+    ),
+    allowed_special_cases=(
+        review.AllowedSpecialCase(
+            character="√",
+            classification="review_needed",
+            evidence_contains="residual-review",
+            rationale="Expected in mathematical excerpts.",
+        ),
+    ),
+)
+
+# Conservative: suggestions are still non-destructive proposals only.
+grouped = repairs.suggest_reviewed_repairs_for_text(
+    text,
+    decision_store=decision_store,
+)
+
+print(len(grouped.approved), len(grouped.rejected), len(grouped.unresolved))
+```
+
+### Notes
+
+- Review decisions do **not** rewrite corpora by default.
+- Decisions are applied in-memory to findings/reports/proposals.
+- Interactive UI/editor workflows are intentionally deferred.
+
 ## Optional pre-commit checks (local convenience only)
 
 `pre-commit` runs lightweight checks automatically before each commit. In LCATS, this is only a local convenience layer.

--- a/lcats/lcats/analysis/corpus/__init__.py
+++ b/lcats/lcats/analysis/corpus/__init__.py
@@ -7,6 +7,7 @@ from lcats.analysis.corpus import output
 from lcats.analysis.corpus import processing
 from lcats.analysis.corpus import repairs
 from lcats.analysis.corpus import repairs_cli
+from lcats.analysis.corpus import review
 from lcats.analysis.corpus import qa
 from lcats.analysis.corpus import specials
 from lcats.analysis.corpus import specials_cli
@@ -20,6 +21,7 @@ __all__ = [
     "processing",
     "repairs",
     "repairs_cli",
+    "review",
     "qa",
     "specials",
     "specials_cli",

--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -123,6 +123,7 @@ def suggest_repairs(
     text: str,
     findings: Iterable[specials.SpecialCharacter],
     rules: Sequence[RepairRule] = DEFAULT_REPAIR_RULES,
+    decision_store=None,
 ) -> list[RepairSuggestion]:
     """Convert likely-repairable findings into conservative suggestions.
 
@@ -138,7 +139,16 @@ def suggest_repairs(
     suggestions: list[RepairSuggestion] = []
     seen_spans: set[tuple[int, int]] = set()
 
-    for finding in findings:
+    filtered_findings = list(findings)
+    if decision_store is not None:
+        from lcats.analysis.corpus import review
+
+        filtered_findings = review.apply_review_to_specials(
+            filtered_findings,
+            decision_store,
+        )
+
+    for finding in filtered_findings:
         if finding.classification != "likely_repairable":
             continue
 
@@ -252,6 +262,7 @@ def suggest_repairs_for_text(
     context: int = 12,
     name_width: int = 0,
     rules: Sequence[RepairRule] = DEFAULT_REPAIR_RULES,
+    decision_store=None,
 ) -> list[RepairSuggestion]:
     """Extract findings from text and propose conservative repairs.
 
@@ -269,7 +280,39 @@ def suggest_repairs_for_text(
         context=context,
         name_width=name_width,
     )
-    return suggest_repairs(text, findings, rules=rules)
+    return suggest_repairs(
+        text,
+        findings,
+        rules=rules,
+        decision_store=decision_store,
+    )
+
+
+def suggest_reviewed_repairs_for_text(
+    text: str,
+    *,
+    allow_smart: bool = False,
+    excluded: Optional[set[str]] = None,
+    allowlist: Optional[specials.AllowlistConfig] = None,
+    context: int = 12,
+    name_width: int = 0,
+    rules: Sequence[RepairRule] = DEFAULT_REPAIR_RULES,
+    decision_store=None,
+):
+    """Return grouped repair suggestions after applying review decisions."""
+    from lcats.analysis.corpus import review
+
+    suggestions = suggest_repairs_for_text(
+        text,
+        allow_smart=allow_smart,
+        excluded=excluded,
+        allowlist=allowlist,
+        context=context,
+        name_width=name_width,
+        rules=rules,
+        decision_store=decision_store,
+    )
+    return review.apply_review_to_repairs(suggestions, decision_store)
 
 
 def build_dry_run_report(

--- a/lcats/lcats/analysis/corpus/review.py
+++ b/lcats/lcats/analysis/corpus/review.py
@@ -1,0 +1,203 @@
+"""Human review decisions for special-character findings and repairs."""
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import specials
+
+APPROVED = "approved"
+REJECTED = "rejected"
+ALLOWED = "allowed"
+UNRESOLVED = "unresolved"
+
+
+@dataclass(frozen=True)
+class RepairReviewDecision:
+    """One human review decision for a repair suggestion signature."""
+
+    rule_id: str
+    original_text: str
+    replacement_text: str
+    decision: str
+    rationale: str = ""
+
+
+@dataclass(frozen=True)
+class AllowedSpecialCase:
+    """One allow/expected rule for special-character findings."""
+
+    character: str = ""
+    codepoint: str = ""
+    classification: str = ""
+    evidence_contains: str = ""
+    rationale: str = ""
+
+
+@dataclass(frozen=True)
+class ReviewedRepairs:
+    """Repair suggestions grouped by review decision."""
+
+    approved: tuple[repairs.RepairSuggestion, ...]
+    rejected: tuple[repairs.RepairSuggestion, ...]
+    unresolved: tuple[repairs.RepairSuggestion, ...]
+
+
+@dataclass(frozen=True)
+class ReviewDecisionStore:
+    """Structured, serializable review decisions for specials and repairs."""
+
+    repair_decisions: tuple[RepairReviewDecision, ...] = ()
+    allowed_special_cases: tuple[AllowedSpecialCase, ...] = ()
+
+    def to_dict(self) -> dict[str, list[dict[str, str]]]:
+        """Return a JSON-serializable representation for persistence."""
+        return {
+            "repair_decisions": [
+                {
+                    "rule_id": decision.rule_id,
+                    "original_text": decision.original_text,
+                    "replacement_text": decision.replacement_text,
+                    "decision": decision.decision,
+                    "rationale": decision.rationale,
+                }
+                for decision in self.repair_decisions
+            ],
+            "allowed_special_cases": [
+                {
+                    "character": allowed.character,
+                    "codepoint": allowed.codepoint,
+                    "classification": allowed.classification,
+                    "evidence_contains": allowed.evidence_contains,
+                    "rationale": allowed.rationale,
+                }
+                for allowed in self.allowed_special_cases
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Optional[dict]) -> "ReviewDecisionStore":
+        """Create a review decision store from a dict payload."""
+        if payload is None:
+            return cls()
+
+        return cls(
+            repair_decisions=tuple(
+                RepairReviewDecision(
+                    rule_id=item.get("rule_id", ""),
+                    original_text=item.get("original_text", ""),
+                    replacement_text=item.get("replacement_text", ""),
+                    decision=item.get("decision", UNRESOLVED),
+                    rationale=item.get("rationale", ""),
+                )
+                for item in payload.get("repair_decisions", [])
+            ),
+            allowed_special_cases=tuple(
+                AllowedSpecialCase(
+                    character=item.get("character", ""),
+                    codepoint=item.get("codepoint", ""),
+                    classification=item.get("classification", ""),
+                    evidence_contains=item.get("evidence_contains", ""),
+                    rationale=item.get("rationale", ""),
+                )
+                for item in payload.get("allowed_special_cases", [])
+            ),
+        )
+
+
+def find_repair_decision(
+    suggestion: repairs.RepairSuggestion,
+    decision_store: ReviewDecisionStore,
+) -> str:
+    """Return the decision state for one repair suggestion."""
+    for decision in decision_store.repair_decisions:
+        if decision.rule_id != suggestion.rule_id:
+            continue
+        if decision.original_text != suggestion.original_text:
+            continue
+        if decision.replacement_text != suggestion.replacement_text:
+            continue
+        return decision.decision
+    return UNRESOLVED
+
+
+def apply_review_to_repairs(
+    suggestions: Sequence[repairs.RepairSuggestion],
+    decision_store: Optional[ReviewDecisionStore],
+) -> ReviewedRepairs:
+    """Partition repairs into approved, rejected, and unresolved groups."""
+    if decision_store is None:
+        return ReviewedRepairs(
+            approved=(),
+            rejected=(),
+            unresolved=tuple(suggestions),
+        )
+
+    approved: list[repairs.RepairSuggestion] = []
+    rejected: list[repairs.RepairSuggestion] = []
+    unresolved: list[repairs.RepairSuggestion] = []
+
+    for suggestion in suggestions:
+        decision = find_repair_decision(suggestion, decision_store)
+        if decision == APPROVED:
+            approved.append(suggestion)
+        elif decision == REJECTED:
+            rejected.append(suggestion)
+        else:
+            unresolved.append(suggestion)
+
+    return ReviewedRepairs(
+        approved=tuple(approved),
+        rejected=tuple(rejected),
+        unresolved=tuple(unresolved),
+    )
+
+
+def _is_allowed_by_case(
+    finding: specials.SpecialCharacter,
+    allowed_case: AllowedSpecialCase,
+) -> bool:
+    """Return True when an allow rule matches one special-character finding."""
+    if allowed_case.character and allowed_case.character != finding.character:
+        return False
+    if allowed_case.codepoint and allowed_case.codepoint != finding.codepoint:
+        return False
+    if (
+        allowed_case.classification
+        and allowed_case.classification != finding.classification
+    ):
+        return False
+    if (
+        allowed_case.evidence_contains
+        and allowed_case.evidence_contains not in finding.evidence
+    ):
+        return False
+    return True
+
+
+def should_suppress_special(
+    finding: specials.SpecialCharacter,
+    decision_store: Optional[ReviewDecisionStore],
+) -> bool:
+    """Return True when a finding is covered by an allowed special-case rule."""
+    if decision_store is None:
+        return False
+
+    for allowed_case in decision_store.allowed_special_cases:
+        if _is_allowed_by_case(finding, allowed_case):
+            return True
+    return False
+
+
+def apply_review_to_specials(
+    findings: Iterable[specials.SpecialCharacter],
+    decision_store: Optional[ReviewDecisionStore],
+) -> list[specials.SpecialCharacter]:
+    """Filter findings using allow/expected special-character decisions."""
+    if decision_store is None:
+        return list(findings)
+    return [
+        finding
+        for finding in findings
+        if not should_suppress_special(finding, decision_store)
+    ]

--- a/lcats/lcats/analysis/corpus/specials.py
+++ b/lcats/lcats/analysis/corpus/specials.py
@@ -319,16 +319,23 @@ def iter_special_character_rows(
     allowlist: AllowlistConfig,
     context: int,
     name_width: int,
+    decision_store=None,
 ):
     """Yield stable TSV rows for each extracted special character."""
-    for result in iter_special_characters(
+    findings = iter_special_characters(
         text=text,
         allow_smart=allow_smart,
         excluded=excluded,
         allowlist=allowlist,
         context=context,
         name_width=name_width,
-    ):
+    )
+    if decision_store is not None:
+        from lcats.analysis.corpus import review
+
+        findings = review.apply_review_to_specials(findings, decision_store)
+
+    for result in findings:
         yield special_character_to_tsv_row(result)
 
 
@@ -340,6 +347,7 @@ def build_special_character_report(
     context: int,
     name_width: int,
     header: bool,
+    decision_store=None,
 ) -> str:
     """Return full TSV report for extracted special characters."""
     lines = []
@@ -353,6 +361,7 @@ def build_special_character_report(
             allowlist=allowlist,
             context=context,
             name_width=name_width,
+            decision_store=decision_store,
         )
     )
     return "\n".join(lines)

--- a/lcats/tests/analysis_tests/repairs_test.py
+++ b/lcats/tests/analysis_tests/repairs_test.py
@@ -5,6 +5,7 @@ import unittest
 from parameterized import parameterized
 
 from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import review
 from lcats.analysis.corpus import specials
 
 
@@ -257,6 +258,52 @@ class RepairsTest(unittest.TestCase):
         self.assertEqual("â€”", suggestion.original_text)
         self.assertEqual("—", suggestion.replacement_text)
         self.assertEqual("high", suggestion.confidence)
+
+    def test_suggest_repairs_for_text_applies_allowed_special_review_rules(self):
+        text = "Text â€” sample"
+        decision_store = review.ReviewDecisionStore(
+            allowed_special_cases=(
+                review.AllowedSpecialCase(
+                    classification="likely_repairable",
+                    evidence_contains="fragment=â€”",
+                ),
+            )
+        )
+
+        suggestions = repairs.suggest_repairs_for_text(
+            text,
+            decision_store=decision_store,
+        )
+
+        self.assertEqual([], suggestions)
+
+    def test_suggest_reviewed_repairs_for_text_groups_decision_states(self):
+        text = "Text â€” and â€¦ sample"
+        decision_store = review.ReviewDecisionStore(
+            repair_decisions=(
+                review.RepairReviewDecision(
+                    rule_id="mojibake-em-dash",
+                    original_text="â€”",
+                    replacement_text="—",
+                    decision=review.APPROVED,
+                ),
+                review.RepairReviewDecision(
+                    rule_id="mojibake-ellipsis",
+                    original_text="â€¦",
+                    replacement_text="…",
+                    decision=review.REJECTED,
+                ),
+            )
+        )
+
+        grouped = repairs.suggest_reviewed_repairs_for_text(
+            text,
+            decision_store=decision_store,
+        )
+
+        self.assertEqual(1, len(grouped.approved))
+        self.assertEqual(1, len(grouped.rejected))
+        self.assertEqual(0, len(grouped.unresolved))
 
 
 if __name__ == "__main__":

--- a/lcats/tests/analysis_tests/review_test.py
+++ b/lcats/tests/analysis_tests/review_test.py
@@ -1,0 +1,137 @@
+"""Unit tests for lcats.analysis.corpus.review."""
+
+import json
+import unittest
+
+from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import review
+from lcats.analysis.corpus import specials
+
+
+class ReviewTest(unittest.TestCase):
+    """Tests for human review decision models and helpers."""
+
+    def test_review_decision_store_round_trip_json(self):
+        decision_store = review.ReviewDecisionStore(
+            repair_decisions=(
+                review.RepairReviewDecision(
+                    rule_id="mojibake-right-single-quote",
+                    original_text="â€™",
+                    replacement_text="’",
+                    decision=review.APPROVED,
+                    rationale="Team-approved conversion",
+                ),
+            ),
+            allowed_special_cases=(
+                review.AllowedSpecialCase(
+                    character="√",
+                    codepoint="U+221A",
+                    classification="review_needed",
+                    evidence_contains="residual-review",
+                    rationale="Expected in formula corpus",
+                ),
+            ),
+        )
+
+        payload = decision_store.to_dict()
+        json.dumps(payload)
+        loaded = review.ReviewDecisionStore.from_dict(payload)
+
+        self.assertEqual(decision_store, loaded)
+
+    def test_apply_review_to_repairs_partitions_by_decision(self):
+        approved = repairs.RepairSuggestion(
+            rule_id="mojibake-right-single-quote",
+            start=0,
+            end=3,
+            original_text="â€™",
+            replacement_text="’",
+            finding_offset=0,
+            evidence="rule=mojibake-pattern; fragment=â€™",
+        )
+        rejected = repairs.RepairSuggestion(
+            rule_id="mojibake-ellipsis",
+            start=4,
+            end=7,
+            original_text="â€¦",
+            replacement_text="…",
+            finding_offset=4,
+            evidence="rule=mojibake-pattern; fragment=â€¦",
+        )
+        unresolved = repairs.RepairSuggestion(
+            rule_id="mojibake-en-dash",
+            start=8,
+            end=11,
+            original_text="â€“",
+            replacement_text="–",
+            finding_offset=8,
+            evidence="rule=mojibake-pattern; fragment=â€“",
+        )
+        decision_store = review.ReviewDecisionStore(
+            repair_decisions=(
+                review.RepairReviewDecision(
+                    rule_id=approved.rule_id,
+                    original_text=approved.original_text,
+                    replacement_text=approved.replacement_text,
+                    decision=review.APPROVED,
+                ),
+                review.RepairReviewDecision(
+                    rule_id=rejected.rule_id,
+                    original_text=rejected.original_text,
+                    replacement_text=rejected.replacement_text,
+                    decision=review.REJECTED,
+                ),
+            )
+        )
+
+        grouped = review.apply_review_to_repairs(
+            [approved, rejected, unresolved],
+            decision_store,
+        )
+
+        self.assertEqual((approved,), grouped.approved)
+        self.assertEqual((rejected,), grouped.rejected)
+        self.assertEqual((unresolved,), grouped.unresolved)
+
+    def test_apply_review_to_specials_suppresses_allowed_findings(self):
+        findings = [
+            specials.SpecialCharacter(
+                character="√",
+                codepoint="U+221A",
+                unicode_name="SQUARE ROOT",
+                occurrence_index=1,
+                offset=10,
+                context="Contains √ symbol",
+                classification="review_needed",
+                evidence="rule=residual-review; unicode_name=SQUARE ROOT",
+            ),
+            specials.SpecialCharacter(
+                character="©",
+                codepoint="U+00A9",
+                unicode_name="COPYRIGHT SIGN",
+                occurrence_index=1,
+                offset=15,
+                context="Contains © symbol",
+                classification="review_needed",
+                evidence="rule=residual-review; unicode_name=COPYRIGHT SIGN",
+            ),
+        ]
+        decision_store = review.ReviewDecisionStore(
+            allowed_special_cases=(
+                review.AllowedSpecialCase(
+                    character="√",
+                    classification="review_needed",
+                    evidence_contains="residual-review",
+                    rationale="Allowed for math excerpts",
+                ),
+            )
+        )
+
+        filtered = review.apply_review_to_specials(findings, decision_store)
+
+        self.assertEqual(1, len(filtered))
+        self.assertEqual("©", filtered[0].character)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/analysis_tests/specials_test.py
+++ b/lcats/tests/analysis_tests/specials_test.py
@@ -2,6 +2,7 @@
 
 import unittest
 
+from lcats.analysis.corpus import review
 from lcats.analysis.corpus import specials
 
 
@@ -131,6 +132,31 @@ class SpecialsTest(unittest.TestCase):
 
         self.assertEqual("review_needed", classification)
         self.assertIn("residual-review", evidence)
+
+    def test_build_special_character_report_applies_review_allow_rules(self):
+        decision_store = review.ReviewDecisionStore(
+            allowed_special_cases=(
+                review.AllowedSpecialCase(
+                    character="√",
+                    classification="review_needed",
+                    evidence_contains="residual-review",
+                ),
+            )
+        )
+
+        report = specials.build_special_character_report(
+            text="A √ and ©",
+            allow_smart=False,
+            excluded=set(),
+            allowlist=specials.AllowlistConfig(),
+            context=4,
+            name_width=0,
+            header=False,
+            decision_store=decision_store,
+        )
+
+        self.assertIn("©", report)
+        self.assertNotIn("√", report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a conservative, library-first model to represent human review decisions for Unicode / special-character findings and repair proposals so later tools can persist and consume reviewer intent. 

### Description
- Add a new review module `lcats.analysis.corpus.review` with dataclasses `RepairReviewDecision`, `AllowedSpecialCase`, `ReviewedRepairs`, and `ReviewDecisionStore`, plus constants `APPROVED`, `REJECTED`, `ALLOWED`, and `UNRESOLVED` and helpers to match/apply decisions. 
- Make review decisions serializable via `ReviewDecisionStore.to_dict()` / `from_dict()` to enable future persistence and config-driven workflows. 
- Integrate decision-aware behavior into existing corpus flows by adding optional `decision_store` parameters: `specials.iter_special_character_rows`, `specials.build_special_character_report`, `repairs.suggest_repairs`, and `repairs.suggest_repairs_for_text`; add `repairs.suggest_reviewed_repairs_for_text` to return partitioned (approved/rejected/unresolved) repair groups. 
- Export the `review` module from `lcats.analysis.corpus` public surface and add focused unit tests validating model, override semantics, and integration with the specials/repairs flows. 
- Keep behavior conservative: decisions only suppress or partition findings/suggestions in-memory and do not mutate corpora or write changes to disk. 

### Testing
- Ran formatting and linting with `scripts/format` and `scripts/lint` and fixed style issues as needed (both passed). 
- Ran the full unit test suite with `scripts/test`; all tests passed after adding new tests. 
- Added and ran focused tests: `tests/analysis_tests/review_test.py` (round-trip serialization, partitioning, suppression), extended `repairs_test.py` and `specials_test.py` to verify decision consumption and override semantics (all assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ae6d99308327952b78333d0607b2)