### PR TITLE
Add lcats assess command for corpus quality and genre assessment

### DIFF
--- a/lcats/lcats/analysis/corpus/assess.py
+++ b/lcats/lcats/analysis/corpus/assess.py
@@ -168,14 +168,14 @@ def _format_findings(findings: list) -> str:
     )
 
 
-def assess_story(
+def run_preflight(
     file_path: pathlib.Path,
-    genre: str,
-    client,
-    model: str = "claude-opus-4-8",
-    max_body_chars: int = 100_000,
-) -> AssessmentResult:
-    """Assess a single corpus JSON file for quality and genre fit."""
+) -> tuple[str, str, str, list, str]:
+    """Read a story file and run QA detectors without calling the API.
+
+    Returns (title, author, url, findings, full_body). Raises on file or parse
+    errors.
+    """
     from lcats.analysis.corpus.cli import (
         coerce_story_text,
         infer_story_title,
@@ -188,27 +188,42 @@ def assess_story(
     metadata = data.get("metadata") or {}
     author = metadata.get("author", "Unknown")
     url = metadata.get("url", "")
-
     full_body = coerce_story_text(data.get("body", ""))
     findings = qa.run_detectors(full_body)
-    findings_text = _format_findings(findings)
+    return title, author, url, findings, full_body
 
-    body = full_body
-    if max_body_chars and len(body) > max_body_chars:
-        body = body[:max_body_chars] + "\n\n[... text truncated ...]"
 
-    system_prompt = SYSTEM_PROMPT_TEMPLATE.format(genre=genre)
-    user_message = (
-        f"STORY METADATA:\n"
-        f"Title: {title}\n"
-        f"Author: {author}\n"
-        f"Source URL: {url}\n"
-        f"Claimed genre: {genre}\n"
-        f"\nPRE-FLIGHT QA FINDINGS:\n{findings_text}\n"
-        f"\nSTORY TEXT:\n{body}"
-    )
+def assess_story(
+    file_path: pathlib.Path,
+    genre: str,
+    client,
+    model: str = "claude-opus-4-8",
+    max_body_chars: int = 100_000,
+) -> AssessmentResult:
+    """Assess a single corpus JSON file for quality and genre fit."""
+    title = file_path.stem
+    author = "Unknown"
+    url = ""
 
     try:
+        title, author, url, findings, full_body = run_preflight(file_path)
+        findings_text = _format_findings(findings)
+
+        body = full_body
+        if max_body_chars and len(body) > max_body_chars:
+            body = body[:max_body_chars] + "\n\n[... text truncated ...]"
+
+        system_prompt = SYSTEM_PROMPT_TEMPLATE.format(genre=genre)
+        user_message = (
+            f"STORY METADATA:\n"
+            f"Title: {title}\n"
+            f"Author: {author}\n"
+            f"Source URL: {url}\n"
+            f"Claimed genre: {genre}\n"
+            f"\nPRE-FLIGHT QA FINDINGS:\n{findings_text}\n"
+            f"\nSTORY TEXT:\n{body}"
+        )
+
         with client.messages.stream(
             model=model,
             max_tokens=2048,

--- a/lcats/lcats/analysis/corpus/assess.py
+++ b/lcats/lcats/analysis/corpus/assess.py
@@ -1,0 +1,264 @@
+"""Story quality and genre assessment using the Claude API."""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import asdict, dataclass, field
+
+VALID_GENRES = ("science fiction", "horror", "western", "romance")
+
+ASSESSMENT_TOOL = {
+    "name": "record_story_assessment",
+    "description": "Record a structured quality and genre assessment for a story.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "verdict": {
+                "type": "string",
+                "enum": ["include", "exclude", "review"],
+                "description": (
+                    "include: wellformed + correct genre + no disqualifying issues. "
+                    "exclude: incomplete story, wrong genre, or serious quality problems. "
+                    "review: borderline — reasonable people could disagree."
+                ),
+            },
+            "exclude_reason": {
+                "type": "string",
+                "description": (
+                    "If verdict is exclude or review, a brief explanation. "
+                    "Omit or leave empty for include."
+                ),
+            },
+            "wellformed": {
+                "type": "boolean",
+                "description": (
+                    "True if the story has a clear beginning and ending and reads "
+                    "as a complete standalone narrative."
+                ),
+            },
+            "genre_match": {
+                "type": "string",
+                "enum": ["confirmed", "disputed", "wrong"],
+                "description": "Whether the story belongs to the claimed target genre.",
+            },
+            "genre_confidence": {
+                "type": "number",
+                "description": "Confidence in the genre assessment, 0.0 to 1.0.",
+            },
+            "genre_suggestion": {
+                "type": "string",
+                "description": (
+                    "If genre_match is wrong or disputed, the most likely actual genre. "
+                    "Omit or leave empty otherwise."
+                ),
+            },
+            "specials_verdict": {
+                "type": "string",
+                "enum": ["author_intentional", "extraction_artifact", "error", "none"],
+                "description": (
+                    "Assessment of any non-ASCII or unusual characters in the text. "
+                    "author_intentional: dialect, verse, period typography, accented names. "
+                    "extraction_artifact: mojibake, garbled encoding, OCR errors. "
+                    "error: clearly corrupted, unreadable passages. "
+                    "none: no unusual characters present."
+                ),
+            },
+            "summary": {
+                "type": "string",
+                "description": "One to two sentence plot summary of the story.",
+            },
+            "issues": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": (
+                                "Issue category: transcriber_note, copyright_notice, "
+                                "toc_remnant, formatting_artifact, incomplete_text, or other."
+                            ),
+                        },
+                        "severity": {
+                            "type": "string",
+                            "enum": ["low", "medium", "high"],
+                        },
+                        "description": {"type": "string"},
+                    },
+                    "required": ["type", "severity", "description"],
+                },
+                "description": "Quality issues found in the story text.",
+            },
+        },
+        "required": [
+            "verdict",
+            "wellformed",
+            "genre_match",
+            "genre_confidence",
+            "specials_verdict",
+            "summary",
+            "issues",
+        ],
+    },
+}
+
+SYSTEM_PROMPT_TEMPLATE = """\
+You are a literary corpus quality assessor for a {genre} fiction research project.
+
+Assess the provided story for inclusion in a curated corpus:
+
+WELLFORMEDNESS: Does the story have a clear beginning and ending? Is it a complete \
+standalone narrative — not a chapter fragment, excerpt, or part of a longer work?
+
+GENRE ACCURACY: Does the story actually belong to the genre "{genre}"?
+  - science fiction: speculative technology, space, aliens, time travel, future societies
+  - horror: dread, supernatural threat, psychological terror, monsters, dark atmosphere
+  - western: frontier American West, cowboys, outlaws, settlers, frontier justice
+  - romance: central love story with emotional relationship development as the primary plot
+
+SPECIAL CHARACTERS: If the story contains non-ASCII or unusual characters, are they:
+  - author_intentional: dialect spelling, verse, period typography, accented names
+  - extraction_artifact: mojibake, garbled encoding, OCR errors, encoding artifacts
+  - error: clearly corrupted, unreadable text passages
+  - none: no unusual characters
+
+QUALITY ISSUES: Flag any:
+  - Transcriber notes, editor commentary, or Project Gutenberg boilerplate inside the body
+  - Copyright notices, disclaimers, or legal text embedded in the story body
+  - Tables of contents, chapter listings, or front matter inside the text
+  - Significant formatting artifacts (stray markup, repeated separators, etc.)
+
+VERDICT RULES:
+  - include: wellformed + correct genre + no disqualifying issues
+  - exclude: incomplete story, wrong genre, or serious quality problems
+  - review: borderline case — reasonable people could disagree
+
+Record your assessment using the record_story_assessment tool. \
+Keep the summary to one or two sentences.\
+"""
+
+
+@dataclass
+class AssessmentResult:
+    file_path: str
+    title: str
+    author: str
+    url: str
+    target_genre: str
+    verdict: str
+    exclude_reason: str = ""
+    wellformed: bool = True
+    genre_match: str = "confirmed"
+    genre_confidence: float = 1.0
+    genre_suggestion: str = ""
+    specials_verdict: str = "none"
+    summary: str = ""
+    issues: list = field(default_factory=list)
+    error: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _format_findings(findings: list) -> str:
+    if not findings:
+        return "None detected."
+    return "\n".join(
+        f"- [{f.severity.upper()}] {f.kind}: {f.message}" for f in findings
+    )
+
+
+def assess_story(
+    file_path: pathlib.Path,
+    genre: str,
+    client,
+    model: str = "claude-opus-4-8",
+    max_body_chars: int = 100_000,
+) -> AssessmentResult:
+    """Assess a single corpus JSON file for quality and genre fit."""
+    from lcats.analysis.corpus.cli import (
+        coerce_story_text,
+        infer_story_title,
+        read_story_data,
+    )
+    from lcats.analysis.corpus import qa
+
+    data = read_story_data(file_path)
+    title = infer_story_title(data, file_path)
+    metadata = data.get("metadata") or {}
+    author = metadata.get("author", "Unknown")
+    url = metadata.get("url", "")
+
+    full_body = coerce_story_text(data.get("body", ""))
+    findings = qa.run_detectors(full_body)
+    findings_text = _format_findings(findings)
+
+    body = full_body
+    if max_body_chars and len(body) > max_body_chars:
+        body = body[:max_body_chars] + "\n\n[... text truncated ...]"
+
+    system_prompt = SYSTEM_PROMPT_TEMPLATE.format(genre=genre)
+    user_message = (
+        f"STORY METADATA:\n"
+        f"Title: {title}\n"
+        f"Author: {author}\n"
+        f"Source URL: {url}\n"
+        f"Claimed genre: {genre}\n"
+        f"\nPRE-FLIGHT QA FINDINGS:\n{findings_text}\n"
+        f"\nSTORY TEXT:\n{body}"
+    )
+
+    try:
+        with client.messages.stream(
+            model=model,
+            max_tokens=2048,
+            system=system_prompt,
+            tools=[ASSESSMENT_TOOL],
+            tool_choice={"type": "tool", "name": "record_story_assessment"},
+            messages=[{"role": "user", "content": user_message}],
+        ) as stream:
+            message = stream.get_final_message()
+
+        tool_block = next(
+            (b for b in message.content if b.type == "tool_use"),
+            None,
+        )
+        if tool_block is None:
+            return AssessmentResult(
+                file_path=str(file_path),
+                title=title,
+                author=author,
+                url=url,
+                target_genre=genre,
+                verdict="review",
+                error="No tool_use block in API response",
+            )
+
+        a = tool_block.input
+        return AssessmentResult(
+            file_path=str(file_path),
+            title=title,
+            author=author,
+            url=url,
+            target_genre=genre,
+            verdict=a.get("verdict", "review"),
+            exclude_reason=a.get("exclude_reason", ""),
+            wellformed=bool(a.get("wellformed", True)),
+            genre_match=a.get("genre_match", "confirmed"),
+            genre_confidence=float(a.get("genre_confidence", 1.0)),
+            genre_suggestion=a.get("genre_suggestion", ""),
+            specials_verdict=a.get("specials_verdict", "none"),
+            summary=a.get("summary", ""),
+            issues=list(a.get("issues", [])),
+        )
+
+    except Exception as exc:
+        return AssessmentResult(
+            file_path=str(file_path),
+            title=title,
+            author=author,
+            url=url,
+            target_genre=genre,
+            verdict="review",
+            error=str(exc),
+        )

--- a/lcats/lcats/analysis/corpus/assess_cli.py
+++ b/lcats/lcats/analysis/corpus/assess_cli.py
@@ -1,0 +1,242 @@
+"""CLI for the lcats assess subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import pathlib
+import sys
+from typing import Optional, Sequence
+
+import tqdm
+
+from lcats.analysis.corpus import discovery
+from lcats.analysis.corpus.assess import VALID_GENRES, AssessmentResult, assess_story
+
+TSV_COLUMNS = [
+    "file_path",
+    "title",
+    "author",
+    "target_genre",
+    "verdict",
+    "genre_match",
+    "genre_confidence",
+    "wellformed",
+    "specials_verdict",
+    "summary",
+    "exclude_reason",
+    "genre_suggestion",
+    "issues_count",
+    "url",
+    "error",
+]
+
+
+def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
+    """Build parser for the assess subcommand."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Assess corpus story JSON files for quality and genre fit using the Claude API."
+        ),
+        add_help=add_help,
+        epilog=(
+            "Examples:\n"
+            "  lcats assess corpora/sherlock --genre 'science fiction'\n"
+            "  lcats assess data/ --genre horror --format tsv --output horror_assessment.tsv\n"
+            "  lcats assess corpora/sherlock --genre western --dry-run\n"
+            "  ANTHROPIC_API_KEY=sk-... lcats assess data/ --genre romance --model claude-haiku-4-5"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "directories",
+        nargs="*",
+        default=["data/"],
+        help="Directories or JSON files to assess (default: data/).",
+    )
+    parser.add_argument(
+        "--genre",
+        required=True,
+        choices=list(VALID_GENRES),
+        metavar="GENRE",
+        help=(
+            f"Target genre for assessment. Choices: {', '.join(VALID_GENRES)}. "
+            "Quote multi-word genres: --genre 'science fiction'."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        default="claude-opus-4-8",
+        help="Claude model to use (default: claude-opus-4-8).",
+    )
+    parser.add_argument(
+        "--max-body-chars",
+        type=int,
+        default=100_000,
+        help="Max story body characters sent to the API (default: 100000).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["jsonl", "json", "tsv", "human"],
+        default="jsonl",
+        help="Output format (default: jsonl).",
+    )
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Write output to FILE instead of stdout.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run pre-flight QA checks and list files without calling the API.",
+    )
+    parser.add_argument("--progress", dest="progress", action="store_true")
+    parser.add_argument("--no-progress", dest="progress", action="store_false")
+    parser.set_defaults(progress=None)
+    return parser
+
+
+def _show_progress(progress_arg: Optional[bool]) -> bool:
+    if progress_arg is not None:
+        return progress_arg
+    return sys.stderr.isatty()
+
+
+def _result_to_tsv_row(result: AssessmentResult) -> dict:
+    return {
+        "file_path": result.file_path,
+        "title": result.title,
+        "author": result.author,
+        "target_genre": result.target_genre,
+        "verdict": result.verdict,
+        "genre_match": result.genre_match,
+        "genre_confidence": f"{result.genre_confidence:.2f}",
+        "wellformed": "yes" if result.wellformed else "no",
+        "specials_verdict": result.specials_verdict,
+        "summary": result.summary,
+        "exclude_reason": result.exclude_reason,
+        "genre_suggestion": result.genre_suggestion,
+        "issues_count": str(len(result.issues)),
+        "url": result.url,
+        "error": result.error,
+    }
+
+
+def _write_human(out, result: AssessmentResult) -> None:
+    symbol = {"include": "✓", "exclude": "✗", "review": "?"}.get(result.verdict, "?")
+    print(f"{symbol} [{result.verdict.upper()}] {result.title}", file=out)
+    print(f"  Author:  {result.author}", file=out)
+    print(
+        f"  Genre:   {result.target_genre} → {result.genre_match} "
+        f"({result.genre_confidence:.0%})",
+        file=out,
+    )
+    if result.summary:
+        print(f"  Summary: {result.summary}", file=out)
+    for issue in result.issues:
+        print(
+            f"  Issue [{issue['severity']}]: {issue['type']} — {issue['description']}",
+            file=out,
+        )
+    if result.exclude_reason:
+        print(f"  Reason:  {result.exclude_reason}", file=out)
+    if result.error:
+        print(f"  ERROR:   {result.error}", file=out)
+    print(file=out)
+
+
+def run(
+    argv: Optional[Sequence[str]] = None,
+    parsed_args: Optional[argparse.Namespace] = None,
+) -> int:
+    """Run the assess subcommand."""
+    parser = build_parser()
+    args = parsed_args if parsed_args is not None else parser.parse_args(argv)
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not args.dry_run and not api_key:
+        print(
+            "error: ANTHROPIC_API_KEY environment variable is not set.\n"
+            "       Set it or use --dry-run to preview without API calls.",
+            file=sys.stderr,
+        )
+        return 1
+
+    client = None
+    if not args.dry_run:
+        try:
+            import anthropic
+
+            client = anthropic.Anthropic(api_key=api_key)
+        except ImportError:
+            print(
+                "error: 'anthropic' package is not installed.\n"
+                "       Run: pip install anthropic",
+                file=sys.stderr,
+            )
+            return 1
+
+    files = list(discovery.find_json_files(args.directories))
+    if not files:
+        print("No JSON files found in the specified paths.", file=sys.stderr)
+        return 0
+
+    output_stream = sys.stdout
+    try:
+        if args.output:
+            output_stream = pathlib.Path(args.output).open(
+                "w", encoding="utf-8", newline=""
+            )
+
+        tsv_writer = None
+        if args.format == "tsv":
+            tsv_writer = csv.DictWriter(
+                output_stream,
+                fieldnames=TSV_COLUMNS,
+                delimiter="\t",
+                extrasaction="ignore",
+            )
+            tsv_writer.writeheader()
+
+        all_results = []
+        for file_path in tqdm.tqdm(files, disable=not _show_progress(args.progress)):
+            if args.dry_run:
+                print(f"[dry-run] {file_path}", file=sys.stderr)
+                continue
+
+            result = assess_story(
+                file_path=file_path,
+                genre=args.genre,
+                client=client,
+                model=args.model,
+                max_body_chars=args.max_body_chars,
+            )
+
+            if args.format == "jsonl":
+                print(json.dumps(result.to_dict()), file=output_stream)
+                output_stream.flush()
+            elif args.format == "json":
+                all_results.append(result.to_dict())
+            elif args.format == "tsv":
+                tsv_writer.writerow(_result_to_tsv_row(result))
+                output_stream.flush()
+            elif args.format == "human":
+                _write_human(output_stream, result)
+
+        if args.format == "json" and all_results:
+            json.dump(all_results, output_stream, indent=2)
+            print(file=output_stream)
+
+        return 0
+
+    except BrokenPipeError:
+        return 141
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        if output_stream is not sys.stdout:
+            output_stream.close()

--- a/lcats/lcats/analysis/corpus/assess_cli.py
+++ b/lcats/lcats/analysis/corpus/assess_cli.py
@@ -13,7 +13,12 @@ from typing import Optional, Sequence
 import tqdm
 
 from lcats.analysis.corpus import discovery
-from lcats.analysis.corpus.assess import VALID_GENRES, AssessmentResult, assess_story
+from lcats.analysis.corpus.assess import (
+    VALID_GENRES,
+    AssessmentResult,
+    assess_story,
+    run_preflight,
+)
 
 TSV_COLUMNS = [
     "file_path",
@@ -125,6 +130,24 @@ def _result_to_tsv_row(result: AssessmentResult) -> dict:
     }
 
 
+def _dry_run_preview(file_path: pathlib.Path, genre: str, out) -> None:
+    try:
+        title, author, url, findings, _body = run_preflight(file_path)
+        print(f"[dry-run] {file_path}", file=out)
+        print(f"  Title:    {title}", file=out)
+        print(f"  Author:   {author}", file=out)
+        print(f"  Genre:    {genre}", file=out)
+        if findings:
+            print(f"  QA findings ({len(findings)}):", file=out)
+            for f in findings:
+                print(f"    [{f.severity.upper()}] {f.kind}: {f.message}", file=out)
+        else:
+            print("  QA findings: none", file=out)
+    except Exception as exc:
+        print(f"[dry-run] {file_path} — ERROR: {exc}", file=out)
+    print(file=out)
+
+
 def _write_human(out, result: AssessmentResult) -> None:
     symbol = {"include": "✓", "exclude": "✗", "review": "?"}.get(result.verdict, "?")
     print(f"{symbol} [{result.verdict.upper()}] {result.title}", file=out)
@@ -155,6 +178,13 @@ def run(
     """Run the assess subcommand."""
     parser = build_parser()
     args = parsed_args if parsed_args is not None else parser.parse_args(argv)
+
+    if args.max_body_chars < 0:
+        print(
+            "error: --max-body-chars must be >= 0 (use 0 for no truncation)",
+            file=sys.stderr,
+        )
+        return 1
 
     api_key = os.environ.get("ANTHROPIC_API_KEY", "")
     if not args.dry_run and not api_key:
@@ -204,7 +234,7 @@ def run(
         all_results = []
         for file_path in tqdm.tqdm(files, disable=not _show_progress(args.progress)):
             if args.dry_run:
-                print(f"[dry-run] {file_path}", file=sys.stderr)
+                _dry_run_preview(file_path, args.genre, output_stream)
                 continue
 
             result = assess_story(

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -4,6 +4,7 @@ import argparse
 import pathlib
 import sys
 
+from lcats.analysis.corpus import assess_cli
 from lcats.analysis.corpus import cli as corpus_cli
 from lcats.analysis.corpus import repairs_cli
 import lcats.gatherers.main
@@ -42,6 +43,10 @@ def _handle_survey(args):
 
 def _handle_stats(args):
     return "", corpus_cli.run_stats(parsed_args=args)
+
+
+def _handle_assess(args):
+    return "", assess_cli.run(parsed_args=args)
 
 
 def _handle_repair_specials(args):
@@ -165,6 +170,28 @@ def build_parser() -> argparse.ArgumentParser:
     )
     survey_parser.set_defaults(handler=_handle_survey)
     command_parsers["survey"] = survey_parser
+
+    assess_parent = assess_cli.build_parser(add_help=False)
+    assess_parser = subparsers.add_parser(
+        "assess",
+        parents=[assess_parent],
+        help="Assess corpus stories for quality and genre fit using the Claude API.",
+        description=(
+            "Assess LCATS corpus JSON files for quality and genre fit. "
+            "Calls the Claude API to produce structured include/exclude/review verdicts, "
+            "genre confidence scores, issue lists, and story summaries."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  lcats assess corpora/sherlock --genre 'science fiction'\n"
+            "  lcats assess data/ --genre horror --format tsv --output horror.tsv\n"
+            "  lcats assess data/ --genre western --dry-run\n"
+            "  ANTHROPIC_API_KEY=sk-... lcats assess corpora/ --genre romance --progress"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    assess_parser.set_defaults(handler=_handle_assess)
+    command_parsers["assess"] = assess_parser
 
     stats_parent = corpus_cli.build_stats_parser(add_help=False)
     stats_parser = subparsers.add_parser(

--- a/lcats/project/executions/AD_HOC/2026_06_29_19_18_19_ASSESS_COMMAND_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_06_29_19_18_19_ASSESS_COMMAND_REVIEW.md
@@ -1,0 +1,49 @@
+---
+execution_id: 2026_06_29_19_18_19_ASSESS_COMMAND_REVIEW
+prompt_id: PROMPT(AD_HOC:ASSESS_COMMAND_REVIEW)[2026-06-29T19:04:48-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/98
+commit: 0543850
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/98
+session_transcript: pending
+created_at: 2026-06-29T19:18:19-04:00
+---
+
+# Summary
+
+Address three reviewer-identified issues on PR #98 (lcats assess command):
+1. File read/QA failures escaped the per-story try/except in assess_story(),
+   aborting the entire batch on a single bad JSON file.
+2. --dry-run only printed file paths; it now runs QA detectors and shows
+   findings for each story before the API call.
+3. --max-body-chars accepted negative values, breaking truncation logic.
+
+# Result
+
+- Extracted run_preflight() helper in assess.py that reads the file, runs
+  qa.run_detectors(), and returns (title, author, url, findings, full_body).
+- assess_story() now initializes safe defaults for title/author/url before the
+  try block and wraps the entire pipeline (preflight + API call) in one
+  try/except, so per-story errors are captured in the error field.
+- Added _dry_run_preview() in assess_cli.py that calls run_preflight() and
+  prints title, author, genre, and QA findings to the output stream.
+- Added --max-body-chars >= 0 validation in run() with a clear error message.
+
+# Validation
+
+- scripts/format --check: passed (metadata.py pre-existing drift absorbed
+  separately; assess.py and assess_cli.py pass cleanly)
+- scripts/lint: passed (ruff + black)
+- scripts/test: 468 tests; 25 errors all due to ModuleNotFoundError for
+  tiktoken — pre-existing environment dependency, not a regression from
+  this change.
+
+# Follow-up
+
+- Pre-existing tiktoken import failure in test suite should be resolved
+  by running scripts/develop in an environment with all dependencies installed.
+- metadata.py has pre-existing Black 24.10.0 formatting drift; can be
+  addressed in a separate cleanup pass.

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
    "matplotlib",
    "seaborn",
    "gutenbergpy @ git+https://github.com/xenotaur/gutenbergpy.git@LCATS/TitleFix",
+   "anthropic",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary

- Adds a new `lcats assess` subcommand that calls the Claude API to assess corpus story JSON files for quality and genre fit
- Produces structured **include / exclude / review** verdicts with genre confidence scores, wellformedness checks, special-character verdicts, issue lists, and 1-2 sentence story summaries
- Supports four output formats: `jsonl` (default, streaming), `json`, `tsv` (spreadsheet-ready), and `human` (terminal-friendly)
- Integrates with the existing pre-flight QA pipeline (`run_detectors`) so automated findings augment the model assessment prompt

## What changed

| File | Change |
|---|---|
| `lcats/analysis/corpus/assess.py` | New: core assessment logic -- Claude tool schema enforcing structured output, `AssessmentResult` dataclass, `assess_story()` function |
| `lcats/analysis/corpus/assess_cli.py` | New: CLI handler -- `build_parser()`, `run()`, four output renderers, `--dry-run` mode, streaming flush for long batch runs |
| `lcats/cli.py` | Register `assess` subparser and `_handle_assess` handler |
| `pyproject.toml` | Add `anthropic` as a dependency |

## Usage

```bash
# Dry run -- list files and QA findings without spending API credits
lcats assess corpora/sherlock --genre 'science fiction' --dry-run

# Full batch assessment, streaming JSONL
ANTHROPIC_API_KEY=sk-... lcats assess corpora/sherlock --genre 'science fiction'

# TSV for bulk spreadsheet import
lcats assess data/ --genre horror --format tsv --output horror_assessment.tsv

# Human-readable with progress bar
lcats assess data/ --genre western --format human --progress

# Cheaper model for exploratory runs
lcats assess data/ --genre romance --model claude-haiku-4-5
```

## Design notes

- Uses Claude **tool use** to enforce structured JSON output -- more reliable than prompting for JSON directly
- Pre-flight QA runs on the **full** story body before any truncation, so findings reflect the complete text even when the API prompt is capped by `--max-body-chars`
- Errors per story are captured in the `error` field and never abort the whole run -- makes batch processing fault-tolerant
- Target genres (science fiction, horror, western, romance) are validated at the CLI layer

## Test plan

- [ ] `lcats assess --help` shows the new subcommand
- [ ] `lcats assess <dir> --genre 'science fiction' --dry-run` lists files without hitting the API
- [ ] `lcats assess <story.json> --genre horror --format human` produces a readable assessment
- [ ] `lcats assess <dir> --genre western --format tsv --output out.tsv` writes a valid TSV with headers
- [ ] Missing `ANTHROPIC_API_KEY` without `--dry-run` prints a clear error and exits 1
- [ ] A story in the wrong genre is marked `genre_match: wrong` with a `genre_suggestion`

Generated with [Claude Code](https://claude.com/claude-code)
