### PR TITLE
Implement WI-SPANOPS-0002: canonical span operation model

### DIFF
--- a/lcats/lcats/analysis/corpus/README.md
+++ b/lcats/lcats/analysis/corpus/README.md
@@ -77,14 +77,19 @@ Repair generation is conservative and rule-based:
 
 ### 3.3 Span operation model
 
-Proposed edits are represented as explicit operations:
+Proposed edits are represented as canonical, deterministic span operations:
 
-- `SpanRepairOperation` captures operation type, span, original text,
-  replacement text, rule id, evidence, and rationale.
-- Suggestions can be converted into operations via
-  `suggestions_to_span_operations(...)`.
-- `apply_span_operations(...)` applies operations deterministically and refuses
-  overlapping edits (returns original text unchanged if overlap is detected).
+- `span_ops.SpanOperation` captures operation identity, type, start/end offsets,
+  original text, replacement text, and provenance metadata.
+- `span_ops.SpanOperationProvenance` preserves rule id, source, evidence,
+  rationale, confidence, and finding offset for review traceability.
+- `span_ops.from_repair_suggestions(...)` and
+  `repairs.suggestions_to_canonical_span_operations(...)` provide deterministic
+  conversion from repair proposals into canonical operations.
+- `span_ops.validate_operation_set(...)` enforces valid ranges, explicit
+  operation semantics, deterministic ordering, and non-overlapping spans.
+- `span_ops.serialize_operations(...)` / `deserialize_operations(...)` provide
+  stable JSON interchange for downstream review and application stages.
 
 ### 3.4 Review / override system
 
@@ -119,8 +124,8 @@ The current end-to-end flow is:
      unique spans become `RepairSuggestion` records.
 
 5. **Span operations**
-   - Suggestions can be translated into explicit replace operations and
-     optionally applied in deterministic order.
+   - Suggestions are translated into canonical span operations for later review
+     and application.
 
 6. **Human review**
    - Review decisions can suppress expected findings and group repair proposals
@@ -142,8 +147,8 @@ Implemented today:
 - Conservative mojibake repair-rule mapping for known broken punctuation
   sequences.
 - Repair suggestions with stable span references and rationale metadata.
-- Explicit span operation conversion and deterministic apply semantics.
-- Overlap-safe operation handling (no partial/unsafe application).
+- Canonical span operation conversion with deterministic ordering semantics.
+- Span-set validation with explicit overlap and structural checks.
 - Human review decision model for repairs and allowed special cases.
 - Decision-aware suppression and grouped reviewed repair outputs.
 - JSON-serializable review decision payload support (`to_dict`/`from_dict`).

--- a/lcats/lcats/analysis/corpus/__init__.py
+++ b/lcats/lcats/analysis/corpus/__init__.py
@@ -11,6 +11,7 @@ from lcats.analysis.corpus import review
 from lcats.analysis.corpus import qa
 from lcats.analysis.corpus import specials
 from lcats.analysis.corpus import specials_cli
+from lcats.analysis.corpus import span_ops
 from lcats.analysis.corpus import stats
 
 __all__ = [
@@ -25,5 +26,6 @@ __all__ = [
     "qa",
     "specials",
     "specials_cli",
+    "span_ops",
     "stats",
 ]

--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable, Optional, Sequence
 
 from lcats.analysis.corpus import specials
+from lcats.analysis.corpus import span_ops
 
 
 @dataclass(frozen=True)
@@ -229,6 +230,19 @@ def suggestions_to_span_operations(
         key=lambda operation: (operation.start, operation.end, operation.rule_id)
     )
     return operations
+
+
+def suggestions_to_canonical_span_operations(
+    suggestions: Sequence[RepairSuggestion],
+) -> list[span_ops.SpanOperation]:
+    """Convert repair suggestions to canonical span operations.
+
+    This conversion is representational only and does not apply edits.
+    """
+    return span_ops.from_repair_suggestions(
+        suggestions,
+        source="repair_suggestion",
+    )
 
 
 def _has_overlapping_spans(operations: Sequence[SpanRepairOperation]) -> bool:

--- a/lcats/lcats/analysis/corpus/span_ops.py
+++ b/lcats/lcats/analysis/corpus/span_ops.py
@@ -1,0 +1,225 @@
+"""Canonical span operation model for deterministic repair workflows."""
+
+import json
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+
+REPLACE_SPAN = "replace_span"
+REMOVE_SPAN = "remove_span"
+INSERT_SPAN = "insert_span"
+
+_OPERATION_ORDER = {
+    REMOVE_SPAN: 0,
+    REPLACE_SPAN: 1,
+    INSERT_SPAN: 2,
+}
+
+
+@dataclass(frozen=True)
+class SpanOperationProvenance:
+    """Traceability metadata linking span operations to repair planning."""
+
+    rule_id: str
+    source: str
+    finding_offset: int
+    evidence: str
+    rationale: str = ""
+    confidence: str = "high"
+
+    def to_dict(self) -> dict[str, str | int]:
+        """Return a stable, JSON-serializable provenance payload."""
+        return {
+            "rule_id": self.rule_id,
+            "source": self.source,
+            "finding_offset": self.finding_offset,
+            "evidence": self.evidence,
+            "rationale": self.rationale,
+            "confidence": self.confidence,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "SpanOperationProvenance":
+        """Build provenance from a serialized mapping."""
+        return cls(
+            rule_id=str(payload.get("rule_id", "")),
+            source=str(payload.get("source", "")),
+            finding_offset=int(payload.get("finding_offset", 0)),
+            evidence=str(payload.get("evidence", "")),
+            rationale=str(payload.get("rationale", "")),
+            confidence=str(payload.get("confidence", "high")),
+        )
+
+
+@dataclass(frozen=True)
+class SpanOperation:
+    """One canonical span operation over character offsets."""
+
+    operation_id: str
+    operation_type: str
+    start: int
+    end: int
+    replacement_text: str
+    original_text: str
+    provenance: SpanOperationProvenance
+
+    def to_dict(self) -> dict[str, object]:
+        """Return stable, JSON-serializable operation payload."""
+        return {
+            "operation_id": self.operation_id,
+            "operation_type": self.operation_type,
+            "start": self.start,
+            "end": self.end,
+            "replacement_text": self.replacement_text,
+            "original_text": self.original_text,
+            "provenance": self.provenance.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "SpanOperation":
+        """Build one operation from a serialized mapping."""
+        return cls(
+            operation_id=str(payload.get("operation_id", "")),
+            operation_type=str(payload.get("operation_type", REPLACE_SPAN)),
+            start=int(payload.get("start", 0)),
+            end=int(payload.get("end", 0)),
+            replacement_text=str(payload.get("replacement_text", "")),
+            original_text=str(payload.get("original_text", "")),
+            provenance=SpanOperationProvenance.from_dict(payload.get("provenance", {})),
+        )
+
+
+def operation_sort_key(operation: SpanOperation) -> tuple[object, ...]:
+    """Return deterministic ordering key for span operations."""
+    return (
+        operation.start,
+        operation.end,
+        _OPERATION_ORDER.get(operation.operation_type, 99),
+        operation.replacement_text,
+        operation.provenance.rule_id,
+        operation.provenance.finding_offset,
+        operation.operation_id,
+    )
+
+
+def sort_operations(operations: Iterable[SpanOperation]) -> list[SpanOperation]:
+    """Return deterministically sorted operations."""
+    return sorted(operations, key=operation_sort_key)
+
+
+def validate_operation(operation: SpanOperation) -> None:
+    """Fail fast when one operation is internally inconsistent."""
+    if operation.start < 0:
+        raise ValueError("start must be non-negative")
+    if operation.end < operation.start:
+        raise ValueError("end must be greater than or equal to start")
+    if operation.operation_type not in _OPERATION_ORDER:
+        raise ValueError("unsupported operation_type")
+
+    if operation.operation_type == INSERT_SPAN and operation.start != operation.end:
+        raise ValueError("insert_span requires start == end")
+    if operation.operation_type in (REMOVE_SPAN, REPLACE_SPAN):
+        if operation.start == operation.end:
+            raise ValueError("remove_span and replace_span require non-empty spans")
+
+    if operation.operation_type == REMOVE_SPAN and operation.replacement_text != "":
+        raise ValueError("remove_span replacement_text must be empty")
+    if operation.operation_type == INSERT_SPAN and operation.original_text != "":
+        raise ValueError("insert_span original_text must be empty")
+
+
+def validate_operation_set(operations: Sequence[SpanOperation]) -> None:
+    """Fail fast when an operation set is invalid or ambiguous."""
+    ordered = sort_operations(operations)
+    seen_ids: set[str] = set()
+    previous: SpanOperation | None = None
+
+    for operation in ordered:
+        validate_operation(operation)
+        if operation.operation_id in seen_ids:
+            raise ValueError("duplicate operation_id")
+        seen_ids.add(operation.operation_id)
+
+        if previous is None:
+            previous = operation
+            continue
+
+        if previous.end > operation.start:
+            raise ValueError("overlapping spans are not allowed")
+        if (
+            previous.operation_type == INSERT_SPAN
+            and operation.operation_type == INSERT_SPAN
+            and previous.start == operation.start
+        ):
+            raise ValueError("multiple insert_span operations at the same index")
+
+        previous = operation
+
+
+def serialize_operations(operations: Sequence[SpanOperation]) -> str:
+    """Serialize a validated canonical operation set to stable JSON."""
+    validate_operation_set(operations)
+    payload = [operation.to_dict() for operation in sort_operations(operations)]
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2)
+
+
+def deserialize_operations(payload: str) -> list[SpanOperation]:
+    """Deserialize and validate canonical operations from JSON."""
+    loaded = json.loads(payload)
+    operations = [SpanOperation.from_dict(item) for item in loaded]
+    validate_operation_set(operations)
+    return sort_operations(operations)
+
+
+def from_repair_suggestions(
+    suggestions: Sequence[object],
+    *,
+    source: str = "repair_proposal",
+) -> list[SpanOperation]:
+    """Convert repair suggestions into canonical span operations.
+
+    Args:
+        suggestions: Sequence of repair suggestion objects with required fields.
+        source: Provenance source label.
+
+    Returns:
+        Deterministically ordered canonical span operations.
+    """
+    sortable = sorted(
+        suggestions,
+        key=lambda suggestion: (
+            suggestion.start,
+            suggestion.end,
+            suggestion.rule_id,
+            suggestion.replacement_text,
+            suggestion.original_text,
+            suggestion.finding_offset,
+            suggestion.evidence,
+        ),
+    )
+
+    operations: list[SpanOperation] = []
+    for index, suggestion in enumerate(sortable):
+        operation_id = f"spanop-{index:06d}-{suggestion.rule_id}"
+        operations.append(
+            SpanOperation(
+                operation_id=operation_id,
+                operation_type=REPLACE_SPAN,
+                start=suggestion.start,
+                end=suggestion.end,
+                replacement_text=suggestion.replacement_text,
+                original_text=suggestion.original_text,
+                provenance=SpanOperationProvenance(
+                    rule_id=suggestion.rule_id,
+                    source=source,
+                    finding_offset=suggestion.finding_offset,
+                    evidence=suggestion.evidence,
+                    rationale=suggestion.rationale,
+                    confidence=suggestion.confidence,
+                ),
+            )
+        )
+
+    validate_operation_set(operations)
+    return sort_operations(operations)

--- a/lcats/tests/analysis_tests/span_ops_test.py
+++ b/lcats/tests/analysis_tests/span_ops_test.py
@@ -1,0 +1,180 @@
+"""Unit tests for canonical span operation models."""
+
+import json
+import unittest
+
+from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import span_ops
+
+
+class SpanOpsTest(unittest.TestCase):
+    """Tests for deterministic canonical span operations."""
+
+    def test_serialize_deserialize_round_trip(self):
+        operation = span_ops.SpanOperation(
+            operation_id="spanop-000000-demo",
+            operation_type=span_ops.REPLACE_SPAN,
+            start=2,
+            end=5,
+            replacement_text="’",
+            original_text="â€™",
+            provenance=span_ops.SpanOperationProvenance(
+                rule_id="mojibake-right-single-quote",
+                source="repair_suggestion",
+                finding_offset=3,
+                evidence="rule=mojibake-pattern; fragment=â€™",
+                rationale="Broken UTF-8 right single quote sequence.",
+                confidence="high",
+            ),
+        )
+
+        payload = span_ops.serialize_operations([operation])
+        loaded = span_ops.deserialize_operations(payload)
+
+        self.assertEqual([operation], loaded)
+        json.loads(payload)
+
+    def test_validate_operation_set_rejects_invalid_spans(self):
+        operation = span_ops.SpanOperation(
+            operation_id="invalid",
+            operation_type=span_ops.REPLACE_SPAN,
+            start=8,
+            end=3,
+            replacement_text="x",
+            original_text="y",
+            provenance=span_ops.SpanOperationProvenance(
+                rule_id="invalid",
+                source="test",
+                finding_offset=0,
+                evidence="e",
+            ),
+        )
+
+        with self.assertRaises(ValueError):
+            span_ops.validate_operation_set([operation])
+
+    def test_validate_operation_set_rejects_overlapping_spans(self):
+        operations = [
+            span_ops.SpanOperation(
+                operation_id="a",
+                operation_type=span_ops.REPLACE_SPAN,
+                start=1,
+                end=4,
+                replacement_text="A",
+                original_text="bcd",
+                provenance=span_ops.SpanOperationProvenance(
+                    rule_id="a",
+                    source="test",
+                    finding_offset=1,
+                    evidence="a",
+                ),
+            ),
+            span_ops.SpanOperation(
+                operation_id="b",
+                operation_type=span_ops.REPLACE_SPAN,
+                start=3,
+                end=5,
+                replacement_text="B",
+                original_text="de",
+                provenance=span_ops.SpanOperationProvenance(
+                    rule_id="b",
+                    source="test",
+                    finding_offset=3,
+                    evidence="b",
+                ),
+            ),
+        ]
+
+        with self.assertRaises(ValueError):
+            span_ops.validate_operation_set(operations)
+
+    def test_from_repair_suggestions_is_deterministic(self):
+        first = repairs.RepairSuggestion(
+            rule_id="rule-b",
+            start=6,
+            end=9,
+            original_text="â€¦",
+            replacement_text="…",
+            finding_offset=7,
+            evidence="rule=mojibake-pattern; fragment=â€¦",
+            rationale="ellipsis",
+        )
+        second = repairs.RepairSuggestion(
+            rule_id="rule-a",
+            start=0,
+            end=3,
+            original_text="â€™",
+            replacement_text="’",
+            finding_offset=0,
+            evidence="rule=mojibake-pattern; fragment=â€™",
+            rationale="quote",
+        )
+
+        run_one = span_ops.from_repair_suggestions([first, second])
+        run_two = span_ops.from_repair_suggestions([second, first])
+
+        self.assertEqual(run_one, run_two)
+        self.assertEqual(
+            ["spanop-000000-rule-a", "spanop-000001-rule-b"],
+            [operation.operation_id for operation in run_one],
+        )
+
+    def test_ordering_rules_are_stable(self):
+        replace = span_ops.SpanOperation(
+            operation_id="replace",
+            operation_type=span_ops.REPLACE_SPAN,
+            start=2,
+            end=4,
+            replacement_text="X",
+            original_text="ab",
+            provenance=span_ops.SpanOperationProvenance(
+                rule_id="replace",
+                source="test",
+                finding_offset=2,
+                evidence="replace",
+            ),
+        )
+        remove = span_ops.SpanOperation(
+            operation_id="remove",
+            operation_type=span_ops.REMOVE_SPAN,
+            start=2,
+            end=4,
+            replacement_text="",
+            original_text="ab",
+            provenance=span_ops.SpanOperationProvenance(
+                rule_id="remove",
+                source="test",
+                finding_offset=2,
+                evidence="remove",
+            ),
+        )
+
+        ordered = span_ops.sort_operations([replace, remove])
+
+        self.assertEqual(["remove", "replace"], [op.operation_id for op in ordered])
+
+    def test_repairs_bridge_to_canonical_operations_preserves_provenance(self):
+        suggestion = repairs.RepairSuggestion(
+            rule_id="mojibake-right-single-quote",
+            start=1,
+            end=4,
+            original_text="â€™",
+            replacement_text="’",
+            finding_offset=2,
+            evidence="rule=mojibake-pattern; fragment=â€™",
+            rationale="Broken UTF-8 right single quote sequence.",
+            confidence="high",
+        )
+
+        operations = repairs.suggestions_to_canonical_span_operations([suggestion])
+
+        self.assertEqual(1, len(operations))
+        operation = operations[0]
+        self.assertEqual(span_ops.REPLACE_SPAN, operation.operation_type)
+        self.assertEqual("mojibake-right-single-quote", operation.provenance.rule_id)
+        self.assertEqual(2, operation.provenance.finding_offset)
+        self.assertIn("fragment=â€™", operation.provenance.evidence)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a canonical, deterministic, and auditable representation for planned text edits that bridges repair proposals to later review and application stages.
- Ensure repair proposals can be converted to a stable, serializable operation set without mutating corpus text.
- Make ordering, provenance, and validation explicit so downstream review/apply stages have a single authoritative input model.

### Description

- Add `lcats.analysis.corpus.span_ops` implementing `SpanOperation` and `SpanOperationProvenance` dataclasses, operation types (`replace_span`, `remove_span`, `insert_span`), deterministic ordering, validation, and stable JSON `serialize_operations`/`deserialize_operations` APIs.
- Implement `from_repair_suggestions(...)` to deterministically convert repair suggestions into canonical span operations while preserving provenance (`rule_id`, `evidence`, `rationale`, `confidence`, `finding_offset`) and stable `operation_id`s.
- Add a bridge helper `repairs.suggestions_to_canonical_span_operations(...)` that calls `span_ops.from_repair_suggestions(...)` (representational only; does not apply edits).
- Export `span_ops` from `lcats.analysis.corpus`, update `lcats/analysis/corpus/README.md` to document the canonical span-op stage, and add focused unit tests in `tests/analysis_tests/span_ops_test.py` covering serialization, validation, determinism, ordering, and provenance preservation.

### Testing

- Ran formatting with `scripts/format` and linting with `scripts/lint`, both completed successfully.
- Ran the full test suite with `scripts/test` which executed `python -m unittest discover -s tests -p "*_test.py"` and returned `OK` (1162 tests ran).
- New unit tests (`tests/analysis_tests/span_ops_test.py`) passed as part of the full test run validating round-trip serialization, invalid-span rejection, overlap detection, deterministic conversion, ordering rules, and provenance preservation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e70f440d908327a13d405c41bdd602)