### PR TITLE
docs(project): emphasize Phase 4 approved-application bridge

### DIFF
--- a/lcats/project/roadmap/roadmap.md
+++ b/lcats/project/roadmap/roadmap.md
@@ -25,7 +25,8 @@ status: active
 - Tighten correctness interpretation to reduce false-safe classifications.
 
 ## Phase 4 — Repair + Review + Application Pipeline (**Active**)
-Focus: move from diagnosis to conservative correction.
+Focus: move from diagnosis to conservative correction and controlled
+application.
 
 ### Phase 4A: Repair Engine
 - Build deterministic, conservative repair planner/executor.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -3,7 +3,7 @@
 This directory tracks actionable execution units aligned to the current roadmap.
 
 ## Current State
-- Active work targets Phase 4 (repair + review pipeline).
+- Active work targets Phase 4 (repair + review + application pipeline).
 - Planned work includes Phase 5 persistence design.
 - Completed bootstrap and early correctness items are moved out of this directory and recorded in `project/memory/decision_log.md`.
 


### PR DESCRIPTION
### Motivation
- Make the transition from review decisions to deterministic application explicit in top-level project planning text to reflect the newly defined Phase 4D work item.

### Description
- Update `project/roadmap/roadmap.md` to expand Phase 4 focus wording to include controlled application after review.
- Update `project/work_items/README.md` to reflect that active work targets the repair + review + application pipeline.

### Testing
- This is a documentation-only change; no unit tests were modified or required.
- Validated the updated files by printing and inspecting their contents with repository tooling commands, which completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e32d62c88327a8e1b9493c7a08fc)