### PR TITLE
Implement approved span operation application

### DIFF
--- a/lcats/lcats/analysis/corpus/README.md
+++ b/lcats/lcats/analysis/corpus/README.md
@@ -108,6 +108,11 @@ Human decision support is library-first and data-structured:
     unresolved groups.
   - `operation_for_application(...)` returns approved operations or override
     replacements while rejecting pending/rejected decisions.
+- Approved application is handled by `application.apply_reviewed_operations(...)`,
+  which audits every considered decision, applies only `approved` and
+  `overridden` operations, skips `pending`/`rejected` decisions, validates spans
+  and overlaps before transformation, and returns transformed text separately
+  from the original input.
 - Decisions support deterministic JSON-serializable payloads through `to_dict()` /
   `from_dict()` and serialization helpers.
 
@@ -138,7 +143,13 @@ The current end-to-end flow is:
    - Review decisions can suppress expected findings and group repair proposals
      by approval state.
 
-7. **Future persistence**
+7. **Approved application**
+   - Reviewed span operations are applied only after eligibility filtering.
+   - Deterministic ordering follows canonical span-operation sort semantics.
+   - Conflicts, invalid spans, and source-text mismatches fail without partial
+     output, preserving the original text in the result.
+
+8. **Future persistence**
    - Decision models are serializable today; first-class persisted review stores
      and workflow tooling are planned but not yet integrated as a complete
      product workflow.
@@ -160,6 +171,9 @@ Implemented today:
   span operations.
 - Decision-aware suppression, grouped reviewed repair outputs, and
   application-eligibility helpers for span operation reviews.
+- Non-destructive approved application from review decisions to transformed text,
+  including structured reports for considered, applied, skipped, and failed
+  operations.
 - Deterministic JSON-serializable review decision payload support (`to_dict`/
   `from_dict` plus serialization helpers).
 
@@ -167,7 +181,8 @@ Implemented today:
 
 Planned near-term enhancements:
 
-- First-class persistence conventions for review decisions (e.g., standard
+- First-class persistence conventions for review decisions and application
+  outputs (e.g., standard
   on-disk location and lifecycle in corpus workflows).
 - Tighter CLI integration for loading/applying decision stores during survey and
   repair reporting flows.

--- a/lcats/lcats/analysis/corpus/application.py
+++ b/lcats/lcats/analysis/corpus/application.py
@@ -1,0 +1,217 @@
+"""Apply reviewed span operations to text without mutating corpus sources."""
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from lcats.analysis.corpus import review
+from lcats.analysis.corpus import span_ops
+
+APPLIED = "applied"
+SKIPPED = "skipped"
+FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class ApplicationDecisionReport:
+    """Audit record for one review decision considered for application."""
+
+    decision_id: str
+    span_operation_id: str
+    state: str
+    outcome: str
+    reason: str
+    operation_id: str = ""
+    override_used: bool = False
+    reviewer: str = ""
+    rationale: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable, JSON-serializable report payload."""
+        return {
+            "decision_id": self.decision_id,
+            "span_operation_id": self.span_operation_id,
+            "state": self.state,
+            "outcome": self.outcome,
+            "reason": self.reason,
+            "operation_id": self.operation_id,
+            "override_used": self.override_used,
+            "reviewer": self.reviewer,
+            "rationale": self.rationale,
+        }
+
+
+@dataclass(frozen=True)
+class ApplicationFailure:
+    """Structured validation failure for an application attempt."""
+
+    message: str
+    operation_id: str = ""
+    decision_id: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        """Return a stable, JSON-serializable failure payload."""
+        return {
+            "message": self.message,
+            "operation_id": self.operation_id,
+            "decision_id": self.decision_id,
+        }
+
+
+@dataclass(frozen=True)
+class ApplicationResult:
+    """Structured result for non-destructive reviewed operation application."""
+
+    success: bool
+    original_text: str
+    transformed_text: str
+    considered: tuple[ApplicationDecisionReport, ...]
+    applied: tuple[ApplicationDecisionReport, ...]
+    skipped: tuple[ApplicationDecisionReport, ...]
+    failures: tuple[ApplicationFailure, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable, JSON-serializable application result payload."""
+        return {
+            "success": self.success,
+            "original_text": self.original_text,
+            "transformed_text": self.transformed_text,
+            "considered": [item.to_dict() for item in self.considered],
+            "applied": [item.to_dict() for item in self.applied],
+            "skipped": [item.to_dict() for item in self.skipped],
+            "failures": [item.to_dict() for item in self.failures],
+        }
+
+
+def _failure_result(
+    text: str,
+    considered: list[ApplicationDecisionReport],
+    applied: list[ApplicationDecisionReport],
+    skipped: list[ApplicationDecisionReport],
+    failure: ApplicationFailure,
+) -> ApplicationResult:
+    """Return a failed result without applying a partial transformation."""
+    return ApplicationResult(
+        success=False,
+        original_text=text,
+        transformed_text=text,
+        considered=tuple(considered),
+        applied=tuple(applied),
+        skipped=tuple(skipped),
+        failures=(failure,),
+    )
+
+
+def _validate_operation_against_text(
+    text: str,
+    operation: span_ops.SpanOperation,
+) -> None:
+    """Fail when an operation cannot be safely applied to this text."""
+    span_ops.validate_operation(operation)
+    if operation.end > len(text):
+        raise ValueError("operation span exceeds text length")
+    if operation.operation_type != span_ops.INSERT_SPAN:
+        actual = text[operation.start : operation.end]
+        if actual != operation.original_text:
+            raise ValueError("operation original_text does not match text span")
+
+
+def _application_sort_key(
+    decision: review.SpanOperationReviewDecision,
+) -> tuple[object, ...]:
+    """Return deterministic ordering key for decisions entering application."""
+    return (
+        span_ops.operation_sort_key(decision.reviewed_operation),
+        decision.decision_id,
+        decision.span_operation_id,
+        decision.state,
+        decision.reviewer,
+    )
+
+
+def _apply_operations(
+    text: str,
+    operations: Sequence[span_ops.SpanOperation],
+) -> str:
+    """Apply validated non-overlapping operations from right to left."""
+    transformed = text
+    for operation in reversed(span_ops.sort_operations(operations)):
+        if operation.operation_type == span_ops.REMOVE_SPAN:
+            replacement = ""
+        else:
+            replacement = operation.replacement_text
+        transformed = (
+            transformed[: operation.start] + replacement + transformed[operation.end :]
+        )
+    return transformed
+
+
+def apply_reviewed_operations(
+    text: str,
+    decisions: Sequence[review.SpanOperationReviewDecision],
+) -> ApplicationResult:
+    """Apply approved or overridden span operations to text.
+
+    Pending and rejected decisions are audited as skipped. Validation happens
+    before any transformation is returned as successful, so invalid spans,
+    mismatched source text, duplicate operation ids, and overlaps fail without a
+    partial output.
+    """
+    considered: list[ApplicationDecisionReport] = []
+    applied: list[ApplicationDecisionReport] = []
+    skipped: list[ApplicationDecisionReport] = []
+    eligible_operations: list[span_ops.SpanOperation] = []
+
+    for decision in sorted(decisions, key=_application_sort_key):
+        try:
+            review.validate_span_operation_review_decision(decision)
+        except ValueError as error:
+            failure = ApplicationFailure(str(error), decision_id=decision.decision_id)
+            return _failure_result(text, considered, applied, skipped, failure)
+
+        if not review.is_span_operation_review_eligible_for_application(decision):
+            report = ApplicationDecisionReport(
+                decision_id=decision.decision_id,
+                span_operation_id=decision.span_operation_id,
+                state=decision.state,
+                outcome=SKIPPED,
+                reason="review state is not eligible for application",
+                operation_id=decision.reviewed_operation.operation_id,
+                reviewer=decision.reviewer,
+                rationale=decision.rationale,
+            )
+            considered.append(report)
+            skipped.append(report)
+            continue
+
+        operation = review.operation_for_application(decision)
+        report = ApplicationDecisionReport(
+            decision_id=decision.decision_id,
+            span_operation_id=decision.span_operation_id,
+            state=decision.state,
+            outcome=APPLIED,
+            reason="review state is eligible for application",
+            operation_id=operation.operation_id,
+            override_used=decision.state == review.OVERRIDDEN,
+            reviewer=decision.reviewer,
+            rationale=decision.rationale,
+        )
+        considered.append(report)
+        applied.append(report)
+        eligible_operations.append(operation)
+
+    try:
+        span_ops.validate_operation_set(eligible_operations)
+        for operation in span_ops.sort_operations(eligible_operations):
+            _validate_operation_against_text(text, operation)
+    except ValueError as error:
+        failure = ApplicationFailure(str(error))
+        return _failure_result(text, considered, applied, skipped, failure)
+
+    return ApplicationResult(
+        success=True,
+        original_text=text,
+        transformed_text=_apply_operations(text, eligible_operations),
+        considered=tuple(considered),
+        applied=tuple(applied),
+        skipped=tuple(skipped),
+    )

--- a/lcats/lcats/analysis/corpus/application.py
+++ b/lcats/lcats/analysis/corpus/application.py
@@ -7,8 +7,8 @@ from lcats.analysis.corpus import review
 from lcats.analysis.corpus import span_ops
 
 APPLIED = "applied"
+ELIGIBLE = "eligible"
 SKIPPED = "skipped"
-FAILED = "failed"
 
 
 @dataclass(frozen=True)
@@ -85,7 +85,7 @@ class ApplicationResult:
 def _failure_result(
     text: str,
     considered: list[ApplicationDecisionReport],
-    applied: list[ApplicationDecisionReport],
+    applied: Sequence[ApplicationDecisionReport],
     skipped: list[ApplicationDecisionReport],
     failure: ApplicationFailure,
 ) -> ApplicationResult:
@@ -117,10 +117,11 @@ def _validate_operation_against_text(
 
 def _application_sort_key(
     decision: review.SpanOperationReviewDecision,
+    operation: span_ops.SpanOperation,
 ) -> tuple[object, ...]:
     """Return deterministic ordering key for decisions entering application."""
     return (
-        span_ops.operation_sort_key(decision.reviewed_operation),
+        span_ops.operation_sort_key(operation),
         decision.decision_id,
         decision.span_operation_id,
         decision.state,
@@ -157,17 +158,42 @@ def apply_reviewed_operations(
     partial output.
     """
     considered: list[ApplicationDecisionReport] = []
-    applied: list[ApplicationDecisionReport] = []
     skipped: list[ApplicationDecisionReport] = []
+    eligible_reports: list[ApplicationDecisionReport] = []
     eligible_operations: list[span_ops.SpanOperation] = []
+    operation_decisions: dict[str, str] = {}
+    ordered_items: list[
+        tuple[
+            tuple[object, ...],
+            review.SpanOperationReviewDecision,
+            span_ops.SpanOperation,
+            bool,
+        ]
+    ] = []
 
-    for decision in sorted(decisions, key=_application_sort_key):
+    for decision in decisions:
         try:
             review.validate_span_operation_review_decision(decision)
         except ValueError as error:
             failure = ApplicationFailure(str(error), decision_id=decision.decision_id)
-            return _failure_result(text, considered, applied, skipped, failure)
+            return _failure_result(text, considered, (), skipped, failure)
 
+        if review.is_span_operation_review_eligible_for_application(decision):
+            operation = review.operation_for_application(decision)
+            override_used = decision.state == review.OVERRIDDEN
+        else:
+            operation = decision.reviewed_operation
+            override_used = False
+        ordered_items.append(
+            (
+                _application_sort_key(decision, operation),
+                decision,
+                operation,
+                override_used,
+            )
+        )
+
+    for _sort_key, decision, operation, override_used in sorted(ordered_items):
         if not review.is_span_operation_review_eligible_for_application(decision):
             report = ApplicationDecisionReport(
                 decision_id=decision.decision_id,
@@ -175,7 +201,7 @@ def apply_reviewed_operations(
                 state=decision.state,
                 outcome=SKIPPED,
                 reason="review state is not eligible for application",
-                operation_id=decision.reviewed_operation.operation_id,
+                operation_id=operation.operation_id,
                 reviewer=decision.reviewer,
                 rationale=decision.rationale,
             )
@@ -183,35 +209,58 @@ def apply_reviewed_operations(
             skipped.append(report)
             continue
 
-        operation = review.operation_for_application(decision)
         report = ApplicationDecisionReport(
             decision_id=decision.decision_id,
             span_operation_id=decision.span_operation_id,
             state=decision.state,
-            outcome=APPLIED,
+            outcome=ELIGIBLE,
             reason="review state is eligible for application",
             operation_id=operation.operation_id,
-            override_used=decision.state == review.OVERRIDDEN,
+            override_used=override_used,
             reviewer=decision.reviewer,
             rationale=decision.rationale,
         )
         considered.append(report)
-        applied.append(report)
+        eligible_reports.append(report)
         eligible_operations.append(operation)
+        operation_decisions[operation.operation_id] = decision.decision_id
 
     try:
         span_ops.validate_operation_set(eligible_operations)
         for operation in span_ops.sort_operations(eligible_operations):
-            _validate_operation_against_text(text, operation)
+            try:
+                _validate_operation_against_text(text, operation)
+            except ValueError as error:
+                failure = ApplicationFailure(
+                    str(error),
+                    operation_id=operation.operation_id,
+                    decision_id=operation_decisions.get(operation.operation_id, ""),
+                )
+                return _failure_result(text, considered, (), skipped, failure)
     except ValueError as error:
         failure = ApplicationFailure(str(error))
-        return _failure_result(text, considered, applied, skipped, failure)
+        return _failure_result(text, considered, (), skipped, failure)
+
+    applied = tuple(
+        ApplicationDecisionReport(
+            decision_id=report.decision_id,
+            span_operation_id=report.span_operation_id,
+            state=report.state,
+            outcome=APPLIED,
+            reason="operation applied after validation",
+            operation_id=report.operation_id,
+            override_used=report.override_used,
+            reviewer=report.reviewer,
+            rationale=report.rationale,
+        )
+        for report in eligible_reports
+    )
 
     return ApplicationResult(
         success=True,
         original_text=text,
         transformed_text=_apply_operations(text, eligible_operations),
         considered=tuple(considered),
-        applied=tuple(applied),
+        applied=applied,
         skipped=tuple(skipped),
     )

--- a/lcats/project/executions/2026-06-18-WI-APPLY-0005.md
+++ b/lcats/project/executions/2026-06-18-WI-APPLY-0005.md
@@ -1,0 +1,39 @@
+---
+prompt_id: PROMPT(WI-APPLY-0005:IMPLEMENT_APPROVED_REPAIR_APPLICATION)[2026-06-18T00:00:00+00:00]
+work_item: WI-APPLY-0005
+created_at: 2026-06-18T00:00:00+00:00
+---
+
+# Execution Record: WI-APPLY-0005
+
+## Prompt ID
+`PROMPT(WI-APPLY-0005:IMPLEMENT_APPROVED_REPAIR_APPLICATION)[2026-06-18T00:00:00+00:00]`
+
+## Soft Idempotence Check
+- Searched for the exact prompt ID and substantially similar WI-APPLY-0005 work.
+- Found the active work item and roadmap/focus references, but no prior execution
+  record or existing application-layer implementation.
+- Continued with a focused implementation that preserves existing span-operation
+  and review models.
+
+## Summary of Changes
+- Added a non-destructive application layer for reviewed span operations.
+- Applied only `approved` decisions as proposed and `overridden` decisions using
+  reviewer replacement operations.
+- Skipped `pending` and `rejected` decisions with structured audit reasons.
+- Validated operation sets, overlap safety, span bounds, and source-text matches
+  before returning any successful transformed output.
+- Added unit tests for eligibility, deterministic ordering, conflict/invalid-span
+  failures, non-destructive behavior, and structured audit serialization.
+- Updated the corpus analysis README to describe the approved application stage.
+- Added this lightweight execution record because `PROMPTS.md`,
+  `scripts/prompts/record-execution`, and the execution README were not present.
+
+## Tests Run
+- `python -m unittest tests.analysis_tests.application_test`
+
+## Explicit Deferrals
+- No persistence workflow was added.
+- No CLI or interactive review UI was added.
+- No in-place corpus rewriting behavior was added.
+- Active work-item status was left unchanged for project planning follow-up.

--- a/lcats/project/executions/README.md
+++ b/lcats/project/executions/README.md
@@ -1,0 +1,9 @@
+# Prompt Execution Records
+
+This directory stores lightweight records for meaningful prompt-driven work.
+Records should identify the prompt ID, related work item, idempotence check,
+summary of changes, tests run, and intentional deferrals.
+
+The requested helper script `scripts/prompts/record-execution` was not present
+when this convention file was created, so records may be added manually in this
+format until a helper exists.

--- a/lcats/project/memory/decision_log.md
+++ b/lcats/project/memory/decision_log.md
@@ -82,3 +82,24 @@
 
 ### Status
 - Accepted
+
+---
+
+## 2026-06-18: Approved application layer completed
+
+### Summary
+- Implemented WI-APPLY-0005 with a deterministic, non-destructive application
+  layer for reviewed span operations.
+
+### Decisions
+- Apply only `approved` decisions as proposed and `overridden` decisions via
+  reviewer replacement operations.
+- Treat `pending` and `rejected` decisions as ineligible and audit them as
+  skipped.
+- Validate operation sets, overlaps, span bounds, and source-text matches before
+  returning any successful transformed output.
+- Keep persistence, CLI application workflows, and in-place corpus rewriting out
+  of scope for this work item.
+
+### Status
+- Accepted

--- a/lcats/tests/analysis_tests/application_test.py
+++ b/lcats/tests/analysis_tests/application_test.py
@@ -1,0 +1,185 @@
+"""Unit tests for approved span operation application."""
+
+import json
+import unittest
+
+from lcats.analysis.corpus import application
+from lcats.analysis.corpus import review
+from lcats.analysis.corpus import span_ops
+
+
+class ApplicationTest(unittest.TestCase):
+    """Tests for non-destructive reviewed operation application."""
+
+    def _operation(
+        self,
+        operation_id="spanop-000001",
+        start=6,
+        end=9,
+        original_text="â€™",
+        replacement_text="’",
+        operation_type=span_ops.REPLACE_SPAN,
+    ):
+        return span_ops.SpanOperation(
+            operation_id=operation_id,
+            operation_type=operation_type,
+            start=start,
+            end=end,
+            replacement_text=replacement_text,
+            original_text=original_text,
+            provenance=span_ops.SpanOperationProvenance(
+                rule_id="mojibake-right-single-quote",
+                source="unit_test",
+                finding_offset=start,
+                evidence=f"fragment={original_text}",
+                rationale="Broken punctuation sequence.",
+            ),
+        )
+
+    def _decision(self, operation, state=review.APPROVED, override=None):
+        return review.SpanOperationReviewDecision(
+            decision_id=f"decision-{operation.operation_id}-{state}",
+            span_operation_id=operation.operation_id,
+            state=state,
+            reviewer="reviewer@example.test",
+            rationale=f"Rationale for {state}",
+            reviewed_operation=operation,
+            audit_metadata=review.ReviewAuditMetadata(source="unit_test"),
+            override=override,
+        )
+
+    def test_eligibility_states_are_applied_or_skipped(self):
+        text = "Alice â€™ Bob â€¦ Carol â€“ Dana"
+        approved = self._operation("approved", 6, 9, "â€™", "’")
+        overridden = self._operation("overridden", 14, 17, "â€¦", "…")
+        replacement = self._operation("override-replacement", 14, 17, "â€¦", "...")
+        pending = self._operation("pending", 24, 27, "â€“", "–")
+        rejected = self._operation("rejected", 24, 27, "â€“", "-")
+
+        result = application.apply_reviewed_operations(
+            text,
+            [
+                self._decision(pending, review.PENDING),
+                self._decision(rejected, review.REJECTED),
+                self._decision(approved, review.APPROVED),
+                self._decision(
+                    overridden,
+                    review.OVERRIDDEN,
+                    review.SpanOperationOverride(
+                        replacement_operation=replacement,
+                        rationale="Use source-specific ellipsis style.",
+                    ),
+                ),
+            ],
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual("Alice ’ Bob ... Carol â€“ Dana", result.transformed_text)
+        self.assertEqual(text, result.original_text)
+        self.assertEqual(text, "Alice â€™ Bob â€¦ Carol â€“ Dana")
+        self.assertEqual(
+            ["approved", "override-replacement"],
+            [r.operation_id for r in result.applied],
+        )
+        self.assertEqual(
+            ["rejected", "pending"], [r.operation_id for r in result.skipped]
+        )
+        self.assertTrue(result.applied[1].override_used)
+        json.dumps(result.to_dict())
+
+    def test_application_is_deterministic_for_input_order(self):
+        text = "A â€™ B â€¦ C"
+        quote = self._operation("quote", 2, 5, "â€™", "’")
+        ellipsis = self._operation(
+            "ellipsis",
+            8,
+            11,
+            "â€¦",
+            "…",
+        )
+        first = application.apply_reviewed_operations(
+            text,
+            [self._decision(ellipsis), self._decision(quote)],
+        )
+        second = application.apply_reviewed_operations(
+            text,
+            [self._decision(quote), self._decision(ellipsis)],
+        )
+
+        self.assertTrue(first.success)
+        self.assertTrue(second.success)
+        self.assertEqual(first.transformed_text, second.transformed_text)
+        self.assertEqual(["quote", "ellipsis"], [r.operation_id for r in first.applied])
+        self.assertEqual(
+            ["quote", "ellipsis"], [r.operation_id for r in second.applied]
+        )
+
+    def test_overlapping_operations_fail_without_partial_output(self):
+        text = "abcdef"
+        first = self._operation("first", 1, 4, "bcd", "BCD")
+        second = self._operation("second", 3, 5, "de", "DE")
+
+        result = application.apply_reviewed_operations(
+            text,
+            [self._decision(first), self._decision(second)],
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(text, result.transformed_text)
+        self.assertIn("overlapping spans", result.failures[0].message)
+
+    def test_invalid_span_fails_without_partial_output(self):
+        text = "abc"
+        operation = self._operation("invalid", 1, 5, "bcde", "BCDE")
+
+        result = application.apply_reviewed_operations(
+            text, [self._decision(operation)]
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(text, result.transformed_text)
+        self.assertIn("exceeds text length", result.failures[0].message)
+
+    def test_original_text_mismatch_fails_without_partial_output(self):
+        text = "abc"
+        operation = self._operation("mismatch", 1, 3, "xy", "XY")
+
+        result = application.apply_reviewed_operations(
+            text, [self._decision(operation)]
+        )
+
+        self.assertFalse(result.success)
+        self.assertEqual(text, result.transformed_text)
+        self.assertIn("does not match", result.failures[0].message)
+
+    def test_insert_and_remove_operations_apply_non_destructively(self):
+        text = "abcd"
+        insert = self._operation(
+            "insert",
+            2,
+            2,
+            "",
+            "X",
+            span_ops.INSERT_SPAN,
+        )
+        remove = self._operation(
+            "remove",
+            3,
+            4,
+            "d",
+            "",
+            span_ops.REMOVE_SPAN,
+        )
+
+        result = application.apply_reviewed_operations(
+            text,
+            [self._decision(remove), self._decision(insert)],
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual("abXc", result.transformed_text)
+        self.assertEqual("abcd", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/analysis_tests/application_test.py
+++ b/lcats/tests/analysis_tests/application_test.py
@@ -114,6 +114,36 @@ class ApplicationTest(unittest.TestCase):
             ["quote", "ellipsis"], [r.operation_id for r in second.applied]
         )
 
+    def test_override_ordering_uses_replacement_operation_span(self):
+        text = "A â€™ B â€¦ C"
+        later_reviewed = self._operation("later-reviewed", 8, 11, "â€¦", "…")
+        earlier_replacement = self._operation("earlier-replacement", 2, 5, "â€™", "'")
+        middle = self._operation("middle", 8, 11, "â€¦", "…")
+
+        result = application.apply_reviewed_operations(
+            text,
+            [
+                self._decision(middle, review.APPROVED),
+                self._decision(
+                    later_reviewed,
+                    review.OVERRIDDEN,
+                    review.SpanOperationOverride(
+                        replacement_operation=earlier_replacement,
+                        rationale="Move override to actual reviewed span.",
+                    ),
+                ),
+            ],
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(
+            ["earlier-replacement", "middle"], [r.operation_id for r in result.applied]
+        )
+        self.assertEqual(
+            ["earlier-replacement", "middle"],
+            [r.operation_id for r in result.considered],
+        )
+
     def test_overlapping_operations_fail_without_partial_output(self):
         text = "abcdef"
         first = self._operation("first", 1, 4, "bcd", "BCD")
@@ -125,6 +155,7 @@ class ApplicationTest(unittest.TestCase):
         )
 
         self.assertFalse(result.success)
+        self.assertEqual((), result.applied)
         self.assertEqual(text, result.transformed_text)
         self.assertIn("overlapping spans", result.failures[0].message)
 
@@ -137,7 +168,10 @@ class ApplicationTest(unittest.TestCase):
         )
 
         self.assertFalse(result.success)
+        self.assertEqual((), result.applied)
         self.assertEqual(text, result.transformed_text)
+        self.assertEqual("invalid", result.failures[0].operation_id)
+        self.assertEqual("decision-invalid-approved", result.failures[0].decision_id)
         self.assertIn("exceeds text length", result.failures[0].message)
 
     def test_original_text_mismatch_fails_without_partial_output(self):


### PR DESCRIPTION
### Motivation
- Provide a safe, deterministic application stage that converts reviewed span operations into non-destructive transformed text outputs.  
- Ensure only `approved` or `overridden` span operations are applied while `pending` and `rejected` operations are audited and skipped.  
- Fail clearly on conflicts, invalid spans, or source-text mismatches and preserve auditability for reproducibility and review traceability.

### Description
- Add new application layer `lcats.analysis.corpus.application` with `apply_reviewed_operations(text, decisions)` producing an `ApplicationResult` that contains `original_text`, `transformed_text`, `considered`, `applied`, `skipped`, and `failures` report objects.  
- Enforce eligibility rules by using existing review helpers (`is_span_operation_review_eligible_for_application` and `operation_for_application`) so only `approved` or `overridden` operations are selected; `pending`/`rejected` decisions are recorded as skipped.  
- Validate and enforce deterministic ordering and conflict safety using `span_ops.operation_sort_key`, `span_ops.sort_operations`, and `span_ops.validate_operation_set`, and run per-operation checks against the source text to detect out-of-bounds spans or `original_text` mismatches before applying anything.  
- Apply operations non-destructively (right-to-left application of validated, non-overlapping operations) and add structured audit/reporting types `ApplicationDecisionReport` and `ApplicationFailure` to preserve which decisions were considered, applied, skipped, or failed.  
- Add unit tests `lcats/tests/analysis_tests/application_test.py` covering eligibility, overrides, deterministic ordering, overlap/conflict rejection, invalid-span and mismatch failures, insert/remove semantics, non-destructive behavior, and result serialization.  
- Update `lcats/lcats/analysis/corpus/README.md` to describe the approved application stage and add a lightweight execution record `lcats/project/executions/2026-06-18-WI-APPLY-0005.md` plus a `project/memory/decision_log.md` entry noting the work item completion and deferrals.

### Testing
- Ran the new focused unit tests with `python -m unittest tests.analysis_tests.application_test`, which passed.  
- Ran the repository test suite with `scripts/test` (all tests passed).  
- Ran formatting and lint checks for changed files: `python -m black --check` and `python -m ruff check` passed for the new/modified files; `scripts/format --check` flagged an unrelated pre-existing formatting drift in `lcats/lcats/gettenberg/metadata.py` but did not affect the changes in this PR.  
- Soft idempotence check recorded in the execution record: no prior execution record for this prompt ID was found, so the implementation proceeded and the result was recorded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3378cb29e48327b320b12e6d7b0e43)