### PR TITLE
Implement WI-LLM-0007: create lcats/llm package with LLMBackend Protocol

### DIFF
--- a/lcats/lcats/llm/__init__.py
+++ b/lcats/lcats/llm/__init__.py
@@ -1,0 +1,1 @@
+"""Unified LLM backend abstraction: LLMBackend Protocol and provider adapters."""

--- a/lcats/lcats/llm/anthropic_backend.py
+++ b/lcats/lcats/llm/anthropic_backend.py
@@ -1,0 +1,83 @@
+"""AnthropicBackend: LLMBackend adapter for the Anthropic Messages API."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from lcats.llm import backend
+
+
+class AnthropicBackend:
+    """LLMBackend implementation backed by the Anthropic Messages API.
+
+    Uses streaming (`messages.stream`) by default to avoid gateway timeouts
+    on large story inputs (typical bodies are 40-100K characters). Set
+    `use_streaming=False` for a blocking call instead.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, use_streaming: bool = True):
+        """Construct an Anthropic-backed LLMBackend.
+
+        Args:
+            api_key: Optional API key. When omitted, the Anthropic SDK reads
+                the ANTHROPIC_API_KEY environment variable.
+            use_streaming: Whether to use the streaming call internally.
+
+        Raises:
+            ImportError: If the `anthropic` package is not installed.
+        """
+        import anthropic
+
+        self._client = anthropic.Anthropic(api_key=api_key)
+        self._use_streaming = use_streaming
+
+    def complete(
+        self,
+        *,
+        system: str,
+        messages: list,
+        model: str,
+        temperature: float = 0.2,
+        max_tokens: int = 4096,
+        tool: Optional[dict] = None,
+    ) -> backend.BackendResponse:
+        """See lcats.llm.backend.LLMBackend.complete."""
+        kwargs = dict(
+            model=model,
+            system=system,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        if tool:
+            kwargs["tools"] = [tool]
+            kwargs["tool_choice"] = {"type": "tool", "name": tool["name"]}
+
+        if self._use_streaming:
+            with self._client.messages.stream(**kwargs) as stream:
+                message = stream.get_final_message()
+        else:
+            message = self._client.messages.create(**kwargs)
+
+        if tool:
+            tool_block = next(
+                block for block in message.content if block.type == "tool_use"
+            )
+            tool_result = tool_block.input
+            text = ""
+        else:
+            text = next(
+                (block.text for block in message.content if block.type == "text"),
+                "",
+            )
+            tool_result = None
+
+        usage = message.usage
+        return backend.BackendResponse(
+            text=text,
+            tool_result=tool_result,
+            model=message.model,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            raw=message,
+        )

--- a/lcats/lcats/llm/anthropic_backend.py
+++ b/lcats/lcats/llm/anthropic_backend.py
@@ -49,7 +49,7 @@ class AnthropicBackend:
             max_tokens=max_tokens,
             temperature=temperature,
         )
-        if tool:
+        if tool is not None:
             kwargs["tools"] = [tool]
             kwargs["tool_choice"] = {"type": "tool", "name": tool["name"]}
 
@@ -59,10 +59,17 @@ class AnthropicBackend:
         else:
             message = self._client.messages.create(**kwargs)
 
-        if tool:
+        if tool is not None:
             tool_block = next(
-                block for block in message.content if block.type == "tool_use"
+                (block for block in message.content if block.type == "tool_use"),
+                None,
             )
+            if tool_block is None:
+                content_types = [b.type for b in message.content]
+                raise ValueError(
+                    f"API returned no tool_use block for tool {tool['name']!r}; "
+                    f"content types: {content_types}"
+                )
             tool_result = tool_block.input
             text = ""
         else:

--- a/lcats/lcats/llm/backend.py
+++ b/lcats/lcats/llm/backend.py
@@ -1,0 +1,68 @@
+"""LLMBackend Protocol and BackendResponse for unified LLM API access."""
+
+from __future__ import annotations
+
+import dataclasses
+
+from typing import Any, Optional, Protocol, runtime_checkable
+
+
+@dataclasses.dataclass
+class BackendResponse:
+    """Normalized result of an LLMBackend.complete() call.
+
+    Attributes:
+        text: Free-text model output. Empty string when `tool` was provided.
+        tool_result: Structured tool-use output. None when no tool was used.
+        model: Exact model string echoed back by the provider's API response.
+        input_tokens: Number of input/prompt tokens reported by the API.
+        output_tokens: Number of output/completion tokens reported by the API.
+        raw: The raw, provider-specific SDK response object, for debugging.
+    """
+
+    text: str
+    tool_result: Optional[dict]
+    model: str
+    input_tokens: int
+    output_tokens: int
+    raw: Any = dataclasses.field(repr=False, default=None)
+
+
+@runtime_checkable
+class LLMBackend(Protocol):
+    """Structural protocol for a single-call LLM backend.
+
+    Implementations adapt a specific provider SDK (OpenAI, Anthropic, ...)
+    to this normalized call shape so callers can switch providers by
+    swapping the backend instance, without touching prompt or call-site code.
+    """
+
+    def complete(
+        self,
+        *,
+        system: str,
+        messages: list,
+        model: str,
+        temperature: float = 0.2,
+        max_tokens: int = 4096,
+        tool: Optional[dict] = None,
+    ) -> BackendResponse:
+        """Run one completion call and return a normalized response.
+
+        Args:
+            system: System prompt text.
+            messages: Chat messages excluding the system prompt, e.g.
+                [{"role": "user", "content": "..."}].
+            model: Provider-specific model identifier.
+            temperature: Sampling temperature.
+            max_tokens: Maximum tokens to generate.
+            tool: Optional single tool schema. When provided, the backend
+                forces the model to call this tool and returns its
+                arguments in `BackendResponse.tool_result`. When None, the
+                backend requests free-form JSON-friendly text output in
+                `BackendResponse.text`.
+
+        Returns:
+            A BackendResponse with normalized fields.
+        """
+        ...

--- a/lcats/lcats/llm/fake_backend.py
+++ b/lcats/lcats/llm/fake_backend.py
@@ -1,0 +1,61 @@
+"""FakeBackend: deterministic LLMBackend test double."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from lcats.llm import backend
+
+
+class FakeBackend:
+    """Deterministic LLMBackend test double.
+
+    Records every call's keyword arguments in `self.calls` for assertion,
+    and always returns a fixed BackendResponse built from the constructor
+    arguments.
+    """
+
+    def __init__(
+        self,
+        response_text: str = "",
+        tool_result: Optional[dict] = None,
+        model: str = "fake-1.0",
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+    ):
+        self.response_text = response_text
+        self.tool_result = tool_result
+        self.model = model
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.calls = []
+
+    def complete(
+        self,
+        *,
+        system: str,
+        messages: list,
+        model: str,
+        temperature: float = 0.2,
+        max_tokens: int = 4096,
+        tool: Optional[dict] = None,
+    ) -> backend.BackendResponse:
+        """Record the call and return the fixed response."""
+        self.calls.append(
+            dict(
+                system=system,
+                messages=messages,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tool=tool,
+            )
+        )
+        return backend.BackendResponse(
+            text=self.response_text,
+            tool_result=self.tool_result,
+            model=self.model,
+            input_tokens=self.input_tokens,
+            output_tokens=self.output_tokens,
+            raw=None,
+        )

--- a/lcats/lcats/llm/openai_backend.py
+++ b/lcats/lcats/llm/openai_backend.py
@@ -44,7 +44,7 @@ class OpenAIBackend:
             temperature=temperature,
             max_tokens=max_tokens,
         )
-        if tool:
+        if tool is not None:
             kwargs["tools"] = [
                 {
                     "type": "function",
@@ -65,8 +65,14 @@ class OpenAIBackend:
         response = self._client.chat.completions.create(**kwargs)
         choice = response.choices[0]
 
-        if tool:
-            raw_arguments = choice.message.tool_calls[0].function.arguments
+        if tool is not None:
+            tool_calls = choice.message.tool_calls
+            if not tool_calls:
+                raise ValueError(
+                    f"API returned no tool calls for tool {tool['name']!r}; "
+                    f"finish_reason: {choice.finish_reason!r}"
+                )
+            raw_arguments = tool_calls[0].function.arguments
             tool_result = json.loads(raw_arguments)
             text = ""
         else:

--- a/lcats/lcats/llm/openai_backend.py
+++ b/lcats/lcats/llm/openai_backend.py
@@ -1,0 +1,84 @@
+"""OpenAIBackend: LLMBackend adapter for the OpenAI chat completions API."""
+
+from __future__ import annotations
+
+import json
+
+from typing import Optional
+
+from lcats.llm import backend
+
+
+class OpenAIBackend:
+    """LLMBackend implementation backed by the OpenAI chat completions API."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        """Construct an OpenAI-backed LLMBackend.
+
+        Args:
+            api_key: Optional API key. When omitted, the OpenAI SDK reads
+                the OPENAI_API_KEY environment variable.
+
+        Raises:
+            ImportError: If the `openai` package is not installed.
+        """
+        import openai
+
+        self._client = openai.OpenAI(api_key=api_key)
+
+    def complete(
+        self,
+        *,
+        system: str,
+        messages: list,
+        model: str,
+        temperature: float = 0.2,
+        max_tokens: int = 4096,
+        tool: Optional[dict] = None,
+    ) -> backend.BackendResponse:
+        """See lcats.llm.backend.LLMBackend.complete."""
+        all_messages = [{"role": "system", "content": system}, *messages]
+        kwargs = dict(
+            model=model,
+            messages=all_messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        if tool:
+            kwargs["tools"] = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool["name"],
+                        "description": tool.get("description", ""),
+                        "parameters": tool["input_schema"],
+                    },
+                }
+            ]
+            kwargs["tool_choice"] = {
+                "type": "function",
+                "function": {"name": tool["name"]},
+            }
+        else:
+            kwargs["response_format"] = {"type": "json_object"}
+
+        response = self._client.chat.completions.create(**kwargs)
+        choice = response.choices[0]
+
+        if tool:
+            raw_arguments = choice.message.tool_calls[0].function.arguments
+            tool_result = json.loads(raw_arguments)
+            text = ""
+        else:
+            text = choice.message.content or ""
+            tool_result = None
+
+        usage = response.usage
+        return backend.BackendResponse(
+            text=text,
+            tool_result=tool_result,
+            model=response.model,
+            input_tokens=usage.prompt_tokens if usage else 0,
+            output_tokens=usage.completion_tokens if usage else 0,
+            raw=response,
+        )

--- a/lcats/project/executions/AD_HOC/2026_06_30_18_52_54_LLM_BACKEND_PACKAGE_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_06_30_18_52_54_LLM_BACKEND_PACKAGE_REVIEW.md
@@ -1,0 +1,68 @@
+---
+execution_id: 2026_06_30_18_52_54_LLM_BACKEND_PACKAGE_REVIEW
+prompt_id: PROMPT(AD_HOC:LLM_BACKEND_PACKAGE_REVIEW)[2026-06-30T18:43:40-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_06_30_02_06_30_CREATE_LLM_BACKEND_PACKAGE
+pr: https://github.com/xenotaur/LCATS/pull/100
+commit: 80eecf8
+created_at: 2026-06-30T18:52:54-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/100
+session_transcript: claude-app:d400d14b-0041-4827-8ef9-a8da8fdba9d6
+---
+
+# Summary
+
+Addressed five Copilot review comments on PR #100 (WI-LLM-0007: create
+`lcats/llm/` package). All comments were present and valid; all were fixed.
+
+# Result
+
+## Fixed
+
+**Comment 1 — OpenAI `if tool:` truthiness** (`openai_backend.py`)
+Changed `if tool:` to `if tool is not None:` for the dispatch branch that
+sets `tools`/`tool_choice`. An empty dict passed as `tool` would have
+silently switched to `json_object` mode rather than raising an error.
+
+**Comment 2 — OpenAI missing tool_calls guard** (`openai_backend.py`)
+Added an explicit guard after `choice.message.tool_calls`: if the list is
+empty or None, raises `ValueError` with the tool name and `finish_reason`
+so callers get a diagnostic error instead of `IndexError`.
+
+**Comment 3 — Anthropic `if tool:` truthiness** (`anthropic_backend.py`)
+Same fix as Comment 1: changed `if tool:` to `if tool is not None:` for
+both the `kwargs` population and the result extraction branches.
+
+**Comment 4 — Anthropic bare `next(generator)` raises StopIteration**
+(`anthropic_backend.py`)
+Replaced `next(block for block in ...)` with `next((block for block in ...),
+None)` plus an explicit None check that raises `ValueError` with the tool
+name and a list of actual content types in the response.
+
+**Comment 5 — Unversioned `openai` dependency** (`pyproject.toml`)
+Changed `"openai"` to `"openai>=1.0.0"`. The `openai.OpenAI` client class
+was introduced in 1.0.0 (November 2023). Pinning the minimum excludes 0.x
+releases that use a completely different API surface.
+
+# Validation
+
+```
+black --version         — black, 26.3.1 (compiled: yes)
+ruff --version          — ruff 0.15.12
+python --version        — Python 3.11.8 (Anaconda environment)
+black --check lcats/llm/ tests/llm_tests/   — 9 files unchanged (clean)
+scripts/lint            — ruff: all checks passed; black: pre-existing
+                          drift in gettenberg/metadata.py only (unrelated)
+scripts/test            — 1207 tests OK
+lrh validate            — 60 issues (same pre-existing baseline; 5 new
+                          PLANNING_ORPHANED_ACTIVE_WORK_ITEM warnings for
+                          active/ work items including WI-LLM-0007, all
+                          pre-existing)
+```
+
+# Follow-up
+
+No new follow-up items. WI-LLM-0008 and WI-LLM-0009 remain proposed,
+awaiting merge of this PR.

--- a/lcats/project/executions/WI-LLM-0007/2026_06_30_02_06_30_CREATE_LLM_BACKEND_PACKAGE.md
+++ b/lcats/project/executions/WI-LLM-0007/2026_06_30_02_06_30_CREATE_LLM_BACKEND_PACKAGE.md
@@ -1,0 +1,88 @@
+---
+execution_id: 2026_06_30_02_06_30_CREATE_LLM_BACKEND_PACKAGE
+prompt_id: PROMPT(WI-LLM-0007:CREATE_LLM_BACKEND_PACKAGE)[2026-06-30T02:06:15-04:00]
+work_item: WI-LLM-0007
+status: in_progress
+rerun_of: 
+pr: 
+commit: 
+created_at: 2026-06-30T02:06:30-04:00
+agent: claude_app
+instruction_source: conversation
+session_transcript: claude-app:d400d14b-0041-4827-8ef9-a8da8fdba9d6
+---
+
+# Summary
+
+Implemented WI-LLM-0007: created the `lcats/lcats/llm/` package containing
+the `LLMBackend` Protocol, `BackendResponse` dataclass, `FakeBackend` test
+double, `OpenAIBackend`, and `AnthropicBackend`, per
+`project/design/unified-llm-backend-design.md` (DESIGN-LLM-BACKEND).
+
+# Result
+
+All planned files were created:
+- `lcats/lcats/llm/__init__.py`
+- `lcats/lcats/llm/backend.py` — `LLMBackend` Protocol (`@runtime_checkable`)
+  and `BackendResponse` dataclass
+- `lcats/lcats/llm/openai_backend.py` — `OpenAIBackend`
+- `lcats/lcats/llm/anthropic_backend.py` — `AnthropicBackend`
+  (`use_streaming=True` by default)
+- `lcats/lcats/llm/fake_backend.py` — `FakeBackend`
+- `tests/llm_tests/backend_test.py`, `openai_backend_test.py`,
+  `anthropic_backend_test.py` (19 tests total)
+- `pyproject.toml` — added `"openai"` dependency
+
+Two deviations from the work item as originally written, both documented in
+the WI-LLM-0007 Scope section:
+
+1. `lcats/llm/__init__.py` does not re-export symbols. `STYLE.md` section 3
+   requires "always import modules, not symbols" for LCATS code; the
+   originally planned re-export list (`from lcats.llm import LLMBackend`,
+   etc.) would have violated this. Callers instead do
+   `from lcats.llm import backend` and use `backend.LLMBackend`.
+2. Test files use the project's `*_test.py` suffix convention
+   (`tests/AGENTS.md`: "Follow existing naming: `*_test.py`"), not the
+   `test_*.py` prefix form originally specified in the work item.
+
+Also discovered and fixed in passing: `anthropic` had been added to
+`pyproject.toml` in PR #98 but never installed (`scripts/develop` was not
+re-run), so it was missing from the active Anaconda environment. Running
+`pip install -e ".[dev]"` after adding `openai` picked up both.
+
+# Validation
+
+```
+python --version        — Python 3.11.8 (Anaconda environment)
+black --version         — black, 26.3.1
+ruff --version           — ruff 0.15.12
+black --check lcats/llm/ tests/llm_tests/   — all clean (after one
+                                               `black lcats/llm/ tests/llm_tests/`
+                                               formatting pass on the new test files)
+ruff check lcats/llm/ tests/llm_tests/      — all checks passed
+python -m unittest discover -s tests/llm_tests -p "*_test.py"  — 19 tests OK
+python -m unittest discover -s tests -p "*_test.py"            — 1207 tests OK (full suite)
+lrh validate             — 55 errors / 5 warnings (unchanged error count from
+                            pre-implementation baseline; +1 warning is the
+                            same PLANNING_ORPHANED_ACTIVE_WORK_ITEM pattern
+                            already present on the other 4 active/ work items,
+                            now also present on WI-LLM-0007 after its move to
+                            active/)
+```
+
+`scripts/format --check --diff` was run but flagged pre-existing drift in
+unrelated files (`lcats/gettenberg/metadata.py` and others) caused by a
+Black version mismatch unrelated to this change; the new files were checked
+directly with `black --check` instead and are clean.
+
+# Follow-up
+
+- WI-LLM-0008 (migrate `JSONPromptExtractor` and `extraction.py`) and
+  WI-LLM-0009 (migrate `assess.py`/`assess_cli.py`) can now proceed in
+  parallel, both depending only on this package.
+- The repo-wide pre-existing `lrh validate` schema drift (missing
+  `type`/`blocked`/`blocked_reason`/`resolution` fields on all work items,
+  `contributors.md` gaps) remains untouched, as previously logged in the
+  PR #99 closeout follow-up.
+- `pr:` and `commit:` fields above are blank pending PR creation; will be
+  filled in once a PR is opened and merged.

--- a/lcats/project/executions/WI-LLM-0007/2026_06_30_02_06_30_CREATE_LLM_BACKEND_PACKAGE.md
+++ b/lcats/project/executions/WI-LLM-0007/2026_06_30_02_06_30_CREATE_LLM_BACKEND_PACKAGE.md
@@ -4,7 +4,7 @@ prompt_id: PROMPT(WI-LLM-0007:CREATE_LLM_BACKEND_PACKAGE)[2026-06-30T02:06:15-04
 work_item: WI-LLM-0007
 status: in_progress
 rerun_of: 
-pr: 
+pr: https://github.com/xenotaur/LCATS/pull/100
 commit: 
 created_at: 2026-06-30T02:06:30-04:00
 agent: claude_app

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -14,10 +14,10 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 - `active/WI-REVIEW-0003.md`
 - `active/WI-APPLY-0005.md`
 - `active/WI-META-0006.md`
+- `active/WI-LLM-0007.md` — Create `lcats/llm/` package (Protocol + backends)
 
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md`
-- `proposed/WI-LLM-0007.md` — Create `lcats/llm/` package (Protocol + backends)
 - `proposed/WI-LLM-0008.md` — Migrate `JSONPromptExtractor` to `LLMBackend`
 - `proposed/WI-LLM-0009.md` — Migrate `assess.py` / `assess_cli.py` to `LLMBackend`
 - `proposed/WI-LLM-0010.md` — Side-by-side model comparison dry run

--- a/lcats/project/work_items/active/WI-LLM-0007.md
+++ b/lcats/project/work_items/active/WI-LLM-0007.md
@@ -1,7 +1,7 @@
 ---
 id: WI-LLM-0007
 title: Create lcats/llm package with LLMBackend Protocol and provider implementations
-status: proposed
+status: active
 priority: high
 owner: unassigned
 linked_workstream: WORKSTREAM-LLM-BACKEND
@@ -20,8 +20,12 @@ existing code is changed in this PR.
 ## Scope
 
 New files:
-- `lcats/lcats/llm/__init__.py` — re-exports `LLMBackend`, `BackendResponse`,
-  `OpenAIBackend`, `AnthropicBackend`, `FakeBackend`
+- `lcats/lcats/llm/__init__.py` — module docstring only, no symbol
+  re-exports. **Deviation from original plan:** `STYLE.md` §3 requires
+  "always import modules, not symbols" for LCATS code (e.g.
+  `from lcats.llm import backend` then `backend.LLMBackend`, not
+  `from lcats.llm import LLMBackend`). The originally planned re-export
+  list would have violated this; callers import each submodule directly.
 - `lcats/lcats/llm/backend.py` — `LLMBackend` Protocol + `BackendResponse`
   dataclass (see DESIGN-LLM-BACKEND for signatures)
 - `lcats/lcats/llm/openai_backend.py` — `OpenAIBackend` implementation
@@ -29,10 +33,13 @@ New files:
   defaults to streaming (`use_streaming=True`)
 - `lcats/lcats/llm/fake_backend.py` — `FakeBackend` with `self.calls` list
   for test assertion
-- `tests/llm_tests/test_backend.py` — Protocol isinstance check, FakeBackend
-  call recording
-- `tests/llm_tests/test_openai_backend.py` — unit tests mocking `openai.OpenAI`
-- `tests/llm_tests/test_anthropic_backend.py` — unit tests mocking
+- `tests/llm_tests/backend_test.py` — Protocol isinstance check, FakeBackend
+  call recording. **Deviation from original plan:** filename uses the
+  project's `*_test.py` suffix convention (`tests/AGENTS.md`), not the
+  `test_*.py` prefix originally specified.
+- `tests/llm_tests/openai_backend_test.py` — unit tests stubbing
+  `openai.OpenAI`
+- `tests/llm_tests/anthropic_backend_test.py` — unit tests stubbing
   `anthropic.Anthropic`
 
 Modified files:

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
    "seaborn",
    "gutenbergpy @ git+https://github.com/xenotaur/gutenbergpy.git@LCATS/TitleFix",
    "anthropic",
-   "openai",
+   "openai>=1.0.0",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
    "seaborn",
    "gutenbergpy @ git+https://github.com/xenotaur/gutenbergpy.git@LCATS/TitleFix",
    "anthropic",
+   "openai",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/lcats/tests/llm_tests/anthropic_backend_test.py
+++ b/lcats/tests/llm_tests/anthropic_backend_test.py
@@ -1,0 +1,173 @@
+"""Unit tests for lcats.llm.anthropic_backend."""
+
+import types
+import unittest
+
+from unittest.mock import patch
+
+from lcats.llm import anthropic_backend
+
+
+def _make_message(
+    text=None, tool_input=None, model="claude-opus-4-8", input_tokens=5, output_tokens=7
+):
+    """Build a stub object shaped like an Anthropic Messages API response."""
+    content = []
+    if text is not None:
+        content.append(types.SimpleNamespace(type="text", text=text))
+    if tool_input is not None:
+        content.append(types.SimpleNamespace(type="tool_use", input=tool_input))
+    usage = types.SimpleNamespace(
+        input_tokens=input_tokens, output_tokens=output_tokens
+    )
+    return types.SimpleNamespace(content=content, usage=usage, model=model)
+
+
+class _StubStream:
+    """Minimal stand-in for the context manager returned by messages.stream."""
+
+    def __init__(self, message):
+        self._message = message
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def get_final_message(self):
+        return self._message
+
+
+class _StubAnthropicClient:
+    """Minimal stand-in for anthropic.Anthropic exposing only what is used."""
+
+    def __init__(self, message):
+        self.last_kwargs = None
+        self.last_method = None
+        self._message = message
+        self.messages = types.SimpleNamespace(stream=self._stream, create=self._create)
+
+    def _stream(self, **kwargs):
+        self.last_kwargs = kwargs
+        self.last_method = "stream"
+        return _StubStream(self._message)
+
+    def _create(self, **kwargs):
+        self.last_kwargs = kwargs
+        self.last_method = "create"
+        return self._message
+
+
+class TestAnthropicBackend(unittest.TestCase):
+    """Verify AnthropicBackend translates to/from the Anthropic Messages API."""
+
+    def test_satisfies_llm_backend_protocol(self):
+        """AnthropicBackend satisfies the LLMBackend protocol."""
+        from lcats.llm import backend
+
+        with patch("anthropic.Anthropic") as mock_ctor:
+            mock_ctor.return_value = _StubAnthropicClient(_make_message(text="ok"))
+            self.assertIsInstance(
+                anthropic_backend.AnthropicBackend(), backend.LLMBackend
+            )
+
+    def test_complete_passes_system_as_top_level_kwarg(self):
+        """system is passed as a top-level kwarg, not embedded in messages."""
+        stub_client = _StubAnthropicClient(_make_message(text="ok"))
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend()
+            backend_under_test.complete(
+                system="be helpful",
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-8",
+            )
+        self.assertEqual(stub_client.last_kwargs["system"], "be helpful")
+        self.assertEqual(
+            stub_client.last_kwargs["messages"], [{"role": "user", "content": "hi"}]
+        )
+
+    def test_complete_without_tool_returns_text_block(self):
+        """complete(tool=None) extracts the text block."""
+        stub_client = _StubAnthropicClient(_make_message(text="hello world"))
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend()
+            result = backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-8",
+            )
+        self.assertEqual(result.text, "hello world")
+        self.assertIsNone(result.tool_result)
+        self.assertNotIn("tools", stub_client.last_kwargs)
+
+    def test_complete_with_tool_sets_tool_choice_and_returns_input(self):
+        """complete(tool=...) sets tools/tool_choice and extracts tool_use input."""
+        tool_schema = {"name": "record_thing", "input_schema": {"type": "object"}}
+        stub_client = _StubAnthropicClient(
+            _make_message(tool_input={"verdict": "include"})
+        )
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend()
+            result = backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-8",
+                tool=tool_schema,
+            )
+        self.assertEqual(stub_client.last_kwargs["tools"], [tool_schema])
+        self.assertEqual(
+            stub_client.last_kwargs["tool_choice"],
+            {"type": "tool", "name": "record_thing"},
+        )
+        self.assertEqual(result.tool_result, {"verdict": "include"})
+        self.assertEqual(result.text, "")
+
+    def test_complete_uses_streaming_by_default(self):
+        """complete() uses messages.stream() by default."""
+        stub_client = _StubAnthropicClient(_make_message(text="ok"))
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend()
+            backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-8",
+            )
+        self.assertEqual(stub_client.last_method, "stream")
+
+    def test_complete_uses_blocking_call_when_streaming_disabled(self):
+        """complete() uses messages.create() when use_streaming=False."""
+        stub_client = _StubAnthropicClient(_make_message(text="ok"))
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend(use_streaming=False)
+            backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-8",
+            )
+        self.assertEqual(stub_client.last_method, "create")
+
+    def test_complete_normalizes_token_usage_and_model(self):
+        """input_tokens/output_tokens/model are normalized from the API response."""
+        stub_client = _StubAnthropicClient(
+            _make_message(
+                text="ok",
+                model="claude-opus-4-8",
+                input_tokens=13,
+                output_tokens=29,
+            )
+        )
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend()
+            result = backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-8",
+            )
+        self.assertEqual(result.model, "claude-opus-4-8")
+        self.assertEqual(result.input_tokens, 13)
+        self.assertEqual(result.output_tokens, 29)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/llm_tests/backend_test.py
+++ b/lcats/tests/llm_tests/backend_test.py
@@ -1,0 +1,108 @@
+"""Unit tests for lcats.llm.backend."""
+
+import unittest
+
+from lcats.llm import backend
+from lcats.llm import fake_backend
+
+
+class TestLLMBackendProtocol(unittest.TestCase):
+    """Verify LLMBackend is a runtime-checkable structural protocol."""
+
+    def test_fake_backend_satisfies_protocol(self):
+        """FakeBackend satisfies LLMBackend without inheriting from it."""
+        self.assertIsInstance(fake_backend.FakeBackend(), backend.LLMBackend)
+
+    def test_object_without_complete_does_not_satisfy_protocol(self):
+        """An object lacking a complete() method does not satisfy LLMBackend."""
+
+        class NotABackend:
+            pass
+
+        self.assertNotIsInstance(NotABackend(), backend.LLMBackend)
+
+
+class TestBackendResponse(unittest.TestCase):
+    """Verify BackendResponse field defaults and shape."""
+
+    def test_fields_round_trip(self):
+        """All constructor fields are stored as given."""
+        response = backend.BackendResponse(
+            text="hello",
+            tool_result=None,
+            model="fake-1.0",
+            input_tokens=10,
+            output_tokens=20,
+            raw={"id": "resp-1"},
+        )
+        self.assertEqual(response.text, "hello")
+        self.assertIsNone(response.tool_result)
+        self.assertEqual(response.model, "fake-1.0")
+        self.assertEqual(response.input_tokens, 10)
+        self.assertEqual(response.output_tokens, 20)
+        self.assertEqual(response.raw, {"id": "resp-1"})
+
+    def test_raw_defaults_to_none(self):
+        """raw is optional and defaults to None."""
+        response = backend.BackendResponse(
+            text="",
+            tool_result={"verdict": "include"},
+            model="fake-1.0",
+            input_tokens=0,
+            output_tokens=0,
+        )
+        self.assertIsNone(response.raw)
+
+
+class TestFakeBackend(unittest.TestCase):
+    """Verify FakeBackend records calls and returns fixed responses."""
+
+    def test_complete_returns_configured_text(self):
+        """complete() returns the configured response_text when no tool is given."""
+        backend_under_test = fake_backend.FakeBackend(response_text="hi there")
+        result = backend_under_test.complete(
+            system="sys",
+            messages=[{"role": "user", "content": "hello"}],
+            model="fake-1.0",
+        )
+        self.assertEqual(result.text, "hi there")
+        self.assertIsNone(result.tool_result)
+
+    def test_complete_returns_configured_tool_result(self):
+        """complete() returns the configured tool_result when a tool is given."""
+        tool_result = {"verdict": "include"}
+        backend_under_test = fake_backend.FakeBackend(tool_result=tool_result)
+        result = backend_under_test.complete(
+            system="sys",
+            messages=[{"role": "user", "content": "hello"}],
+            model="fake-1.0",
+            tool={"name": "record_thing", "input_schema": {}},
+        )
+        self.assertEqual(result.tool_result, tool_result)
+
+    def test_calls_are_recorded(self):
+        """Each complete() call is appended to self.calls with its kwargs."""
+        backend_under_test = fake_backend.FakeBackend()
+        backend_under_test.complete(
+            system="sys1",
+            messages=[{"role": "user", "content": "a"}],
+            model="model-a",
+            temperature=0.5,
+            max_tokens=100,
+        )
+        backend_under_test.complete(
+            system="sys2",
+            messages=[{"role": "user", "content": "b"}],
+            model="model-b",
+            tool={"name": "t"},
+        )
+        self.assertEqual(len(backend_under_test.calls), 2)
+        self.assertEqual(backend_under_test.calls[0]["system"], "sys1")
+        self.assertEqual(backend_under_test.calls[0]["model"], "model-a")
+        self.assertEqual(backend_under_test.calls[0]["temperature"], 0.5)
+        self.assertIsNone(backend_under_test.calls[0]["tool"])
+        self.assertEqual(backend_under_test.calls[1]["tool"], {"name": "t"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/llm_tests/openai_backend_test.py
+++ b/lcats/tests/llm_tests/openai_backend_test.py
@@ -1,0 +1,152 @@
+"""Unit tests for lcats.llm.openai_backend."""
+
+import json
+import types
+import unittest
+
+from unittest.mock import patch
+
+from lcats.llm import openai_backend
+
+
+def _make_response(
+    content=None,
+    tool_call_arguments=None,
+    model="gpt-4o-2024-08-06",
+    prompt_tokens=5,
+    completion_tokens=7,
+):
+    """Build a stub object shaped like an OpenAI chat completion response."""
+    if tool_call_arguments is not None:
+        function = types.SimpleNamespace(arguments=tool_call_arguments)
+        tool_call = types.SimpleNamespace(function=function)
+        message = types.SimpleNamespace(content=None, tool_calls=[tool_call])
+    else:
+        message = types.SimpleNamespace(content=content, tool_calls=None)
+    choice = types.SimpleNamespace(message=message)
+    usage = types.SimpleNamespace(
+        prompt_tokens=prompt_tokens, completion_tokens=completion_tokens
+    )
+    return types.SimpleNamespace(choices=[choice], usage=usage, model=model)
+
+
+class _StubOpenAIClient:
+    """Minimal stand-in for openai.OpenAI exposing only what the backend uses."""
+
+    def __init__(self, response):
+        self.last_kwargs = None
+        self._response = response
+        self.chat = types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=self._create)
+        )
+
+    def _create(self, **kwargs):
+        self.last_kwargs = kwargs
+        return self._response
+
+
+class TestOpenAIBackend(unittest.TestCase):
+    """Verify OpenAIBackend translates to/from the OpenAI chat completions API."""
+
+    def test_satisfies_llm_backend_protocol(self):
+        """OpenAIBackend satisfies the LLMBackend protocol."""
+        from lcats.llm import backend
+
+        with patch("openai.OpenAI") as mock_ctor:
+            mock_ctor.return_value = _StubOpenAIClient(_make_response(content="{}"))
+            self.assertIsInstance(openai_backend.OpenAIBackend(), backend.LLMBackend)
+
+    def test_complete_without_tool_uses_json_object_mode(self):
+        """complete(tool=None) requests response_format=json_object."""
+        stub_client = _StubOpenAIClient(_make_response(content='{"a": 1}'))
+        with patch("openai.OpenAI", return_value=stub_client):
+            backend_under_test = openai_backend.OpenAIBackend()
+            result = backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="gpt-4o-2024-08-06",
+            )
+        self.assertEqual(
+            stub_client.last_kwargs["response_format"], {"type": "json_object"}
+        )
+        self.assertNotIn("tools", stub_client.last_kwargs)
+        self.assertEqual(result.text, '{"a": 1}')
+        self.assertIsNone(result.tool_result)
+
+    def test_complete_prepends_system_message(self):
+        """complete() prepends the system prompt to the messages list."""
+        stub_client = _StubOpenAIClient(_make_response(content="ok"))
+        with patch("openai.OpenAI", return_value=stub_client):
+            backend_under_test = openai_backend.OpenAIBackend()
+            backend_under_test.complete(
+                system="be helpful",
+                messages=[{"role": "user", "content": "hi"}],
+                model="gpt-4o-2024-08-06",
+            )
+        sent_messages = stub_client.last_kwargs["messages"]
+        self.assertEqual(sent_messages[0], {"role": "system", "content": "be helpful"})
+        self.assertEqual(sent_messages[1], {"role": "user", "content": "hi"})
+
+    def test_complete_with_tool_uses_function_calling(self):
+        """complete(tool=...) sets tools/tool_choice and parses tool arguments."""
+        tool_schema = {
+            "name": "record_thing",
+            "description": "Record a thing.",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+        stub_client = _StubOpenAIClient(
+            _make_response(tool_call_arguments=json.dumps({"verdict": "include"}))
+        )
+        with patch("openai.OpenAI", return_value=stub_client):
+            backend_under_test = openai_backend.OpenAIBackend()
+            result = backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="gpt-4o-2024-08-06",
+                tool=tool_schema,
+            )
+        self.assertEqual(
+            stub_client.last_kwargs["tools"],
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "record_thing",
+                        "description": "Record a thing.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        )
+        self.assertEqual(
+            stub_client.last_kwargs["tool_choice"],
+            {"type": "function", "function": {"name": "record_thing"}},
+        )
+        self.assertNotIn("response_format", stub_client.last_kwargs)
+        self.assertEqual(result.tool_result, {"verdict": "include"})
+        self.assertEqual(result.text, "")
+
+    def test_complete_normalizes_token_usage_and_model(self):
+        """input_tokens/output_tokens/model are normalized from the API response."""
+        stub_client = _StubOpenAIClient(
+            _make_response(
+                content="ok",
+                model="gpt-4o-2024-08-06",
+                prompt_tokens=11,
+                completion_tokens=22,
+            )
+        )
+        with patch("openai.OpenAI", return_value=stub_client):
+            backend_under_test = openai_backend.OpenAIBackend()
+            result = backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="gpt-4o-2024-08-06",
+            )
+        self.assertEqual(result.model, "gpt-4o-2024-08-06")
+        self.assertEqual(result.input_tokens, 11)
+        self.assertEqual(result.output_tokens, 22)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements WI-LLM-0007 from the unified LLM backend design (DESIGN-LLM-BACKEND, PR #99): the `lcats/llm/` package providing an `LLMBackend` Protocol with OpenAI and Anthropic adapter implementations.

This unifies LCATS's two existing LLM API call patterns -- raw OpenAI chat completions and Anthropic tool use (from `lcats assess`, PR #98) -- behind a single injectable interface, so a future model-comparison experiment can swap providers without touching prompt or call-site code.

**No existing call sites are migrated in this PR.** That is the scope of WI-LLM-0008 (JSONPromptExtractor + extraction.py) and WI-LLM-0009 (assess.py/assess_cli.py), both of which depend on this package and can proceed in parallel after this merges.

## What changed

| File | Change |
|---|---|
| `lcats/lcats/llm/backend.py` | New: `LLMBackend` Protocol (`@runtime_checkable`, structural subtyping per PEP 544) and `BackendResponse` dataclass |
| `lcats/lcats/llm/openai_backend.py` | New: `OpenAIBackend` -- translates `complete()` to `chat.completions.create`, using `response_format=json_object` or function-calling depending on whether `tool` is provided |
| `lcats/lcats/llm/anthropic_backend.py` | New: `AnthropicBackend` -- translates to the Messages API, `system` as a top-level kwarg, tool use when `tool` is provided. Streams by default (`use_streaming=True`) to avoid gateway timeouts on large story bodies; `use_streaming=False` for a blocking call |
| `lcats/lcats/llm/fake_backend.py` | New: `FakeBackend` test double recording every call's kwargs in `self.calls` |
| `lcats/lcats/llm/__init__.py` | New: module docstring only |
| `tests/llm_tests/*_test.py` | New: 19 unit tests across all three backends + the Protocol/dataclass |
| `pyproject.toml` | Added `"openai"` dependency |
| `project/work_items/active/WI-LLM-0007.md` | Moved from `proposed/`; status `proposed` -> `active` |
| `project/executions/WI-LLM-0007/...md` | New execution record (`status: in_progress`) |

## Deviations from the original work item

Both documented in the WI-LLM-0007 Scope section and the execution record:

1. **No symbol re-exports in `__init__.py`.** `STYLE.md` section 3 requires "always import modules, not symbols" for LCATS code. The work item originally specified re-exporting `LLMBackend`, `BackendResponse`, etc. from `__init__.py`; that would violate the style guide. Callers instead do `from lcats.llm import backend` and use `backend.LLMBackend`.
2. **Test file naming.** `tests/AGENTS.md` specifies the `*_test.py` suffix convention (e.g. `backend_test.py`), not the `test_*.py` prefix the work item originally specified.

## Side discovery

`anthropic` was added to `pyproject.toml` in PR #98 but `scripts/develop` was never re-run, so it was missing from the active Anaconda dev environment. Installing this PR's `openai` addition also picked up the previously-undelivered `anthropic` install.

## Test plan

- [x] `python -m unittest discover -s tests/llm_tests -p "*_test.py"` -- 19 tests pass
- [x] `python -m unittest discover -s tests -p "*_test.py"` -- full suite, 1207 tests pass
- [x] `black --check lcats/llm/ tests/llm_tests/` -- clean
- [x] `ruff check lcats/llm/ tests/llm_tests/` -- clean
- [x] `lrh validate` -- 55 errors / 5 warnings, unchanged from pre-PR baseline (all pre-existing repo-wide schema drift; the one new warning matches the same `PLANNING_ORPHANED_ACTIVE_WORK_ITEM` pattern already present on the other 4 active work items)
- [x] `isinstance(FakeBackend(), LLMBackend)`, `isinstance(OpenAIBackend(), LLMBackend)`, `isinstance(AnthropicBackend(), LLMBackend)` all `True`
- [x] No live API calls in any test (SDK clients stubbed via `unittest.mock.patch` on the constructor, returning minimal stand-in objects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
