### PR TITLE
Implement span-operation review decisions (WI-REVIEW-0003)

### DIFF
--- a/lcats/lcats/analysis/corpus/README.md
+++ b/lcats/lcats/analysis/corpus/README.md
@@ -98,11 +98,18 @@ Human decision support is library-first and data-structured:
 - `ReviewDecisionStore` stores:
   - `repair_decisions` (`approved`, `rejected`, `unresolved`)
   - `allowed_special_cases` for recurring expected special characters
+- Span-operation review models store one decision per span operation with
+  `pending`, `approved`, `rejected`, and `overridden` states.
+- Overrides preserve the reviewed operation and reviewer-specified replacement
+  operation plus required rationale.
 - Review application utilities:
   - `apply_review_to_specials(...)` suppresses findings covered by allowed cases.
   - `apply_review_to_repairs(...)` partitions suggestions into approved/rejected/
     unresolved groups.
-- Decisions support `to_dict()` / `from_dict()` for JSON-serializable payloads.
+  - `operation_for_application(...)` returns approved operations or override
+    replacements while rejecting pending/rejected decisions.
+- Decisions support deterministic JSON-serializable payloads through `to_dict()` /
+  `from_dict()` and serialization helpers.
 
 ## 4. Data Flow
 
@@ -149,9 +156,12 @@ Implemented today:
 - Repair suggestions with stable span references and rationale metadata.
 - Canonical span operation conversion with deterministic ordering semantics.
 - Span-set validation with explicit overlap and structural checks.
-- Human review decision model for repairs and allowed special cases.
-- Decision-aware suppression and grouped reviewed repair outputs.
-- JSON-serializable review decision payload support (`to_dict`/`from_dict`).
+- Human review decision model for repairs, allowed special cases, and canonical
+  span operations.
+- Decision-aware suppression, grouped reviewed repair outputs, and
+  application-eligibility helpers for span operation reviews.
+- Deterministic JSON-serializable review decision payload support (`to_dict`/
+  `from_dict` plus serialization helpers).
 
 ## 6. Planned Features (Near-term Roadmap)
 

--- a/lcats/lcats/analysis/corpus/review.py
+++ b/lcats/lcats/analysis/corpus/review.py
@@ -1,4 +1,4 @@
-"""Human review decisions for special-character findings and repairs."""
+"""Human review models for findings, repairs, and span operations."""
 
 import json
 
@@ -175,13 +175,27 @@ def operation_for_application(
     return decision.reviewed_operation
 
 
+def _span_operation_review_decision_sort_key(
+    decision: SpanOperationReviewDecision,
+) -> tuple[object, ...]:
+    """Return deterministic ordering key for span operation review decisions."""
+    return (
+        span_ops.operation_sort_key(decision.reviewed_operation),
+        decision.decision_id,
+        decision.span_operation_id,
+        decision.state,
+        decision.reviewer,
+    )
+
+
 def serialize_span_operation_review_decisions(
     decisions: Sequence[SpanOperationReviewDecision],
 ) -> str:
     """Serialize validated span operation review decisions to stable JSON."""
     for decision in decisions:
         validate_span_operation_review_decision(decision)
-    payload = [decision.to_dict() for decision in decisions]
+    ordered = sorted(decisions, key=_span_operation_review_decision_sort_key)
+    payload = [decision.to_dict() for decision in ordered]
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2)
 
 

--- a/lcats/lcats/analysis/corpus/review.py
+++ b/lcats/lcats/analysis/corpus/review.py
@@ -1,15 +1,186 @@
 """Human review decisions for special-character findings and repairs."""
 
+import json
+
 from dataclasses import dataclass
 from typing import Iterable, Optional, Sequence
 
 from lcats.analysis.corpus import repairs
+from lcats.analysis.corpus import span_ops
 from lcats.analysis.corpus import specials
 
+PENDING = "pending"
 APPROVED = "approved"
 REJECTED = "rejected"
+OVERRIDDEN = "overridden"
 ALLOWED = "allowed"
 UNRESOLVED = "unresolved"
+
+SPAN_OPERATION_REVIEW_STATES = frozenset((PENDING, APPROVED, REJECTED, OVERRIDDEN))
+
+
+@dataclass(frozen=True)
+class ReviewAuditMetadata:
+    """Audit metadata for one span operation review decision."""
+
+    created_at: str = ""
+    updated_at: str = ""
+    source: str = "human_review"
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a stable, JSON-serializable audit metadata payload."""
+        return {
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "source": self.source,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Optional[dict]) -> "ReviewAuditMetadata":
+        """Build audit metadata from a serialized mapping."""
+        if payload is None:
+            return cls()
+        return cls(
+            created_at=str(payload.get("created_at", "")),
+            updated_at=str(payload.get("updated_at", "")),
+            source=str(payload.get("source", "human_review")),
+            notes=str(payload.get("notes", "")),
+        )
+
+
+@dataclass(frozen=True)
+class SpanOperationOverride:
+    """Reviewer-specified replacement for a proposed span operation."""
+
+    replacement_operation: span_ops.SpanOperation
+    rationale: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable, JSON-serializable override payload."""
+        return {
+            "replacement_operation": self.replacement_operation.to_dict(),
+            "rationale": self.rationale,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "SpanOperationOverride":
+        """Build override details from a serialized mapping."""
+        return cls(
+            replacement_operation=span_ops.SpanOperation.from_dict(
+                payload.get("replacement_operation", {})
+            ),
+            rationale=str(payload.get("rationale", "")),
+        )
+
+
+@dataclass(frozen=True)
+class SpanOperationReviewDecision:
+    """One auditable human review decision for one span operation."""
+
+    decision_id: str
+    span_operation_id: str
+    state: str
+    reviewer: str
+    rationale: str
+    reviewed_operation: span_ops.SpanOperation
+    audit_metadata: ReviewAuditMetadata = ReviewAuditMetadata()
+    override: SpanOperationOverride | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return stable, JSON-serializable review decision payload."""
+        payload = {
+            "decision_id": self.decision_id,
+            "span_operation_id": self.span_operation_id,
+            "state": self.state,
+            "reviewer": self.reviewer,
+            "rationale": self.rationale,
+            "reviewed_operation": self.reviewed_operation.to_dict(),
+            "audit_metadata": self.audit_metadata.to_dict(),
+            "override": None,
+        }
+        if self.override is not None:
+            payload["override"] = self.override.to_dict()
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "SpanOperationReviewDecision":
+        """Build a span operation review decision from a mapping."""
+        override_payload = payload.get("override")
+        decision = cls(
+            decision_id=str(payload.get("decision_id", "")),
+            span_operation_id=str(payload.get("span_operation_id", "")),
+            state=str(payload.get("state", PENDING)),
+            reviewer=str(payload.get("reviewer", "")),
+            rationale=str(payload.get("rationale", "")),
+            reviewed_operation=span_ops.SpanOperation.from_dict(
+                payload.get("reviewed_operation", {})
+            ),
+            audit_metadata=ReviewAuditMetadata.from_dict(payload.get("audit_metadata")),
+            override=(
+                SpanOperationOverride.from_dict(override_payload)
+                if override_payload is not None
+                else None
+            ),
+        )
+        validate_span_operation_review_decision(decision)
+        return decision
+
+
+def validate_span_operation_review_decision(
+    decision: SpanOperationReviewDecision,
+) -> None:
+    """Fail fast when a span operation review decision is inconsistent."""
+    if decision.state not in SPAN_OPERATION_REVIEW_STATES:
+        raise ValueError("unsupported review decision state")
+    if decision.span_operation_id != decision.reviewed_operation.operation_id:
+        raise ValueError("span_operation_id must match reviewed operation")
+    span_ops.validate_operation(decision.reviewed_operation)
+
+    if decision.state == OVERRIDDEN:
+        if decision.override is None:
+            raise ValueError("overridden decisions require override details")
+        span_ops.validate_operation(decision.override.replacement_operation)
+    elif decision.override is not None:
+        raise ValueError("only overridden decisions may include override details")
+
+
+def is_span_operation_review_eligible_for_application(
+    decision: SpanOperationReviewDecision,
+) -> bool:
+    """Return True when the reviewed operation can feed application planning."""
+    validate_span_operation_review_decision(decision)
+    return decision.state in (APPROVED, OVERRIDDEN)
+
+
+def operation_for_application(
+    decision: SpanOperationReviewDecision,
+) -> span_ops.SpanOperation:
+    """Return the approved operation or reviewer replacement for application."""
+    if not is_span_operation_review_eligible_for_application(decision):
+        raise ValueError("review decision is not eligible for application")
+    if decision.state == OVERRIDDEN:
+        return decision.override.replacement_operation
+    return decision.reviewed_operation
+
+
+def serialize_span_operation_review_decisions(
+    decisions: Sequence[SpanOperationReviewDecision],
+) -> str:
+    """Serialize validated span operation review decisions to stable JSON."""
+    for decision in decisions:
+        validate_span_operation_review_decision(decision)
+    payload = [decision.to_dict() for decision in decisions]
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2)
+
+
+def deserialize_span_operation_review_decisions(
+    payload: str,
+) -> list[SpanOperationReviewDecision]:
+    """Deserialize and validate span operation review decisions from JSON."""
+    loaded = json.loads(payload)
+    return [SpanOperationReviewDecision.from_dict(item) for item in loaded]
 
 
 @dataclass(frozen=True)

--- a/lcats/lcats/analysis/corpus/review.py
+++ b/lcats/lcats/analysis/corpus/review.py
@@ -128,6 +128,11 @@ class SpanOperationReviewDecision:
         return decision
 
 
+def _has_review_text(value: str) -> bool:
+    """Return True when a review text field contains non-whitespace text."""
+    return value.strip() != ""
+
+
 def validate_span_operation_review_decision(
     decision: SpanOperationReviewDecision,
 ) -> None:
@@ -138,9 +143,14 @@ def validate_span_operation_review_decision(
         raise ValueError("span_operation_id must match reviewed operation")
     span_ops.validate_operation(decision.reviewed_operation)
 
+    if not _has_review_text(decision.rationale):
+        raise ValueError("review rationale is required")
+
     if decision.state == OVERRIDDEN:
         if decision.override is None:
             raise ValueError("overridden decisions require override details")
+        if not _has_review_text(decision.override.rationale):
+            raise ValueError("override rationale is required")
         span_ops.validate_operation(decision.override.replacement_operation)
     elif decision.override is not None:
         raise ValueError("only overridden decisions may include override details")

--- a/lcats/lcats/analysis/corpus/span_ops.py
+++ b/lcats/lcats/analysis/corpus/span_ops.py
@@ -5,7 +5,6 @@ import json
 from dataclasses import dataclass
 from typing import Iterable, Sequence
 
-
 REPLACE_SPAN = "replace_span"
 REMOVE_SPAN = "remove_span"
 INSERT_SPAN = "insert_span"

--- a/lcats/lcats/analysis/corpus/specials.py
+++ b/lcats/lcats/analysis/corpus/specials.py
@@ -9,7 +9,6 @@ import unicodedata
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
-
 SMART_ALLOWED = {"–", "—", "‘", "’", "“", "”", "…"}
 ASCII_PUNCT = {chr(index) for index in range(32, 127)} - set(
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"

--- a/lcats/lcats/analysis/graph_plotters.py
+++ b/lcats/lcats/analysis/graph_plotters.py
@@ -102,7 +102,7 @@ def plot_tokens_per_story_by_author(
     grouped = [df[df["author"] == a]["body_tokens"].to_numpy() for a in order]
 
     fig, ax = plt.subplots(figsize=figsize)
-    ax.boxplot(grouped, showfliers=False, labels=label_order, vert=True)
+    ax.boxplot(grouped, showfliers=False, tick_labels=label_order, vert=True)
 
     if log_tokens:
         ax.set_yscale("log")

--- a/lcats/lcats/analysis/graph_plotters.py
+++ b/lcats/lcats/analysis/graph_plotters.py
@@ -1,9 +1,18 @@
 """Plotting functions for LCATS corpus analysis."""
 
+import inspect
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+
+
+def _boxplot_label_keyword(boxplot_callable) -> str:
+    """Return the supported Matplotlib boxplot label keyword."""
+    if "tick_labels" in inspect.signature(boxplot_callable).parameters:
+        return "tick_labels"
+    return "labels"
 
 
 def plot_author_stories_vs_tokens(
@@ -102,7 +111,9 @@ def plot_tokens_per_story_by_author(
     grouped = [df[df["author"] == a]["body_tokens"].to_numpy() for a in order]
 
     fig, ax = plt.subplots(figsize=figsize)
-    ax.boxplot(grouped, showfliers=False, tick_labels=label_order, vert=True)
+    boxplot_kwargs = {"showfliers": False, "vert": True}
+    boxplot_kwargs[_boxplot_label_keyword(ax.boxplot)] = label_order
+    ax.boxplot(grouped, **boxplot_kwargs)
 
     if log_tokens:
         ax.set_yscale("log")

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -10,7 +10,6 @@ import lcats.gatherers.main
 import lcats.inspect
 from lcats import meta_registry
 
-
 TOP_LEVEL_DESCRIPTION = (
     "LCATS is a literary case-based reasoning toolkit for gathering, inspecting, "
     "surveying, and analyzing corpora."

--- a/lcats/lcats/gettenberg/metadata.py
+++ b/lcats/lcats/gettenberg/metadata.py
@@ -79,27 +79,23 @@ def get_metadata_from_header(field: str, header: Iterable[str]) -> Set[str]:
 
 def titles_for(cache, bid: int) -> Set[str]:
     """Return set of title strings for a given Gutenberg book ID."""
-    rows = cache.native_query(
-        f"""
+    rows = cache.native_query(f"""
         SELECT t.name AS v
         FROM titles t
         JOIN books b ON t.bookid = b.id
         WHERE b.gutenbergbookid = {int(bid)}
-        """
-    )
+        """)
     return values.strings_from_sql(rows)
 
 
 def languages_for(cache, bid: int) -> Set[str]:
     """Return set of language strings for a given Gutenberg book ID."""
-    rows = cache.native_query(
-        f"""
+    rows = cache.native_query(f"""
         SELECT l.name AS v
         FROM languages l
         JOIN books b ON l.id = b.languageid
         WHERE b.gutenbergbookid = {int(bid)}
-        """
-    )
+        """)
     return values.strings_from_sql(rows)
 
 
@@ -135,15 +131,13 @@ def convert_to_names(cache, numbers):
 
 def authors_split(cache, bid: int) -> Set[str]:
     """Return set of author strings for a given Gutenberg book ID."""
-    rows = cache.native_query(
-        f"""
+    rows = cache.native_query(f"""
         SELECT a.id AS v
         FROM authors a
         JOIN book_authors ba ON a.id = ba.authorid
         JOIN books b         ON ba.bookid = b.id
         WHERE b.gutenbergbookid = {int(bid)}
-        """
-    )
+        """)
 
     number_list = [
         int(number_str) for number_str in list(values.strings_from_sql(rows))
@@ -159,43 +153,37 @@ def authors_split(cache, bid: int) -> Set[str]:
 
 def authors_for(cache, bid: int) -> Set[str]:
     """Return set of author strings for a given Gutenberg book ID."""
-    rows = cache.native_query(
-        f"""
+    rows = cache.native_query(f"""
         SELECT a.name AS v
         FROM authors a
         JOIN book_authors ba ON a.id = ba.authorid
         JOIN books b         ON ba.bookid = b.id
         WHERE b.gutenbergbookid = {int(bid)}
-        """
-    )
+        """)
 
     return values.strings_from_sql(rows)
 
 
 def aliases_for(cache, bid: int) -> Set[str]:
     """Return set of alias strings for a given Gutenberg book ID."""
-    rows = cache.native_query(
-        f"""
+    rows = cache.native_query(f"""
         SELECT a.name AS v
         FROM aliases a
         JOIN book_aliases ba ON a.id = ba.authorid
         JOIN books b         ON ba.bookid = b.id
         WHERE b.gutenbergbookid = {int(bid)}
-        """
-    )
+        """)
 
     return values.strings_from_sql(rows)
 
 
 def subjects_for(cache, bid: int) -> Set[str]:
     """Return set of subject strings for a given Gutenberg book ID."""
-    rows = cache.native_query(
-        f"""
+    rows = cache.native_query(f"""
         SELECT s.name AS v
         FROM subjects s
         JOIN book_subjects bs ON s.id = bs.subjectid
         JOIN books b          ON bs.bookid = b.id
         WHERE b.gutenbergbookid = {int(bid)}
-        """
-    )
+        """)
     return values.strings_from_sql(rows)

--- a/lcats/lcats/meta_registry.py
+++ b/lcats/lcats/meta_registry.py
@@ -6,7 +6,6 @@ import re
 from typing import Any
 from urllib import parse
 
-
 PROJECTS_DIR_NAME = "projects"
 PROJECT_DIR_DEFAULT = "project"
 

--- a/lcats/tests/analysis_tests/graph_plotters_test.py
+++ b/lcats/tests/analysis_tests/graph_plotters_test.py
@@ -86,6 +86,31 @@ class TestTokensPerStoryByAuthorFrame(unittest.TestCase):
         self.assertEqual(list(story_stats.columns), original_columns)
 
 
+class TestBoxplotLabelKeyword(unittest.TestCase):
+    """Tests for Matplotlib boxplot keyword compatibility."""
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_supports_current_matplotlib(self):
+        """Current Matplotlib boxplot label keyword is detected."""
+        _, ax = plt.subplots()
+
+        keyword = graph_plotters._boxplot_label_keyword(ax.boxplot)
+
+        self.assertIn(keyword, {"tick_labels", "labels"})
+
+    def test_supports_legacy_matplotlib_signature(self):
+        """Older Matplotlib boxplot labels keyword remains supported."""
+
+        def legacy_boxplot(values, labels=None):
+            return values, labels
+
+        keyword = graph_plotters._boxplot_label_keyword(legacy_boxplot)
+
+        self.assertEqual("labels", keyword)
+
+
 class TestPlotAuthorStoriesVsTokens(unittest.TestCase):
     """Tests for plot_author_stories_vs_tokens."""
 

--- a/lcats/tests/analysis_tests/review_test.py
+++ b/lcats/tests/analysis_tests/review_test.py
@@ -6,6 +6,7 @@ import unittest
 from lcats.analysis.corpus import repairs
 from lcats.analysis.corpus import review
 from lcats.analysis.corpus import specials
+from lcats.analysis.corpus import span_ops
 
 
 class ReviewTest(unittest.TestCase):
@@ -131,6 +132,115 @@ class ReviewTest(unittest.TestCase):
 
         self.assertEqual(1, len(filtered))
         self.assertEqual("©", filtered[0].character)
+
+
+class SpanOperationReviewTest(unittest.TestCase):
+    """Tests for span-operation review decision semantics."""
+
+    def _operation(self, operation_id="spanop-demo", replacement_text="’"):
+        return span_ops.SpanOperation(
+            operation_id=operation_id,
+            operation_type=span_ops.REPLACE_SPAN,
+            start=1,
+            end=4,
+            replacement_text=replacement_text,
+            original_text="â€™",
+            provenance=span_ops.SpanOperationProvenance(
+                rule_id="mojibake-right-single-quote",
+                source="repair_suggestion",
+                finding_offset=1,
+                evidence="rule=mojibake-pattern; fragment=â€™",
+                rationale="Broken UTF-8 right single quote sequence.",
+            ),
+        )
+
+    def _decision(self, state, override=None):
+        operation = self._operation()
+        return review.SpanOperationReviewDecision(
+            decision_id=f"review-{state}",
+            span_operation_id=operation.operation_id,
+            state=state,
+            reviewer="reviewer@example.test",
+            rationale=f"Decision rationale for {state}",
+            reviewed_operation=operation,
+            audit_metadata=review.ReviewAuditMetadata(
+                created_at="2026-06-16T00:00:00Z",
+                updated_at="2026-06-16T00:00:00Z",
+                source="unit_test",
+                notes="deterministic audit metadata",
+            ),
+            override=override,
+        )
+
+    def test_decision_state_application_eligibility(self):
+        replacement = self._operation("spanop-demo-override", "'")
+        override = review.SpanOperationOverride(
+            replacement_operation=replacement,
+            rationale="Prefer ASCII apostrophe for this source.",
+        )
+        cases = [
+            (review.PENDING, None, False),
+            (review.APPROVED, None, True),
+            (review.REJECTED, None, False),
+            (review.OVERRIDDEN, override, True),
+        ]
+
+        for state, override_details, expected in cases:
+            with self.subTest(state=state):
+                decision = self._decision(state, override_details)
+
+                actual = review.is_span_operation_review_eligible_for_application(
+                    decision
+                )
+
+                self.assertEqual(expected, actual)
+
+    def test_operation_for_application_uses_override_replacement(self):
+        replacement = self._operation("spanop-demo-override", "'")
+        decision = self._decision(
+            review.OVERRIDDEN,
+            review.SpanOperationOverride(
+                replacement_operation=replacement,
+                rationale="Reviewer supplied replacement operation.",
+            ),
+        )
+
+        application_operation = review.operation_for_application(decision)
+
+        self.assertEqual(self._operation(), decision.reviewed_operation)
+        self.assertEqual(replacement, decision.override.replacement_operation)
+        self.assertEqual(replacement, application_operation)
+
+    def test_pending_and_rejected_operations_cannot_be_selected_for_application(self):
+        for state in (review.PENDING, review.REJECTED):
+            with self.subTest(state=state):
+                decision = self._decision(state)
+
+                with self.assertRaises(ValueError):
+                    review.operation_for_application(decision)
+
+    def test_span_operation_review_round_trip_preserves_auditability(self):
+        replacement = self._operation("spanop-demo-override", "'")
+        decision = self._decision(
+            review.OVERRIDDEN,
+            review.SpanOperationOverride(
+                replacement_operation=replacement,
+                rationale="Reviewer supplied replacement operation.",
+            ),
+        )
+
+        payload = review.serialize_span_operation_review_decisions([decision])
+        loaded = review.deserialize_span_operation_review_decisions(payload)
+
+        json.loads(payload)
+        self.assertEqual([decision], loaded)
+        self.assertEqual("reviewer@example.test", loaded[0].reviewer)
+        self.assertEqual(
+            "Decision rationale for overridden",
+            loaded[0].rationale,
+        )
+        self.assertEqual(self._operation(), loaded[0].reviewed_operation)
+        self.assertEqual(replacement, loaded[0].override.replacement_operation)
 
 
 if __name__ == "__main__":

--- a/lcats/tests/analysis_tests/review_test.py
+++ b/lcats/tests/analysis_tests/review_test.py
@@ -219,6 +219,50 @@ class SpanOperationReviewTest(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     review.operation_for_application(decision)
 
+    def test_review_decision_requires_rationale(self):
+        for state in review.SPAN_OPERATION_REVIEW_STATES:
+            with self.subTest(state=state):
+                override = None
+                if state == review.OVERRIDDEN:
+                    override = review.SpanOperationOverride(
+                        replacement_operation=self._operation(
+                            "spanop-demo-override", "'"
+                        ),
+                        rationale="Override rationale.",
+                    )
+                decision = review.SpanOperationReviewDecision(
+                    decision_id=f"review-{state}",
+                    span_operation_id="spanop-demo",
+                    state=state,
+                    reviewer="reviewer@example.test",
+                    rationale="",
+                    reviewed_operation=self._operation(),
+                    override=override,
+                )
+
+                with self.assertRaises(ValueError):
+                    review.validate_span_operation_review_decision(decision)
+
+    def test_overridden_decision_requires_override_rationale(self):
+        decision = self._decision(
+            review.OVERRIDDEN,
+            review.SpanOperationOverride(
+                replacement_operation=self._operation("spanop-demo-override", "'"),
+                rationale="",
+            ),
+        )
+
+        with self.assertRaises(ValueError):
+            review.validate_span_operation_review_decision(decision)
+
+    def test_deserialize_rejects_missing_rationale(self):
+        decision = self._decision(review.APPROVED)
+        payload = decision.to_dict()
+        del payload["rationale"]
+
+        with self.assertRaises(ValueError):
+            review.SpanOperationReviewDecision.from_dict(payload)
+
     def test_span_operation_review_round_trip_preserves_auditability(self):
         replacement = self._operation("spanop-demo-override", "'")
         decision = self._decision(

--- a/lcats/tests/analysis_tests/review_test.py
+++ b/lcats/tests/analysis_tests/review_test.py
@@ -263,6 +263,53 @@ class SpanOperationReviewTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             review.SpanOperationReviewDecision.from_dict(payload)
 
+    def test_span_operation_review_serialization_is_deterministically_ordered(self):
+        first_operation = self._operation("spanop-a", "’")
+        second_operation = span_ops.SpanOperation(
+            operation_id="spanop-b",
+            operation_type=span_ops.REPLACE_SPAN,
+            start=8,
+            end=11,
+            replacement_text="…",
+            original_text="â€¦",
+            provenance=span_ops.SpanOperationProvenance(
+                rule_id="mojibake-ellipsis",
+                source="repair_suggestion",
+                finding_offset=8,
+                evidence="rule=mojibake-pattern; fragment=â€¦",
+                rationale="Broken UTF-8 ellipsis sequence.",
+            ),
+        )
+        first_decision = review.SpanOperationReviewDecision(
+            decision_id="review-a",
+            span_operation_id=first_operation.operation_id,
+            state=review.APPROVED,
+            reviewer="reviewer@example.test",
+            rationale="Approve first operation.",
+            reviewed_operation=first_operation,
+        )
+        second_decision = review.SpanOperationReviewDecision(
+            decision_id="review-b",
+            span_operation_id=second_operation.operation_id,
+            state=review.APPROVED,
+            reviewer="reviewer@example.test",
+            rationale="Approve second operation.",
+            reviewed_operation=second_operation,
+        )
+
+        run_one = review.serialize_span_operation_review_decisions(
+            [second_decision, first_decision]
+        )
+        run_two = review.serialize_span_operation_review_decisions(
+            [first_decision, second_decision]
+        )
+
+        self.assertEqual(run_one, run_two)
+        loaded = review.deserialize_span_operation_review_decisions(run_one)
+        self.assertEqual(
+            ["review-a", "review-b"], [item.decision_id for item in loaded]
+        )
+
     def test_span_operation_review_round_trip_preserves_auditability(self):
         replacement = self._operation("spanop-demo-override", "'")
         decision = self._decision(


### PR DESCRIPTION
### Motivation
- Provide an explicit, library-first human review model for span-operation-based repairs so each proposed span operation can be approved, rejected, or overridden with auditability.
- Ensure review decisions are deterministic, JSON-serializable, and validateable so downstream application planning can reliably decide eligibility without persistence or UI dependencies.

### Description
- Add explicit span-operation review dataclasses: `SpanOperationReviewDecision`, `SpanOperationOverride`, and `ReviewAuditMetadata`, plus constants for `pending`, `approved`, `rejected`, and `overridden` states, and a canonical set `SPAN_OPERATION_REVIEW_STATES`.
- Implement validation helpers `validate_span_operation_review_decision` and JSON helpers `serialize_span_operation_review_decisions` / `deserialize_span_operation_review_decisions` that preserve reviewed operation, reviewer, rationale, audit metadata, and override details.
- Implement application-eligibility helpers `is_span_operation_review_eligible_for_application` and `operation_for_application` where only `approved` and `overridden` are eligible and overridden returns the reviewer-provided replacement operation while preserving the original reviewed operation.
- Add unit tests exercising decision states, eligibility semantics, override behavior (original operation preserved, replacement preserved), serialization round-trip, and audit fields (reviewer, rationale, audit metadata).
- Make a small compatibility fix to `graph_plotters.plot_tokens_per_story_by_author` to use Matplotlib's `tick_labels` kwarg so the full test-suite runs in the current environment, and run formatting/linting to normalize touched files.

### Testing
- Ran formatting with `scripts/format` and linting with `scripts/lint`, both completed successfully.
- Ran the full test suite with `scripts/test`, which completed successfully: all tests passed (`Ran 1175 tests ... OK`).
- Also ran targeted unit tests for the review module (`python -m unittest tests.analysis_tests.review_test`) which passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ea011dfc8327a06ccc531b54c2e7)