### PR TITLE
Implement WI-REPAIR-0001 conservative dry-run repair engine

### DIFF
--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -1,5 +1,7 @@
 """Conservative repair proposal helpers for special-character findings."""
 
+import json
+
 from dataclasses import dataclass
 from typing import Iterable, Optional, Sequence
 
@@ -44,6 +46,21 @@ class SpanRepairOperation:
     evidence: str
     rationale: str = ""
     confidence: str = "high"
+
+
+@dataclass(frozen=True)
+class RepairPlanEntry:
+    """One machine-serializable dry-run plan entry."""
+
+    start: int
+    end: int
+    original_text: str
+    replacement_text: str
+    rule_id: str
+    confidence: str
+    evidence: str
+    rationale: str
+    finding_offset: int
 
 
 DEFAULT_REPAIR_RULES = (
@@ -321,17 +338,64 @@ def build_dry_run_report(
     file_label: str = "",
 ) -> str:
     """Return a deterministic dry-run report for review/audit."""
+    plan_entries = build_dry_run_plan_entries(suggestions)
     lines = []
-    for suggestion in suggestions:
+    for entry in plan_entries:
         prefix = f"{file_label}:" if file_label else ""
         lines.append(
             (
-                f"{prefix}{suggestion.start}-{suggestion.end}\t"
-                f"{suggestion.rule_id}\t"
-                f"confidence={suggestion.confidence}\t"
-                f"before={suggestion.original_text}\t"
-                f"after={suggestion.replacement_text}\t"
-                f"reason={suggestion.rationale}"
+                f"{prefix}{entry.start}-{entry.end}\t"
+                f"{entry.rule_id}\t"
+                f"confidence={entry.confidence}\t"
+                f"before={entry.original_text}\t"
+                f"after={entry.replacement_text}\t"
+                f"reason={entry.rationale}"
             )
         )
+    return "\n".join(lines)
+
+
+def build_dry_run_plan_entries(
+    suggestions: Sequence[RepairSuggestion],
+) -> list[RepairPlanEntry]:
+    """Convert suggestions into deterministic plan entries for dry-run use."""
+    entries = [
+        RepairPlanEntry(
+            start=suggestion.start,
+            end=suggestion.end,
+            original_text=suggestion.original_text,
+            replacement_text=suggestion.replacement_text,
+            rule_id=suggestion.rule_id,
+            confidence=suggestion.confidence,
+            evidence=suggestion.evidence,
+            rationale=suggestion.rationale,
+            finding_offset=suggestion.finding_offset,
+        )
+        for suggestion in suggestions
+    ]
+    entries.sort(key=lambda entry: (entry.start, entry.end, entry.rule_id))
+    return entries
+
+
+def build_dry_run_jsonl_report(
+    suggestions: Sequence[RepairSuggestion],
+    *,
+    path: str = "",
+) -> str:
+    """Return deterministic JSONL report for machine parsing."""
+    lines = []
+    for entry in build_dry_run_plan_entries(suggestions):
+        payload = {
+            "path": path,
+            "start": entry.start,
+            "end": entry.end,
+            "original_text": entry.original_text,
+            "replacement_text": entry.replacement_text,
+            "rule_id": entry.rule_id,
+            "confidence": entry.confidence,
+            "evidence": entry.evidence,
+            "rationale": entry.rationale,
+            "finding_offset": entry.finding_offset,
+        }
+        lines.append(json.dumps(payload, ensure_ascii=False, sort_keys=True))
     return "\n".join(lines)

--- a/lcats/lcats/analysis/corpus/repairs_cli.py
+++ b/lcats/lcats/analysis/corpus/repairs_cli.py
@@ -19,6 +19,12 @@ def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
     )
     parser.add_argument("files", nargs="+")
     parser.add_argument("--header", action="store_true")
+    parser.add_argument(
+        "--format",
+        choices=["tsv", "jsonl"],
+        default="tsv",
+        help="Dry-run report format (human TSV or machine JSONL).",
+    )
     return parser
 
 
@@ -27,25 +33,34 @@ def run(argv=None, parsed_args=None) -> int:
     parser = build_parser()
     args = parsed_args if parsed_args is not None else parser.parse_args(argv)
 
-    if args.header:
+    if args.header and args.format == "tsv":
         print("path\tstart\tend\trule\tconfidence\tbefore\tafter\treason")
 
     for file_name in args.files:
         file_path = pathlib.Path(file_name)
         text = file_path.read_text(encoding="utf-8")
         suggestions = repairs.suggest_repairs_for_text(text)
-        for suggestion in suggestions:
+        if args.format == "jsonl":
+            report = repairs.build_dry_run_jsonl_report(
+                suggestions,
+                path=str(file_path),
+            )
+            if report:
+                print(report)
+            continue
+
+        for entry in repairs.build_dry_run_plan_entries(suggestions):
             print(
                 "\t".join(
                     [
                         str(file_path),
-                        str(suggestion.start),
-                        str(suggestion.end),
-                        suggestion.rule_id,
-                        suggestion.confidence,
-                        suggestion.original_text,
-                        suggestion.replacement_text,
-                        suggestion.rationale,
+                        str(entry.start),
+                        str(entry.end),
+                        entry.rule_id,
+                        entry.confidence,
+                        entry.original_text,
+                        entry.replacement_text,
+                        entry.rationale,
                     ]
                 )
             )

--- a/lcats/project/memory/decision_log.md
+++ b/lcats/project/memory/decision_log.md
@@ -1,5 +1,24 @@
 # Decision Log
 
+## 2026-04-21: WI-REPAIR-0001 conservative repair engine completed
+
+### Summary
+- Completed Phase 4A conservative repair engine work item with a deterministic,
+  dry-run-first proposal workflow.
+
+### Decisions
+- Keep repair planning in the new `lcats.analysis.corpus` tree.
+- Preserve conservative scope: only `likely_repairable` findings with explicit,
+  known repair rules produce proposals.
+- Add machine-parseable dry-run output (`jsonl`) alongside human-readable TSV
+  output for audit/review tooling.
+- Keep mutation non-default. No CLI apply path was introduced in this item.
+
+### Status
+- Accepted
+
+---
+
 ## 2026-04-20: Bootstrap decision
 
 ### Summary

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -8,10 +8,12 @@ This directory tracks actionable execution units aligned to the current roadmap.
 - Completed bootstrap and early correctness items are moved out of this directory and recorded in `project/memory/decision_log.md`.
 
 ## Active Items
-- `WI-REPAIR-0001.md`
 - `WI-SPANOPS-0002.md`
 - `WI-REVIEW-0003.md`
 - `WI-APPLY-0005.md`
 
 ## Planned Items
 - `WI-PERSIST-0004.md`
+
+## Completed Items
+- `WI-REPAIR-0001.md`

--- a/lcats/project/work_items/WI-REPAIR-0001.md
+++ b/lcats/project/work_items/WI-REPAIR-0001.md
@@ -1,7 +1,7 @@
 ---
 id: WI-REPAIR-0001
 title: Implement conservative repair engine
-status: active
+status: completed
 priority: high
 owner: unassigned
 linked_focus: FOCUS-REPAIR-REVIEW
@@ -21,3 +21,13 @@ Implement a deterministic repair engine that converts classification findings in
 - Repair plan is deterministic for identical input.
 - Dry-run output is human-readable and machine-parseable.
 - No corpus content is mutated unless explicitly approved through review flow.
+
+## Completion Notes
+- Implemented conservative repair proposal generation in
+  `lcats.analysis.corpus.repairs` with explicit rule mapping from
+  `likely_repairable` classification evidence fragments to high-confidence
+  replacements.
+- Added deterministic dry-run plan models and reporting helpers for both human
+  TSV inspection and machine-parseable JSONL output.
+- Preserved non-destructive-by-default behavior. Repair application helpers
+  remain library-level utilities and are not used by default CLI dry-run paths.

--- a/lcats/tests/analysis_tests/repairs_cli_test.py
+++ b/lcats/tests/analysis_tests/repairs_cli_test.py
@@ -1,6 +1,7 @@
 """Unit tests for lcats.analysis.corpus.repairs_cli."""
 
 import io
+import json
 import pathlib
 import tempfile
 import unittest
@@ -59,6 +60,22 @@ class RepairsCliTest(unittest.TestCase):
         self.assertIn("before=â€™", report)
         self.assertIn("after=’", report)
         self.assertIn("confidence=high", report)
+
+    def test_jsonl_output_is_machine_parseable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = pathlib.Path(tmpdir) / "sample.txt"
+            file_path.write_text("Example â€¦ token", encoding="utf-8")
+
+            output = io.StringIO()
+            with unittest.mock.patch("sys.stdout", output):
+                repairs_cli.run(["--format", "jsonl", str(file_path)])
+
+            lines = output.getvalue().strip().splitlines()
+            self.assertEqual(1, len(lines))
+            payload = json.loads(lines[0])
+            self.assertEqual(str(file_path), payload["path"])
+            self.assertEqual("â€¦", payload["original_text"])
+            self.assertEqual("…", payload["replacement_text"])
 
 
 if __name__ == "__main__":

--- a/lcats/tests/analysis_tests/repairs_test.py
+++ b/lcats/tests/analysis_tests/repairs_test.py
@@ -1,5 +1,6 @@
 """Unit tests for lcats.analysis.corpus.repairs."""
 
+import json
 import unittest
 
 from parameterized import parameterized
@@ -276,6 +277,59 @@ class RepairsTest(unittest.TestCase):
         )
 
         self.assertEqual([], suggestions)
+
+    def test_build_dry_run_plan_entries_preserves_rationale_and_location(self):
+        suggestions = [
+            repairs.RepairSuggestion(
+                rule_id="mojibake-ellipsis",
+                start=12,
+                end=15,
+                original_text="â€¦",
+                replacement_text="…",
+                finding_offset=13,
+                evidence="rule=mojibake-pattern; fragment=â€¦",
+                confidence="high",
+                rationale="Broken UTF-8 ellipsis sequence.",
+            )
+        ]
+
+        entries = repairs.build_dry_run_plan_entries(suggestions)
+
+        self.assertEqual(1, len(entries))
+        entry = entries[0]
+        self.assertEqual(12, entry.start)
+        self.assertEqual(15, entry.end)
+        self.assertEqual("â€¦", entry.original_text)
+        self.assertEqual("…", entry.replacement_text)
+        self.assertEqual("mojibake-ellipsis", entry.rule_id)
+        self.assertIn("fragment=â€¦", entry.evidence)
+        self.assertEqual("Broken UTF-8 ellipsis sequence.", entry.rationale)
+        self.assertEqual(13, entry.finding_offset)
+
+    def test_build_dry_run_jsonl_report_is_machine_parseable(self):
+        suggestions = [
+            repairs.RepairSuggestion(
+                rule_id="mojibake-em-dash",
+                start=5,
+                end=8,
+                original_text="â€”",
+                replacement_text="—",
+                finding_offset=6,
+                evidence="rule=mojibake-pattern; fragment=â€”",
+                confidence="high",
+                rationale="Broken UTF-8 em dash sequence.",
+            )
+        ]
+
+        report = repairs.build_dry_run_jsonl_report(suggestions, path="story.txt")
+
+        lines = report.splitlines()
+        self.assertEqual(1, len(lines))
+        payload = json.loads(lines[0])
+        self.assertEqual("story.txt", payload["path"])
+        self.assertEqual("â€”", payload["original_text"])
+        self.assertEqual("—", payload["replacement_text"])
+        self.assertEqual("mojibake-em-dash", payload["rule_id"])
 
     def test_suggest_reviewed_repairs_for_text_groups_decision_states(self):
         text = "Text â€” and â€¦ sample"


### PR DESCRIPTION
### Motivation
- Provide a deterministic, conservative repair planner that converts existing `likely_repairable` findings into auditable repair proposals without mutating corpus files by default.
- Surface rationale/evidence and stable location metadata so later review/approval stages can operate on complete, machine-parseable proposals.
- Offer both human-readable and machine-friendly dry-run outputs to support reviewer inspection and tool integration while preserving non-destructive defaults.

### Description
- Added a stable, serializable plan model `RepairPlanEntry` and the helper `build_dry_run_plan_entries(...)` in `lcats.analysis.corpus.repairs` to produce deterministic, sorted plan entries for suggestions.
- Implemented `build_dry_run_jsonl_report(...)` to emit machine-parseable JSONL, and updated `build_dry_run_report(...)` to render deterministic TSV lines from normalized plan entries (all in `lcats/lcats/analysis/corpus/repairs.py`).
- Kept repair generation conservative and deterministic by mapping only `likely_repairable` classification evidence fragments to `DEFAULT_REPAIR_RULES` and ignoring ambiguous or unsupported spans; existing library-level apply helpers remain available but are not invoked by default.
- Added minimal CLI support in `lcats/lcats/analysis/corpus/repairs_cli.py` with `--format` (`tsv` or `jsonl`) so dry-run inspection can produce either human TSV or machine JSONL without performing writes.
- Added unit tests that verify plan-entry preservation of rationale/location and that JSONL output is parseable, and updated project planning artifacts (`project/work_items/WI-REPAIR-0001.md`, `project/work_items/README.md`, and `project/memory/decision_log.md`) to record completion and decisions.

### Testing
- Ran formatting with `scripts/format` and linting with `scripts/lint` in `lcats/` and both completed successfully.
- Ran the full test suite with `scripts/test` in `lcats/` and all tests passed: 1156 tests ran and reported `OK`.
- New/updated unit tests exercised `build_dry_run_plan_entries(...)` and `build_dry_run_jsonl_report(...)` and the CLI `--format jsonl` path, and those tests passed as part of the suite.
- Verified that default dry-run CLI behavior remains non-destructive (tests assert files are unchanged after dry-run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6fb83f9d08327a99865e4c70ed728)