### PR TITLE
Add Phase 4D (Approved Application) planning and WI-APPLY-0005

### DIFF
--- a/lcats/project/focus/current_focus.md
+++ b/lcats/project/focus/current_focus.md
@@ -16,6 +16,7 @@ Build the repair and review pipeline.
 2. Dry-run-first workflows.
 3. Span-based transformations.
 4. Human review and override system.
+5. Deterministic application of approved repairs.
 
 ## Why This Is Current
 - Survey/classification and immediate correctness fixes are complete.

--- a/lcats/project/roadmap/roadmap.md
+++ b/lcats/project/roadmap/roadmap.md
@@ -24,7 +24,7 @@ status: active
 - Apply mojibake precedence fix in classification.
 - Tighten correctness interpretation to reduce false-safe classifications.
 
-## Phase 4 — Repair + Review Pipeline (**Active**)
+## Phase 4 — Repair + Review + Application Pipeline (**Active**)
 Focus: move from diagnosis to conservative correction.
 
 ### Phase 4A: Repair Engine
@@ -38,6 +38,12 @@ Focus: move from diagnosis to conservative correction.
 ### Phase 4C: Review Loop
 - Add human review/override checkpoints.
 - Record decision rationale for accepted/rejected changes.
+
+### Phase 4D: Approved Application
+- Apply reviewed and approved span operations to corpus text.
+- Ensure deterministic, non-destructive transformation workflow.
+- Produce transformed outputs separate from original source.
+- Validate that applied operations match reviewed decisions exactly.
 
 ## Phase 5 — Persistence / Corpus State (**Planned**)
 - Define persistent corpus state and operation history model.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -11,6 +11,7 @@ This directory tracks actionable execution units aligned to the current roadmap.
 - `WI-REPAIR-0001.md`
 - `WI-SPANOPS-0002.md`
 - `WI-REVIEW-0003.md`
+- `WI-APPLY-0005.md`
 
 ## Planned Items
 - `WI-PERSIST-0004.md`

--- a/lcats/project/work_items/WI-APPLY-0005.md
+++ b/lcats/project/work_items/WI-APPLY-0005.md
@@ -1,0 +1,26 @@
+---
+id: WI-APPLY-0005
+title: Apply approved repair operations safely and deterministically
+status: active
+priority: high
+owner: unassigned
+linked_focus: FOCUS-REPAIR-REVIEW
+---
+
+# Work Item: WI-APPLY-0005
+
+## Objective
+Implement a system to apply reviewed and approved span operations to corpus text safely and deterministically.
+
+## Scope
+- Accept only approved operations from the review system.
+- Apply operations in deterministic order.
+- Ensure no unintended mutations occur.
+- Produce transformed text outputs separate from original corpus.
+- Validate applied results match intended span operations.
+
+## Acceptance Criteria
+- Applying the same approved operations yields identical output.
+- No unreviewed changes are ever applied.
+- Output is reproducible and auditable.
+- Original corpus remains unchanged unless explicitly replaced via higher-level workflow.

--- a/lcats/project/work_items/WI-REVIEW-0003.md
+++ b/lcats/project/work_items/WI-REVIEW-0003.md
@@ -16,6 +16,8 @@ Implement a review loop that allows humans to approve, reject, or override propo
 - Define review decision states and required rationale.
 - Connect repair proposals and span ops to reviewable units.
 - Record reviewer decisions as auditable artifacts.
+- Ensure only approved operations are eligible for application.
+- Define interface between review outputs and application stage.
 
 ## Acceptance Criteria
 - Every proposed change has an explicit review outcome.

--- a/lcats/project/work_items/WI-SPANOPS-0002.md
+++ b/lcats/project/work_items/WI-SPANOPS-0002.md
@@ -16,6 +16,8 @@ Create span-based transformation primitives used by the repair engine.
 - Define span operation schema (start/end, replacement, reason).
 - Support composition of multiple operations per file.
 - Ensure operation ordering and conflict handling are explicit.
+- Support deterministic application of non-overlapping operations to text.
+- Define behavior for overlapping/conflicting operations.
 
 ## Acceptance Criteria
 - Span operations can represent planned repairs without ambiguity.


### PR DESCRIPTION
### Motivation
- Fill a missing pipeline step between human review (Phase 4C) and persistence (Phase 5) by explicitly defining how approved span operations are applied to text. 
- Ensure applications of approved repairs are deterministic, non-destructive, and auditable before any persistence decisions are introduced. 

### Description
- Rename Phase 4 in `project/roadmap/roadmap.md` to “Repair + Review + Application Pipeline” and add a new `Phase 4D: Approved Application` section describing deterministic, non-destructive application of approved span ops. 
- Add a new work item `project/work_items/WI-APPLY-0005.md` defining objective, scope, and acceptance criteria for safely applying approved repair operations. 
- Update `project/work_items/README.md` to list `WI-APPLY-0005.md` as an active item. 
- Clarify scopes in `project/work_items/WI-SPANOPS-0002.md` and `project/work_items/WI-REVIEW-0003.md` to require deterministic application behavior and an interface ensuring only approved operations are eligible for application. 
- Extend `project/focus/current_focus.md` to include deterministic application of approved repairs in the current focus scope. 

### Testing
- Ran `git diff --check` to validate no whitespace or patch-format issues and it completed without errors. 
- No unit tests or linters were run in this change set; full test and lint runs are expected in follow-up validation per project guidance.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e0fb7e5c83279ffbbc9d37b3fce2)