### PR TITLE
Implement `meta register` CLI slice and workspace project registry

### DIFF
--- a/lcats/README.md
+++ b/lcats/README.md
@@ -30,6 +30,9 @@ scripts/test
 scripts/clean && scripts/build && scripts/develop
 lcats info
 lcats gather
+
+# Register a repository in the workspace meta registry
+lcats meta register <repo_locator>
 ```
 Publishing this package to PyPI is not yet supported because we don't yet have extensive enough tests.
 

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -1,12 +1,14 @@
 """Command-line interface for the Literary Captain's Advisory Tool System (LCATS)."""
 
 import argparse
+import pathlib
 import sys
 
 from lcats.analysis.corpus import cli as corpus_cli
 from lcats.analysis.corpus import repairs_cli
 import lcats.gatherers.main
 import lcats.inspect
+from lcats import meta_registry
 
 
 TOP_LEVEL_DESCRIPTION = (
@@ -45,6 +47,22 @@ def _handle_stats(args):
 
 def _handle_repair_specials(args):
     return "", repairs_cli.run(parsed_args=args)
+
+
+def _handle_meta_register(args):
+    try:
+        record = meta_registry.register_project(
+            workspace_root=pathlib.Path.cwd(),
+            repo_locator=args.repo_locator,
+            force=args.force,
+        )
+    except ValueError as error:
+        return str(error), 1
+
+    return (
+        f"Registered project {record['id']} as projects/{record['directory_name']}.toml",
+        0,
+    )
 
 
 def _handle_index(_args):
@@ -181,6 +199,26 @@ def build_parser() -> argparse.ArgumentParser:
     )
     repair_specials_parser.set_defaults(handler=_handle_repair_specials)
     command_parsers["repair-specials"] = repair_specials_parser
+
+    meta_parser = subparsers.add_parser(
+        "meta",
+        help="Manage LRH workspace project metadata records.",
+        description="Manage LRH workspace project metadata records.",
+    )
+    meta_subparsers = meta_parser.add_subparsers(dest="meta_command")
+
+    meta_register_parser = meta_subparsers.add_parser(
+        "register",
+        help="Register a repository locator in the local workspace registry.",
+    )
+    meta_register_parser.add_argument("repo_locator")
+    meta_register_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow duplicate repo_locator entries.",
+    )
+    meta_register_parser.set_defaults(handler=_handle_meta_register)
+    command_parsers["meta"] = meta_parser
 
     index_parser = subparsers.add_parser(
         "index",

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -273,6 +273,8 @@ def dispatch(command, args):
         parsed = parser.parse_args(argv)
     handler = getattr(parsed, "handler", None)
     if handler is None:
+        if command in parser.command_parsers:
+            return parser.command_parsers[command].format_help(), 1
         return parser.format_help(), 1
     return handler(parsed)
 
@@ -292,7 +294,15 @@ def main(argv=None):
     else:
         parsed = parser.parse_args(argv)
 
-    result, status = parsed.handler(parsed)
+    handler = getattr(parsed, "handler", None)
+    if handler is None:
+        if argv and argv[0] in parser.command_parsers:
+            print(parser.command_parsers[argv[0]].format_help())
+        else:
+            print(parser.format_help())
+        sys.exit(1)
+
+    result, status = handler(parsed)
     if result:
         print(result)
     sys.exit(status)

--- a/lcats/lcats/meta_registry.py
+++ b/lcats/lcats/meta_registry.py
@@ -1,0 +1,142 @@
+"""Workspace project registry helpers for the meta register CLI slice."""
+
+import datetime
+import pathlib
+import re
+from typing import Any
+from urllib import parse
+
+
+PROJECTS_DIR_NAME = "projects"
+PROJECT_DIR_DEFAULT = "project"
+
+
+def _normalise_slug(value: str) -> str:
+    """Return a lowercase slug suitable for registry directory naming."""
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "project"
+
+
+def infer_names(repo_locator: str) -> tuple[str, str]:
+    """Infer display and short names from an arbitrary repository locator."""
+    parsed = parse.urlparse(repo_locator)
+    candidate = parsed.path or repo_locator
+    candidate = candidate.rstrip("/")
+    base = pathlib.Path(candidate).name or "project"
+    base = re.sub(r"\.git$", "", base)
+    short_name = _normalise_slug(base)
+    display_name = " ".join(part.capitalize() for part in short_name.split("-"))
+    return display_name, short_name
+
+
+def detect_setup_state(
+    repo_locator: str, project_dir: str = PROJECT_DIR_DEFAULT
+) -> str:
+    """Detect whether a local repo appears to contain an LRH project directory."""
+    maybe_local = pathlib.Path(repo_locator)
+    if maybe_local.exists() and maybe_local.is_dir():
+        if (maybe_local / project_dir).exists():
+            return "lrh_project_present"
+    return "not_set_up"
+
+
+def _extract_value(line: str) -> str | None:
+    match = re.match(r'^\s*([a-z_]+)\s*=\s*"([^"]*)"\s*$', line.strip())
+    if not match:
+        return None
+    return match.group(2)
+
+
+def _read_record(path: pathlib.Path) -> dict[str, str]:
+    record: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip().startswith("id ="):
+            value = _extract_value(line)
+            if value is not None:
+                record["id"] = value
+        if line.strip().startswith("repo_locator ="):
+            value = _extract_value(line)
+            if value is not None:
+                record["repo_locator"] = value
+    return record
+
+
+def _existing_records(projects_dir: pathlib.Path) -> list[dict[str, Any]]:
+    records = []
+    if not projects_dir.exists():
+        return records
+    for path in sorted(projects_dir.glob("*.toml")):
+        data = _read_record(path)
+        data["path"] = path
+        records.append(data)
+    return records
+
+
+def _next_project_id(records: list[dict[str, Any]]) -> str:
+    today = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d")
+    last_number = 0
+    for record in records:
+        project_id = record.get("id", "")
+        match = re.match(r"^proj-(\d{8})-(\d{3})$", project_id)
+        if match and match.group(1) == today:
+            last_number = max(last_number, int(match.group(2)))
+    next_number = last_number + 1
+    return f"proj-{today}-{next_number:03d}"
+
+
+def _ensure_unique_filename(projects_dir: pathlib.Path, directory_name: str) -> str:
+    candidate = directory_name
+    counter = 1
+    while (projects_dir / f"{candidate}.toml").exists():
+        counter += 1
+        candidate = f"{directory_name}-{counter}"
+    return candidate
+
+
+def register_project(
+    workspace_root: pathlib.Path,
+    repo_locator: str,
+    force: bool = False,
+    project_dir: str = PROJECT_DIR_DEFAULT,
+) -> dict[str, str]:
+    """Create and persist a workspace registry entry for a project."""
+    projects_dir = workspace_root / PROJECTS_DIR_NAME
+    projects_dir.mkdir(parents=True, exist_ok=True)
+    records = _existing_records(projects_dir)
+
+    for record in records:
+        if record.get("repo_locator") == repo_locator and not force:
+            raise ValueError(f"Project already registered for locator: {repo_locator}")
+
+    display_name, short_name = infer_names(repo_locator)
+    setup_state = detect_setup_state(repo_locator, project_dir=project_dir)
+    project_id = _next_project_id(records)
+    directory_name = _ensure_unique_filename(projects_dir, short_name)
+
+    record = {
+        "id": project_id,
+        "display_name": display_name,
+        "short_name": short_name,
+        "status": "active",
+        "setup_state": setup_state,
+        "repo_locator": repo_locator,
+        "project_dir": project_dir,
+        "directory_name": directory_name,
+    }
+
+    text = (
+        "[project]\n"
+        f"id = \"{record['id']}\"\n"
+        f"display_name = \"{record['display_name']}\"\n"
+        f"short_name = \"{record['short_name']}\"\n"
+        f"status = \"{record['status']}\"\n"
+        f"setup_state = \"{record['setup_state']}\"\n\n"
+        "[identity]\n"
+        f"repo_locator = \"{record['repo_locator']}\"\n"
+        f"project_dir = \"{record['project_dir']}\"\n\n"
+        "[registry]\n"
+        f"directory_name = \"{record['directory_name']}\"\n"
+    )
+
+    (projects_dir / f"{directory_name}.toml").write_text(text, encoding="utf-8")
+    return record

--- a/lcats/lcats/meta_registry.py
+++ b/lcats/lcats/meta_registry.py
@@ -11,6 +11,20 @@ PROJECTS_DIR_NAME = "projects"
 PROJECT_DIR_DEFAULT = "project"
 
 
+def _toml_string(value: str) -> str:
+    """Return a TOML basic string literal for the supplied value."""
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\b", "\\b")
+        .replace("\t", "\\t")
+        .replace("\n", "\\n")
+        .replace("\f", "\\f")
+        .replace("\r", "\\r")
+    )
+    return f'"{escaped}"'
+
+
 def _normalise_slug(value: str) -> str:
     """Return a lowercase slug suitable for registry directory naming."""
     slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
@@ -126,16 +140,16 @@ def register_project(
 
     text = (
         "[project]\n"
-        f"id = \"{record['id']}\"\n"
-        f"display_name = \"{record['display_name']}\"\n"
-        f"short_name = \"{record['short_name']}\"\n"
-        f"status = \"{record['status']}\"\n"
-        f"setup_state = \"{record['setup_state']}\"\n\n"
+        f"id = {_toml_string(record['id'])}\n"
+        f"display_name = {_toml_string(record['display_name'])}\n"
+        f"short_name = {_toml_string(record['short_name'])}\n"
+        f"status = {_toml_string(record['status'])}\n"
+        f"setup_state = {_toml_string(record['setup_state'])}\n\n"
         "[identity]\n"
-        f"repo_locator = \"{record['repo_locator']}\"\n"
-        f"project_dir = \"{record['project_dir']}\"\n\n"
+        f"repo_locator = {_toml_string(record['repo_locator'])}\n"
+        f"project_dir = {_toml_string(record['project_dir'])}\n\n"
         "[registry]\n"
-        f"directory_name = \"{record['directory_name']}\"\n"
+        f"directory_name = {_toml_string(record['directory_name'])}\n"
     )
 
     (projects_dir / f"{directory_name}.toml").write_text(text, encoding="utf-8")

--- a/lcats/project/roadmap/roadmap.md
+++ b/lcats/project/roadmap/roadmap.md
@@ -49,6 +49,7 @@ application.
 ## Phase 5 — Persistence / Corpus State (**Planned**)
 - Define persistent corpus state and operation history model.
 - Support replay/audit across runs and contributors.
+- Deliver initial workspace meta registry slice (`meta register`) as an entry point into persistent project identity.
 
 ## Phase 6 — Narrative Structure + Reasoning (**Future**)
 - Introduce structured narrative representations.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -11,6 +11,7 @@ This directory tracks actionable execution units aligned to the current roadmap.
 - `WI-SPANOPS-0002.md`
 - `WI-REVIEW-0003.md`
 - `WI-APPLY-0005.md`
+- `WI-META-0006.md`
 
 ## Planned Items
 - `WI-PERSIST-0004.md`

--- a/lcats/project/work_items/WI-META-0006.md
+++ b/lcats/project/work_items/WI-META-0006.md
@@ -1,0 +1,28 @@
+---
+id: WI-META-0006
+title: Implement Meta CLI register slice for workspace project registry
+status: active
+priority: high
+owner: unassigned
+linked_focus: FOCUS-REPAIR-REVIEW
+---
+
+# Work Item: WI-META-0006
+
+## Objective
+Implement the initial Meta CLI registration slice to register repositories in a workspace-local project registry.
+
+## Scope
+- Add `meta register <repo_locator>` CLI flow.
+- Create stable project registry records under `projects/`.
+- Detect setup state using local `project/` presence.
+- Block duplicates unless explicitly forced.
+
+## Acceptance Criteria
+- Register command writes a TOML project record with project, identity, and registry sections.
+- Project IDs are stable and unique per workspace registry.
+- Duplicate registration is rejected unless `--force` is provided.
+- Tests cover success path, duplicate handling, and setup-state detection.
+
+## Notes
+- This item intentionally excludes `meta list`, orchestration, and UI work.

--- a/lcats/tests/cli_test.py
+++ b/lcats/tests/cli_test.py
@@ -121,6 +121,14 @@ class TestCli(unittest.TestCase):
         self.assertEqual(expected_code, cm.exception.code)
         self.assertIn("usage: lcats", captured.stdout.getvalue())
 
+    def test_meta_requires_subcommand_without_crashing(self):
+        """Running lcats meta should show meta help and exit with code 1."""
+        with capture.capture_output() as captured:
+            with self.assertRaises(SystemExit) as cm:
+                cli.main(["meta"])
+        self.assertEqual(1, cm.exception.code)
+        self.assertIn("usage: lcats meta", captured.stdout.getvalue())
+
     @parameterized.parameterized.expand(
         [
             (["survey", "--help"], "usage: lcats survey"),

--- a/lcats/tests/cli_test.py
+++ b/lcats/tests/cli_test.py
@@ -72,6 +72,21 @@ class TestCli(unittest.TestCase):
         self.assertEqual(0, actual_status)
         mock_run.assert_called_once()
 
+    @mock.patch("lcats.meta_registry.register_project")
+    def test_dispatch_meta_register(self, mock_register_project):
+        """Ensure meta register delegates to meta_registry."""
+        mock_register_project.return_value = {
+            "id": "proj-20260422-001",
+            "directory_name": "example",
+        }
+
+        actual_message, actual_status = cli.dispatch(
+            "meta", ["register", "https://example.com/repo.git"]
+        )
+        self.assertEqual(0, actual_status)
+        self.assertIn("proj-20260422-001", actual_message)
+        mock_register_project.assert_called_once()
+
     @parameterized.parameterized.expand(
         [
             ("index", "Indexing data files is not yet implemented."),
@@ -111,9 +126,11 @@ class TestCli(unittest.TestCase):
             (["survey", "--help"], "usage: lcats survey"),
             (["stats", "--help"], "usage: lcats stats"),
             (["repair-specials", "--help"], "usage: lcats repair-specials"),
+            (["meta", "register", "--help"], "usage: lcats meta register"),
             (["help", "survey"], "usage: lcats survey"),
             (["help", "stats"], "usage: lcats stats"),
             (["help", "repair-specials"], "usage: lcats repair-specials"),
+            (["help", "meta"], "usage: lcats meta"),
         ]
     )
     def test_command_help(self, argv, expected_usage):

--- a/lcats/tests/meta_registry_test.py
+++ b/lcats/tests/meta_registry_test.py
@@ -5,6 +5,11 @@ import pathlib
 import tempfile
 import unittest
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
+    import tomli as tomllib
+
 from lcats import meta_registry
 
 
@@ -67,6 +72,20 @@ class TestMetaRegistry(unittest.TestCase):
                 repo_locator=str(repo_dir),
             )
             self.assertEqual(record["setup_state"], "not_set_up")
+
+    def test_register_project_escapes_toml_string_values(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = pathlib.Path(tmp)
+            locator = 'C:\\repos\\my"proj'
+
+            record = meta_registry.register_project(
+                workspace_root=workspace,
+                repo_locator=locator,
+            )
+            record_path = workspace / "projects" / f"{record['directory_name']}.toml"
+
+            parsed = tomllib.loads(record_path.read_text(encoding="utf-8"))
+            self.assertEqual(parsed["identity"]["repo_locator"], locator)
 
     def test_project_ids_increment_for_same_day(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/lcats/tests/meta_registry_test.py
+++ b/lcats/tests/meta_registry_test.py
@@ -1,0 +1,89 @@
+"""Tests for lcats.meta_registry."""
+
+import datetime
+import pathlib
+import tempfile
+import unittest
+
+from lcats import meta_registry
+
+
+class TestMetaRegistry(unittest.TestCase):
+
+    def test_register_project_successful_writes_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = pathlib.Path(tmp)
+            repo_dir = workspace / "sample-repo"
+            (repo_dir / "project").mkdir(parents=True)
+
+            record = meta_registry.register_project(
+                workspace_root=workspace,
+                repo_locator=str(repo_dir),
+            )
+
+            self.assertEqual(record["setup_state"], "lrh_project_present")
+            self.assertEqual(record["short_name"], "sample-repo")
+
+            record_path = workspace / "projects" / f"{record['directory_name']}.toml"
+            self.assertTrue(record_path.exists())
+            text = record_path.read_text(encoding="utf-8")
+            self.assertIn("[project]", text)
+            self.assertIn('setup_state = "lrh_project_present"', text)
+
+    def test_register_project_duplicate_detection(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = pathlib.Path(tmp)
+            repo_dir = workspace / "repo-one"
+            repo_dir.mkdir(parents=True)
+
+            meta_registry.register_project(
+                workspace_root=workspace,
+                repo_locator=str(repo_dir),
+            )
+
+            with self.assertRaises(ValueError):
+                meta_registry.register_project(
+                    workspace_root=workspace,
+                    repo_locator=str(repo_dir),
+                )
+
+            forced = meta_registry.register_project(
+                workspace_root=workspace,
+                repo_locator=str(repo_dir),
+                force=True,
+            )
+            self.assertTrue(
+                (workspace / "projects" / f"{forced['directory_name']}.toml").exists()
+            )
+
+    def test_register_project_setup_state_not_set_up(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = pathlib.Path(tmp)
+            repo_dir = workspace / "repo-two"
+            repo_dir.mkdir(parents=True)
+
+            record = meta_registry.register_project(
+                workspace_root=workspace,
+                repo_locator=str(repo_dir),
+            )
+            self.assertEqual(record["setup_state"], "not_set_up")
+
+    def test_project_ids_increment_for_same_day(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = pathlib.Path(tmp)
+            first = meta_registry.register_project(
+                workspace_root=workspace,
+                repo_locator="https://example.com/a.git",
+            )
+            second = meta_registry.register_project(
+                workspace_root=workspace,
+                repo_locator="https://example.com/b.git",
+            )
+
+            date_part = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d")
+            self.assertEqual(first["id"], f"proj-{date_part}-001")
+            self.assertEqual(second["id"], f"proj-{date_part}-002")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a minimal Meta CLI slice to register repositories with a durable workspace project registry as the first persistence entry point for project identity. 
- Make it possible to register both LRH-style repos and arbitrary repo locators and detect local setup state for later orchestration work. 
- Keep the change small and traceable to a work item so future control-plane features can build on a stable registry record format. 

### Description
- Added a focused registry module `lcats.meta_registry` that infers `display_name`/`short_name`, detects `setup_state` (`lrh_project_present` or `not_set_up`), generates stable `project_id` values `proj-YYYYMMDD-###`, prevents duplicate registrations unless `--force` is passed, and writes TOML records under `projects/*.toml` with `[project]`, `[identity]`, and `[registry]` sections. 
- Wired a new CLI slice into `lcats` with `meta register <repo_locator>` and a handler that delegates to `meta_registry.register_project` and returns user-friendly success or error messages. 
- Added unit tests `tests/meta_registry_test.py` and CLI dispatch tests to cover successful registration, duplicate detection/`--force`, setup-state detection, and CLI help/dispatch behavior. 
- Updated `README.md`, the roadmap, and added the traceability work item `WI-META-0006` to document scope and acceptance criteria, while intentionally not implementing `meta list`, UI, or orchestration in this PR. 

### Testing
- Ran formatting and linting: `scripts/format` (applied formatting) and `scripts/lint` (Ruff checks passed and Black check satisfied after formatting). 
- Ran the full test suite with `scripts/test` and all unit tests passed (existing and new tests), indicating the new tests and changes are green. 
- The change is scoped to the registry/CLI slice and tests added: success path, duplicate handling, setup-state detection, and CLI dispatch help coverage. 

Work item: `WI-META-0006`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82f6d8e3c83279646e41610bee8e8)