### PR TITLE
docs: scaffold docs hub and CLI status matrix (phase: scaffold)

### DIFF
--- a/lcats/README.md
+++ b/lcats/README.md
@@ -36,6 +36,17 @@ lcats meta register <repo_locator>
 ```
 Publishing this package to PyPI is not yet supported because we don't yet have extensive enough tests.
 
+
+## Documentation
+
+LCATS documentation is being organized under `docs/`.
+
+- Docs hub: [`docs/index.md`](docs/index.md)
+- CLI implementation status reference: [`docs/reference/cli-status.md`](docs/reference/cli-status.md)
+- LRH control-plane docs: [`project/README.md`](project/README.md)
+
+The execution root remains `lcats/` (for example: `cd LCATS/lcats`).
+
 ## Optional pre-commit checks (local convenience only)
 
 `pre-commit` runs lightweight checks automatically before each commit. In LCATS, this is only a local convenience layer.

--- a/lcats/docs/README.md
+++ b/lcats/docs/README.md
@@ -1,0 +1,11 @@
+# LCATS documentation hub
+
+This `docs/` tree is the human-facing documentation layer for LCATS.
+
+Use this directory for Diátaxis content:
+- `tutorials/` for guided learning paths.
+- `how-to/` for task-oriented procedures.
+- `reference/` for exact commands, schemas, and behavior.
+- `explanation/` for architecture and rationale.
+
+Start at `index.md` for the docs map.

--- a/lcats/docs/index.md
+++ b/lcats/docs/index.md
@@ -1,0 +1,30 @@
+# LCATS docs index
+
+This page is the entry point for LCATS human-facing documentation.
+
+## Project execution root
+
+Run LCATS commands from the nested execution root:
+
+```bash
+cd LCATS/lcats
+```
+
+## Diátaxis map
+
+### Tutorials
+
+Tutorials are not scaffolded in this phase.
+
+### How-to guides
+
+How-to guides are not scaffolded in this phase.
+
+### Reference
+
+- [CLI status matrix](reference/cli-status.md)
+
+### Explanation
+
+- Control-plane concepts live in [`project/README.md`](../project/README.md).
+- Corpus-analysis architecture details live in [`lcats/analysis/corpus/README.md`](../lcats/analysis/corpus/README.md).

--- a/lcats/docs/reference/README.md
+++ b/lcats/docs/reference/README.md
@@ -1,0 +1,5 @@
+# LCATS reference docs
+
+Reference pages describe exact interfaces and current behavior.
+
+- [CLI status matrix](cli-status.md)

--- a/lcats/docs/reference/cli-status.md
+++ b/lcats/docs/reference/cli-status.md
@@ -1,0 +1,26 @@
+# LCATS CLI status matrix
+
+This page summarizes top-level `lcats` CLI command status based on implementation in `lcats/lcats/cli.py`.
+
+## Implemented commands
+
+- `help`
+- `info`
+- `gather`
+- `inspect`
+- `display`
+- `survey`
+- `stats`
+- `repair-specials`
+- `meta register`
+
+## Placeholder commands (declared, not implemented)
+
+- `index` (`"Indexing data files is not yet implemented."`)
+- `advise` (`"Getting advice from LCATS is not yet implemented."`)
+- `eval` (`"Evaluating LCATS is not yet implemented."`)
+
+## Notes
+
+- This is a status reference page, not a tutorial.
+- Command options and examples should be verified against `lcats <command> --help` when writing detailed command references.

--- a/lcats/project/prompts/PROMPT-AD_HOC-REQUEST_ORGANIZE_DOCS-2026-05-27-scaffold.md
+++ b/lcats/project/prompts/PROMPT-AD_HOC-REQUEST_ORGANIZE_DOCS-2026-05-27-scaffold.md
@@ -1,0 +1,23 @@
+# Prompt execution record
+
+- Prompt ID: `PROMPT(AD_HOC:REQUEST_ORGANIZE_DOCS)[2026-05-27T00:00:00+00:00]`
+- Phase: `scaffold`
+- Date: 2026-05-27
+- Scope source: `project/audits/2026-05-26-docs-audit.md`
+
+## Soft idempotence check
+
+- Searched repository markdown for this prompt family and exact prompt string before edits.
+- No existing execution record for this exact prompt/date was found.
+
+## Scoped changes executed
+
+- Added `docs/` scaffold index and reference landing pages.
+- Added a CLI status matrix that separates implemented commands from placeholders.
+- Added top-level README links to the docs hub and status reference.
+
+## Explicit deferrals
+
+- No tutorial pages were authored in this phase.
+- No broad file moves or large rewrites were performed.
+- No generated, exhaustive CLI flag reference was produced in this phase.


### PR DESCRIPTION
### Motivation
- Implement a low-risk first phase from the docs audit to create a human-facing docs hub and improve discoverability without moving existing files. 
- Provide a concise, auditable status reference that separates implemented CLI behavior from planned/placeholder commands to avoid presenting planned behavior as implemented.

### Description
- Added a documentation scaffold under `lcats/docs/` with `docs/README.md` and `docs/index.md` as the docs hub and Diátaxis entry map. 
- Added `docs/reference/README.md` and `docs/reference/cli-status.md` to host a CLI status matrix derived from `lcats/lcats/cli.py`. 
- Updated `lcats/README.md` to link to the new docs hub, the CLI status reference, and the LRH control-plane docs, and to remind readers of the nested execution root. 
- Recorded this prompt execution (soft-idempotence check + scope) at `lcats/project/prompts/PROMPT-AD_HOC-REQUEST_ORGANIZE_DOCS-2026-05-27-scaffold.md` and deferred tutorials and larger migrations to subsequent phases.

### Testing
- From the project execution root (`lcats/`) ran `scripts/format`, `scripts/lint`, and `scripts/test`, and all steps completed successfully. 
- Performed a repository markdown search for prior prompt execution records before edits as a soft-idempotence lookup and recorded the result in the prompt execution record file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1644243c6c8327a5006f651b7214c7)