### PR TITLE
Implement WI-LLM-0008: migrate JSONPromptExtractor and extraction.py to LLMBackend

### DIFF
--- a/lcats/lcats/analysis/llm_extractor.py
+++ b/lcats/lcats/analysis/llm_extractor.py
@@ -32,9 +32,13 @@ class JSONPromptExtractor:
     temperature : float
     max_tokens : int
         Max tokens to request from the backend (default 4096).
+    client : deprecated
+        Legacy alias for `backend`. Pass the backend as the first positional
+        argument or use `backend=` instead. Emits DeprecationWarning on use.
     force_json : deprecated
-        Formerly controlled response_format. Now ignored — the backend always
-        returns JSON when no tool is provided. Emits DeprecationWarning on use.
+        Formerly controlled response_format. Now ignored — the backend
+        requests JSON-friendly text; callers are still responsible for parsing.
+        Emits DeprecationWarning on use.
     text_indexer : Optional[Callable[[str], Tuple[str, Any]]]
         If provided, called as (indexed_text, index_meta) = text_indexer(story_text).
     result_aligner : Optional[Callable[[Dict[str, Any], str, Any], Dict[str, Any]]]
@@ -45,13 +49,14 @@ class JSONPromptExtractor:
 
     def __init__(
         self,
-        backend,
+        backend=_UNSET,
         *,
         system_prompt: str,
         user_prompt_template: str,
         output_key: str = "segments",
         default_model: str = "gpt-4o",
         temperature: float = 0.2,
+        client=_UNSET,
         force_json=_UNSET,
         max_tokens: int = 4096,
         text_indexer: Optional[Callable[[str], Tuple[str, Any]]] = None,
@@ -62,10 +67,28 @@ class JSONPromptExtractor:
             Callable[[Dict[str, Any], str, Any], Dict[str, Any]]
         ] = None,
     ):
+        if client is not _UNSET:
+            if backend is not _UNSET:
+                raise TypeError(
+                    "Pass the backend as the first positional argument or use "
+                    "backend=, not both backend= and the deprecated client=."
+                )
+            warnings.warn(
+                "client= is deprecated; pass the backend as the first positional "
+                "argument or use backend= instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            backend = client
+        if backend is _UNSET:
+            raise TypeError(
+                "JSONPromptExtractor() missing required argument: 'backend'"
+            )
         if force_json is not _UNSET:
             warnings.warn(
                 "force_json is deprecated and will be removed in a future release. "
-                "The LLMBackend always returns JSON when no tool is provided.",
+                "The backend requests JSON-friendly text; callers are responsible "
+                "for parsing the response.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/lcats/lcats/analysis/llm_extractor.py
+++ b/lcats/lcats/analysis/llm_extractor.py
@@ -1,10 +1,14 @@
 """Generic JSON-focused LLM extractor."""
 
 import json
+import warnings
 
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from lcats import utils
+from lcats.llm import backend as llm_backend
+
+_UNSET = object()
 
 
 class JSONPromptExtractor:
@@ -14,7 +18,8 @@ class JSONPromptExtractor:
 
     Parameters
     ----------
-    client : OpenAI-like client
+    backend : LLMBackend
+        Backend satisfying the lcats.llm.backend.LLMBackend Protocol.
     system_prompt : str
     user_prompt_template : str
         May reference either `{indexed_story_text}` or `{story_text}`.
@@ -25,8 +30,11 @@ class JSONPromptExtractor:
         Key in the returned JSON object to extract (e.g., "segments").
     default_model : str
     temperature : float
-    force_json : bool
-        If True, pass response_format={"type": "json_object"} when supported.
+    max_tokens : int
+        Max tokens to request from the backend (default 4096).
+    force_json : deprecated
+        Formerly controlled response_format. Now ignored — the backend always
+        returns JSON when no tool is provided. Emits DeprecationWarning on use.
     text_indexer : Optional[Callable[[str], Tuple[str, Any]]]
         If provided, called as (indexed_text, index_meta) = text_indexer(story_text).
     result_aligner : Optional[Callable[[Dict[str, Any], str, Any], Dict[str, Any]]]
@@ -37,39 +45,48 @@ class JSONPromptExtractor:
 
     def __init__(
         self,
-        client: Any,
+        backend,
         *,
         system_prompt: str,
         user_prompt_template: str,
         output_key: str = "segments",
         default_model: str = "gpt-4o",
         temperature: float = 0.2,
-        force_json: bool = True,
+        force_json=_UNSET,
+        max_tokens: int = 4096,
         text_indexer: Optional[Callable[[str], Tuple[str, Any]]] = None,
         result_aligner: Optional[
             Callable[[Dict[str, Any], str, Any], Dict[str, Any]]
         ] = None,
         result_validator: Optional[
             Callable[[Dict[str, Any], str, Any], Dict[str, Any]]
-        ] = None,  # << NEW
+        ] = None,
     ):
-        self.client = client
+        if force_json is not _UNSET:
+            warnings.warn(
+                "force_json is deprecated and will be removed in a future release. "
+                "The LLMBackend always returns JSON when no tool is provided.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.backend = backend
         self.system_prompt = system_prompt
         self.user_prompt_template = user_prompt_template
         self.output_key = output_key
         self.default_model = default_model
         self.temperature = temperature
-        self.force_json = force_json
+        self.force_json = force_json if force_json is not _UNSET else True
+        self.max_tokens = max_tokens
         self.text_indexer = text_indexer
         self.result_aligner = result_aligner
-        self.result_validator = result_validator  # << NEW
+        self.result_validator = result_validator
 
         # Debug/inspection hooks
         self.last_messages: Optional[List[Dict[str, str]]] = None
         self.last_response: Any = None
         self.last_raw_output: Optional[str] = None
         self.last_index_meta: Any = None
-        self.last_validation_report: Optional[Dict[str, Any]] = None  # << NEW
+        self.last_validation_report: Optional[Dict[str, Any]] = None
 
     # ---------- helpers ----------
 
@@ -95,7 +112,7 @@ class JSONPromptExtractor:
         return content, None
 
     def build_messages(self, story_text: str) -> List[Dict[str, str]]:
-        """Public: build messages without invoking the client."""
+        """Public: build messages without invoking the backend."""
         content, _ = self._prepare_user_content(story_text)
         return [
             {"role": "system", "content": self.system_prompt},
@@ -184,7 +201,7 @@ class JSONPromptExtractor:
         """Turn an arbitrary client exception into a normalized api_error dict.
 
         Args:
-            exc: Exception from the client.
+            exc: Exception from the backend.
 
         Returns:
             A normalized error dict.
@@ -249,30 +266,29 @@ class JSONPromptExtractor:
         ]
         self.last_messages = messages
 
-        # Call model (now guarded)
+        # Call backend
         api_error: Optional[Dict[str, Any]] = None
-        response = None
+        backend_response: Optional[llm_backend.BackendResponse] = None
         raw_output = ""
 
         try:
-            kwargs = dict(model=model, messages=messages, temperature=self.temperature)
-            if self.force_json:
-                kwargs["response_format"] = {"type": "json_object"}
-            response = self.client.chat.completions.create(**kwargs)
-            self.last_response = response
+            backend_response = self.backend.complete(
+                system=self.system_prompt,
+                messages=[{"role": "user", "content": user_content}],
+                model=model,
+                temperature=self.temperature,
+                max_tokens=self.max_tokens,
+            )
+            self.last_response = backend_response
+            raw_output = backend_response.text
 
-            # Defensive read of response
-            choices = getattr(response, "choices", None) or []
-            if choices and getattr(choices[0], "message", None):
-                raw_output = choices[0].message.content or ""
-            else:
-                # Treat as an API error-like condition
+            if not raw_output:
                 api_error = {
-                    "status": getattr(response, "status_code", None),
+                    "status": None,
                     "code": "empty_response",
                     "type": "client_or_server",
-                    "message": "No choices/content returned by API.",
-                    "raw": str(getattr(response, "__dict__", response)),
+                    "message": "No content returned by backend.",
+                    "raw": repr(backend_response),
                     "category": "unknown",
                     "can_retry": True,
                     "needs_smaller_request": False,
@@ -282,14 +298,13 @@ class JSONPromptExtractor:
 
         except Exception as exc:
             api_error = self._normalize_api_error(exc)
-            # Early return with surfaced error; keep structure consistent.
             return {
                 "story_text": story_text,
                 "model_name": model,
                 "messages": messages,
-                "response": response,
-                "response_id": getattr(response, "id", None) if response else None,
-                "usage": getattr(response, "usage", None) if response else None,
+                "response": None,
+                "response_id": None,
+                "usage": None,
                 "raw_output": "",
                 "parsed_output": None,
                 "extracted_output": None,
@@ -299,7 +314,7 @@ class JSONPromptExtractor:
                 "index_meta": index_meta,
                 "validation_report": None,
                 "validation_error": None,
-                "api_error": api_error,  # << surfaced, actionable
+                "api_error": api_error,
             }
 
         self.last_raw_output = raw_output
@@ -349,15 +364,23 @@ class JSONPromptExtractor:
             else:
                 extraction_error = f"Expected '{self.output_key}' key in JSON response."
 
-        # Pull out optional metadata when available
-        response_id = getattr(response, "id", None)
-        usage = getattr(response, "usage", None)
+        raw_response = backend_response.raw if backend_response else None
+        response_id = getattr(raw_response, "id", None)
+        usage = (
+            {
+                "input_tokens": backend_response.input_tokens,
+                "output_tokens": backend_response.output_tokens,
+            }
+            if backend_response
+            else None
+        )
+        result_model_name = backend_response.model if backend_response else model
 
         return {
             "story_text": story_text,
-            "model_name": model,
+            "model_name": result_model_name,
             "messages": messages,
-            "response": response,  # non-serializable; strip with make_serializable()
+            "response": raw_response,
             "response_id": response_id,
             "usage": usage,
             "raw_output": raw_output,
@@ -369,5 +392,5 @@ class JSONPromptExtractor:
             "index_meta": index_meta,
             "validation_report": validation_report,
             "validation_error": validation_error,
-            "api_error": api_error,  # None on success; dict on failure/empty
+            "api_error": api_error,
         }

--- a/lcats/lcats/analysis/scene_analysis.py
+++ b/lcats/lcats/analysis/scene_analysis.py
@@ -183,23 +183,22 @@ STORY (with paragraph ids; DO NOT include [P####] markers in anchors):
 """
 
 
-def make_segment_extractor(client: Any) -> llm_extractor.JSONPromptExtractor:
+def make_segment_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
     """Create a JSONPromptExtractor configured for scene/sequel extraction.
 
     Args:
-        client: OpenAI-like client (supports chat.completions.create).
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
 
     Returns:
         Configured JSONPromptExtractor that returns a dict under key "segments".
     """
     return llm_extractor.JSONPromptExtractor(
-        client,
+        backend,
         system_prompt=SCENE_SEQUEL_SYSTEM_PROMPT,
         user_prompt_template=SCENE_SEQUEL_USER_PROMPT_TEMPLATE,
         output_key="segments",
         default_model="gpt-4o",
         temperature=0.2,
-        force_json=True,
         text_indexer=text_segmenter.paragraph_text_indexer,
         result_aligner=text_segmenter.segments_result_aligner,
         result_validator=text_segmenter.segments_auditor,
@@ -464,26 +463,25 @@ SEGMENT:
 """
 
 
-def make_semantics_extractor(client: Any) -> llm_extractor.JSONPromptExtractor:
+def make_semantics_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
     """Create a JSONPromptExtractor configured for per-segment semantics.
 
     Args:
-        client: OpenAI-like client (supports chat.completions.create).
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
 
     Returns:
         Configured JSONPromptExtractor that returns a dict under key "judgment".
     """
     return llm_extractor.JSONPromptExtractor(
-        client=client,
+        backend,
         system_prompt=SCENE_SEMANTICS_SYSTEM_PROMPT,
         user_prompt_template=SCENE_SEMANTICS_USER_PROMPT_TEMPLATE,
         output_key="judgment",
         default_model="gpt-4o",
         temperature=0.2,
-        force_json=True,
-        text_indexer=None,  # segment-level: no indexing
-        result_aligner=None,  # segment-level: no alignment
-        result_validator=None,  # optional: add later if desired
+        text_indexer=None,
+        result_aligner=None,
+        result_validator=None,
     )
 
 

--- a/lcats/lcats/analysis/story_analysis.py
+++ b/lcats/lcats/analysis/story_analysis.py
@@ -395,23 +395,24 @@ STORY:
 """
 
 
-def make_doc_classification_extractor(client: Any) -> llm_extractor.JSONPromptExtractor:
+def make_doc_classification_extractor(
+    backend: Any,
+) -> llm_extractor.JSONPromptExtractor:
     """Create a JSONPromptExtractor for whole-text document classification.
 
     Args:
-        client: OpenAI-like client (e.g., openai.OpenAI()).
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
 
     Returns:
         Configured JSONPromptExtractor that emits a dict under key "classification".
     """
     return llm_extractor.JSONPromptExtractor(
-        client,
+        backend,
         system_prompt=DOC_CLASSIFY_SYSTEM_PROMPT,
-        user_prompt_template=DOC_CLASSIFY_USER_PROMPT_TEMPLATE,  # uses {story_text}
+        user_prompt_template=DOC_CLASSIFY_USER_PROMPT_TEMPLATE,
         output_key="classification",
         default_model="gpt-4o",
         temperature=0.1,
-        force_json=True,
-        text_indexer=None,  # not needed for whole-text classification
-        result_aligner=None,  # no offsets to align
+        text_indexer=None,
+        result_aligner=None,
     )

--- a/lcats/lcats/analysis/story_processors.py
+++ b/lcats/lcats/analysis/story_processors.py
@@ -47,7 +47,7 @@ def story_summarizer(data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def make_annotated_segment_extractor(
-    client: Any,
+    backend: Any,
     *,
     segment_model: str = "gpt-4o",
     semantic_model: str = "gpt-4o",
@@ -60,7 +60,7 @@ def make_annotated_segment_extractor(
     per-segment semantic judgment.
 
     Args:
-        client: OpenAI-like client (supports chat.completions.create).
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
         segment_model: Model name to use for story-level segmentation.
         semantic_model: Model name to use for per-segment semantic labeling.
         include_validation: If True, include segmentation validation report.
@@ -73,8 +73,8 @@ def make_annotated_segment_extractor(
         None at factory time. Runtime exceptions inside the processor are
         captured into an `"error"` string in the returned payload.
     """
-    seg_extractor = scene_analysis.make_segment_extractor(client)
-    sem_extractor = scene_analysis.make_semantics_extractor(client)
+    seg_extractor = scene_analysis.make_segment_extractor(backend)
+    sem_extractor = scene_analysis.make_semantics_extractor(backend)
 
     def processor_function(data: Dict[str, Any]) -> Dict[str, Any]:
         """Produce annotated segments for a single story JSON.

--- a/lcats/lcats/extraction.py
+++ b/lcats/lcats/extraction.py
@@ -65,8 +65,6 @@ def extract_from_story(
     temperature: float = 0.2,
 ) -> ExtractionResult:
     """Perform structured extraction from a story using an LLM and a prompt template."""
-    from lcats.llm import backend as llm_backend  # noqa: F401 (Protocol reference)
-
     messages = template.build_prompt(story_text)
     # messages[0] is the system turn; messages[1:] are user/assistant turns.
     backend_response = backend.complete(

--- a/lcats/lcats/extraction.py
+++ b/lcats/lcats/extraction.py
@@ -35,7 +35,7 @@ class ExtractionResult:  # pylint: disable=too-many-instance-attributes
     model_name: str
     template: ExtractionTemplate
     messages: List[Dict[str, str]]
-    response: Optional[object]  # raw OpenAI response object
+    response: Optional[object]  # raw provider response (BackendResponse.raw)
     raw_output: Optional[str]  # raw text output from the LLM
     parsed_output: Optional[Dict]
     parsing_error: Optional[str]
@@ -60,18 +60,22 @@ class ExtractionResult:  # pylint: disable=too-many-instance-attributes
 def extract_from_story(
     story_text: str,
     template: ExtractionTemplate,
-    client,
+    backend,
     model_name: str = "gpt-3.5-turbo",
     temperature: float = 0.2,
 ) -> ExtractionResult:
     """Perform structured extraction from a story using an LLM and a prompt template."""
+    from lcats.llm import backend as llm_backend  # noqa: F401 (Protocol reference)
+
     messages = template.build_prompt(story_text)
-    response = client.chat.completions.create(
+    # messages[0] is the system turn; messages[1:] are user/assistant turns.
+    backend_response = backend.complete(
+        system=messages[0]["content"],
+        messages=messages[1:],
         model=model_name,
-        messages=messages,
         temperature=temperature,
     )
-    raw_output = response.choices[0].message.content
+    raw_output = backend_response.text
 
     try:
         parsed_output = utils.extract_json(raw_output)
@@ -94,10 +98,10 @@ def extract_from_story(
 
     return ExtractionResult(
         story_text=story_text,
-        model_name=model_name,
+        model_name=backend_response.model,
         template=template,
         messages=messages,
-        response=response,
+        response=backend_response.raw,
         raw_output=raw_output,
         parsed_output=parsed_output,
         parsing_error=parsing_error,

--- a/lcats/project/executions/AD_HOC/2026_06_30_23_17_22_WI_LLM_0008_MIGRATE_EXTRACTOR_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_06_30_23_17_22_WI_LLM_0008_MIGRATE_EXTRACTOR_REVIEW.md
@@ -1,0 +1,52 @@
+---
+execution_id: 2026_06_30_23_17_22_WI_LLM_0008_MIGRATE_EXTRACTOR_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_LLM_0008_MIGRATE_EXTRACTOR_REVIEW)[2026-06-30T23:01:57-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_06_30_22_17_14_WI_LLM_0008_MIGRATE_EXTRACTOR
+pr: 101
+commit: 2e5544e
+created_at: 2026-06-30T23:17:22-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/101
+session_transcript: claude-app:d400d14b-0041-4827-8ef9-a8da8fdba9d6
+---
+
+# Summary
+
+Addressed four review comments on PR #101 (WI-LLM-0008 migration of
+JSONPromptExtractor and extraction.py to LLMBackend).
+
+# Result
+
+**Comment 1 (chatgpt-codex-connector P2) — client= alias:** Added deprecated
+`client=` keyword alias to `JSONPromptExtractor.__init__`. Callers using
+`client=client` (e.g. notebook `11_analyze_corpus.ipynb:1158`) now receive a
+`DeprecationWarning` and continue to work instead of raising `TypeError`.
+Passing both `backend=` and `client=` raises `TypeError`. Missing both raises
+`TypeError`. Three new tests added.
+
+**Comment 2 (copilot) — docstring overclaim:** Fixed `force_json` docstring:
+"always returns JSON" changed to "requests JSON-friendly text; callers are
+still responsible for parsing the response."
+
+**Comment 3 (copilot) — warning message overclaim:** Fixed `DeprecationWarning`
+text for `force_json` with the same correction.
+
+**Comment 4 (copilot) — unused import:** Removed the unused
+`from lcats.llm import backend as llm_backend  # noqa: F401` line from
+`lcats/extraction.py`.
+
+# Validation
+
+- `black --check` on changed files: passes
+- `ruff check` on changed files: passes
+- `scripts/test`: 1216 tests passing (0 failures)
+  (Note: `scripts/lint` reports pre-existing `metadata.py` formatting drift,
+  unrelated to this PR — same baseline as before these changes.)
+
+# Follow-up
+
+- PR #101 needs review and merge
+- `session_transcript: pending` should be updated to
+  `claude-app:d400d14b-0041-4827-8ef9-a8da8fdba9d6` after session ends

--- a/lcats/project/executions/WI-LLM-0008/2026_06_30_22_17_14_WI_LLM_0008_MIGRATE_EXTRACTOR.md
+++ b/lcats/project/executions/WI-LLM-0008/2026_06_30_22_17_14_WI_LLM_0008_MIGRATE_EXTRACTOR.md
@@ -1,0 +1,53 @@
+---
+execution_id: 2026_06_30_22_17_14_WI_LLM_0008_MIGRATE_EXTRACTOR
+prompt_id: PROMPT(WI-LLM-0008:WI_LLM_0008_MIGRATE_EXTRACTOR)[2026-06-30T22:16:01-04:00]
+work_item: WI-LLM-0008
+status: in_progress
+rerun_of: 
+pr: 101
+commit: 72e4897
+created_at: 2026-06-30T22:17:14-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-LLM-0008.md
+session_transcript: claude-app:d400d14b-0041-4827-8ef9-a8da8fdba9d6
+---
+
+# Summary
+
+Migrated `JSONPromptExtractor` (Pattern B) and `extract_from_story` (Pattern A2)
+to use `LLMBackend` instead of raw OpenAI client calls. Renamed `client` to
+`backend` throughout the call stack (four factory functions + both extractor
+entry points). Deprecated `force_json=` with an `_UNSET` sentinel. Updated five
+test files to use `FakeBackend` stubs instead of `MagicMock`/`Mock`.
+
+# Result
+
+- `lcats/lcats/analysis/llm_extractor.py` — `JSONPromptExtractor` now accepts
+  `backend` (LLMBackend Protocol) instead of `client`. `force_json` deprecated.
+  Result dict now uses `BackendResponse.model`, `BackendResponse.raw`, and
+  normalized `{"input_tokens": N, "output_tokens": N}` usage dict.
+- `lcats/lcats/extraction.py` — `extract_from_story` parameter renamed
+  `client` → `backend`; call site uses `backend.complete()`.
+- `lcats/lcats/analysis/scene_analysis.py` — `make_segment_extractor` and
+  `make_semantics_extractor` renamed `client` → `backend`, dropped `force_json=True`.
+- `lcats/lcats/analysis/story_analysis.py` — `make_doc_classification_extractor`
+  renamed `client` → `backend`, dropped `force_json=True`.
+- `lcats/lcats/analysis/story_processors.py` — `make_annotated_segment_extractor`
+  renamed `client` → `backend`.
+- Five test files updated: `FakeBackend` replaces `MagicMock`/`Mock` for all
+  backend/client stubs. `llm_extractor_test.py` fully rewritten.
+
+No bare `chat.completions.create` calls remain outside `lcats/llm/openai_backend.py`.
+
+# Validation
+
+- `black --check`: all changed files pass
+- `ruff check`: all changed files pass
+- `scripts/test`: 1213 tests passing (0 failures)
+- `rg "chat.completions.create" lcats/lcats/`: only in `lcats/llm/openai_backend.py`
+
+# Follow-up
+
+- PR #101 needs review and merge
+- After merge: move WI-LLM-0008 to `resolved/`; update `status: resolved` with commit hash
+- WI-LLM-0009: Migrate `assess.py` / `assess_cli.py` to LLMBackend (next in workstream)

--- a/lcats/project/work_items/proposed/WI-LLM-0008.md
+++ b/lcats/project/work_items/proposed/WI-LLM-0008.md
@@ -1,7 +1,7 @@
 ---
 id: WI-LLM-0008
 title: Migrate JSONPromptExtractor and extraction.py to LLMBackend
-status: proposed
+status: active
 priority: high
 owner: unassigned
 linked_workstream: WORKSTREAM-LLM-BACKEND

--- a/lcats/tests/analysis_tests/llm_extractor_test.py
+++ b/lcats/tests/analysis_tests/llm_extractor_test.py
@@ -120,6 +120,40 @@ class TestJSONPromptExtractorInit(unittest.TestCase):
                 user_prompt_template="tmpl {story_text}",
             )
 
+    def test_client_kwarg_deprecated_alias(self):
+        """Passing client= as keyword arg emits DeprecationWarning and stores as backend."""
+        fb = fake_backend.FakeBackend()
+        with self.assertWarns(DeprecationWarning):
+            ext = llm_extractor.JSONPromptExtractor(
+                client=fb,
+                system_prompt="sys",
+                user_prompt_template="tmpl {story_text}",
+            )
+        self.assertIs(ext.backend, fb)
+
+    def test_client_and_backend_together_raises(self):
+        """Passing both client= and backend= positionally raises TypeError."""
+        fb = fake_backend.FakeBackend()
+        import warnings
+
+        with self.assertRaises(TypeError):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                llm_extractor.JSONPromptExtractor(
+                    fb,
+                    client=fb,
+                    system_prompt="sys",
+                    user_prompt_template="tmpl {story_text}",
+                )
+
+    def test_missing_backend_raises(self):
+        """Calling without backend= or client= raises TypeError."""
+        with self.assertRaises(TypeError):
+            llm_extractor.JSONPromptExtractor(
+                system_prompt="sys",
+                user_prompt_template="tmpl {story_text}",
+            )
+
     def test_optional_hooks_default_to_none(self):
         """text_indexer, result_aligner, result_validator default to None."""
         ext = _make_extractor()

--- a/lcats/tests/analysis_tests/llm_extractor_test.py
+++ b/lcats/tests/analysis_tests/llm_extractor_test.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 from parameterized import parameterized
 
 from lcats.analysis import llm_extractor
+from lcats.llm import fake_backend
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -14,31 +15,41 @@ from lcats.analysis import llm_extractor
 
 
 def _make_extractor(**kwargs):
-    """Return a JSONPromptExtractor with sensible defaults."""
+    """Return a JSONPromptExtractor backed by a FakeBackend.
+
+    Pass `response_text=` to control what the backend returns.
+    Pass `backend=` to supply a fully configured FakeBackend (overrides response_text).
+    All other kwargs are forwarded to JSONPromptExtractor.
+    Note: force_json is intentionally omitted here to avoid DeprecationWarning in
+    tests that don't specifically test the deprecation path.
+    """
+    if "backend" not in kwargs:
+        response_text = kwargs.pop("response_text", "")
+        fb_model = kwargs.pop("fb_model", "fake-1.0")
+        kwargs["backend"] = fake_backend.FakeBackend(
+            response_text=response_text, model=fb_model
+        )
     defaults = dict(
-        client=MagicMock(),
         system_prompt="You are a helpful assistant.",
         user_prompt_template="Analyse: {story_text}",
         output_key="segments",
         default_model="gpt-4o",
         temperature=0.2,
-        force_json=True,
     )
     defaults.update(kwargs)
     return llm_extractor.JSONPromptExtractor(**defaults)
 
 
-def _make_mock_response(content):
-    """Return a mock OpenAI-like response object."""
-    message = MagicMock()
-    message.content = content
-    choice = MagicMock()
-    choice.message = message
-    response = MagicMock()
-    response.choices = [choice]
-    response.id = "resp-001"
-    response.usage = None
-    return response
+class _RaisingBackend:
+    """Stub backend that always raises a given exception from complete()."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def complete(
+        self, *, system, messages, model, temperature=0.2, max_tokens=4096, tool=None
+    ):
+        raise self._exc
 
 
 # ---------------------------------------------------------------------------
@@ -51,14 +62,14 @@ class TestJSONPromptExtractorInit(unittest.TestCase):
 
     def test_stores_required_params(self):
         """Constructor stores system_prompt, user_prompt_template, and output_key."""
-        client = MagicMock()
+        fb = fake_backend.FakeBackend()
         ext = llm_extractor.JSONPromptExtractor(
-            client,
+            fb,
             system_prompt="sys",
             user_prompt_template="tmpl {story_text}",
             output_key="items",
         )
-        self.assertIs(ext.client, client)
+        self.assertIs(ext.backend, fb)
         self.assertEqual(ext.system_prompt, "sys")
         self.assertEqual(ext.user_prompt_template, "tmpl {story_text}")
         self.assertEqual(ext.output_key, "items")
@@ -70,9 +81,44 @@ class TestJSONPromptExtractorInit(unittest.TestCase):
         self.assertAlmostEqual(ext.temperature, 0.2)
 
     def test_force_json_default(self):
-        """force_json defaults to True."""
+        """force_json attribute defaults to True when not explicitly passed."""
         ext = _make_extractor()
         self.assertTrue(ext.force_json)
+
+    def test_force_json_deprecated_warning_on_explicit_true(self):
+        """Passing force_json=True emits DeprecationWarning."""
+        fb = fake_backend.FakeBackend()
+        with self.assertWarns(DeprecationWarning):
+            llm_extractor.JSONPromptExtractor(
+                fb,
+                system_prompt="sys",
+                user_prompt_template="tmpl {story_text}",
+                force_json=True,
+            )
+
+    def test_force_json_deprecated_warning_on_false(self):
+        """Passing force_json=False also emits DeprecationWarning."""
+        fb = fake_backend.FakeBackend()
+        with self.assertWarns(DeprecationWarning):
+            llm_extractor.JSONPromptExtractor(
+                fb,
+                system_prompt="sys",
+                user_prompt_template="tmpl {story_text}",
+                force_json=False,
+            )
+
+    def test_no_warning_when_force_json_not_passed(self):
+        """Omitting force_json does not emit any DeprecationWarning."""
+        import warnings
+
+        fb = fake_backend.FakeBackend()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            llm_extractor.JSONPromptExtractor(
+                fb,
+                system_prompt="sys",
+                user_prompt_template="tmpl {story_text}",
+            )
 
     def test_optional_hooks_default_to_none(self):
         """text_indexer, result_aligner, result_validator default to None."""
@@ -165,11 +211,12 @@ class TestBuildMessages(unittest.TestCase):
         self.assertEqual(msgs[1]["role"], "user")
         self.assertIn("my story", msgs[1]["content"])
 
-    def test_does_not_call_client(self):
-        """build_messages should not call the client."""
-        ext = _make_extractor()
+    def test_does_not_call_backend(self):
+        """build_messages should not call the backend."""
+        fb = fake_backend.FakeBackend()
+        ext = _make_extractor(backend=fb)
         ext.build_messages("some text")
-        ext.client.chat.completions.create.assert_not_called()
+        self.assertEqual(fb.calls, [])
 
 
 # ---------------------------------------------------------------------------
@@ -384,18 +431,10 @@ class TestNormalizeApiError(unittest.TestCase):
 class TestExtractSuccess(unittest.TestCase):
     """Tests for extract() on the happy path."""
 
-    def _make_ext_with_response(self, content, output_key="segments"):
-        """Return (extractor, mock_client) configured to return content."""
-        client = MagicMock()
-        response = _make_mock_response(content)
-        client.chat.completions.create.return_value = response
-        ext = _make_extractor(client=client, output_key=output_key)
-        return ext, client, response
-
     def test_returns_extracted_output_on_success(self):
         """extract() returns the parsed segments list on a valid JSON response."""
         payload = json.dumps({"segments": [{"id": 1}]})
-        ext, _, _ = self._make_ext_with_response(payload)
+        ext = _make_extractor(response_text=payload)
         result = ext.extract("some story")
         self.assertIsNone(result["api_error"])
         self.assertIsNone(result["extraction_error"])
@@ -404,7 +443,7 @@ class TestExtractSuccess(unittest.TestCase):
     def test_populates_all_result_keys(self):
         """Result dict contains all expected keys."""
         payload = json.dumps({"segments": []})
-        ext, _, _ = self._make_ext_with_response(payload)
+        ext = _make_extractor(response_text=payload)
         result = ext.extract("story")
         expected_keys = {
             "story_text",
@@ -426,40 +465,36 @@ class TestExtractSuccess(unittest.TestCase):
         }
         self.assertEqual(set(result.keys()), expected_keys)
 
-    def test_model_name_override(self):
-        """Passing model_name overrides the default model."""
+    def test_model_name_from_backend_response(self):
+        """model_name in result comes from BackendResponse.model."""
         payload = json.dumps({"segments": []})
-        ext, _, _ = self._make_ext_with_response(payload)
-        result = ext.extract("story", model_name="gpt-3.5-turbo")
-        self.assertEqual(result["model_name"], "gpt-3.5-turbo")
+        fb = fake_backend.FakeBackend(response_text=payload, model="backend-v1")
+        ext = _make_extractor(backend=fb)
+        result = ext.extract("story")
+        self.assertEqual(result["model_name"], "backend-v1")
 
-    def test_force_json_adds_response_format(self):
-        """When force_json=True, response_format is passed to create()."""
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": []})
-        )
-        ext = _make_extractor(client=client, force_json=True)
-        ext.extract("story")
-        call_kwargs = client.chat.completions.create.call_args[1]
-        self.assertIn("response_format", call_kwargs)
-        self.assertEqual(call_kwargs["response_format"], {"type": "json_object"})
+    def test_model_name_override_passed_to_backend(self):
+        """Passing model_name to extract() forwards it to backend.complete()."""
+        payload = json.dumps({"segments": []})
+        fb = fake_backend.FakeBackend(response_text=payload)
+        ext = _make_extractor(backend=fb)
+        ext.extract("story", model_name="gpt-3.5-turbo")
+        self.assertEqual(fb.calls[0]["model"], "gpt-3.5-turbo")
 
-    def test_force_json_false_omits_response_format(self):
-        """When force_json=False, response_format is NOT passed to create()."""
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": []})
+    def test_usage_dict_has_token_counts(self):
+        """usage in result is a dict with input_tokens and output_tokens."""
+        payload = json.dumps({"segments": []})
+        fb = fake_backend.FakeBackend(
+            response_text=payload, input_tokens=10, output_tokens=20
         )
-        ext = _make_extractor(client=client, force_json=False)
-        ext.extract("story")
-        call_kwargs = client.chat.completions.create.call_args[1]
-        self.assertNotIn("response_format", call_kwargs)
+        ext = _make_extractor(backend=fb)
+        result = ext.extract("story")
+        self.assertEqual(result["usage"], {"input_tokens": 10, "output_tokens": 20})
 
     def test_last_messages_set(self):
         """After extract(), last_messages is populated."""
         payload = json.dumps({"segments": []})
-        ext, _, _ = self._make_ext_with_response(payload)
+        ext = _make_extractor(response_text=payload)
         ext.extract("test text")
         self.assertIsNotNone(ext.last_messages)
         self.assertEqual(ext.last_messages[0]["role"], "system")
@@ -467,16 +502,18 @@ class TestExtractSuccess(unittest.TestCase):
     def test_last_raw_output_set(self):
         """After a successful call, last_raw_output holds the model response."""
         payload = json.dumps({"segments": [1, 2]})
-        ext, _, _ = self._make_ext_with_response(payload)
+        ext = _make_extractor(response_text=payload)
         ext.extract("test text")
         self.assertEqual(ext.last_raw_output, payload)
 
     def test_call_dunder_delegates_to_extract(self):
         """__call__ returns the same result as extract()."""
         payload = json.dumps({"segments": ["a"]})
-        ext, _, _ = self._make_ext_with_response(payload)
-        result_call = ext("story text")
-        ext2, _, _ = self._make_ext_with_response(payload)
+        fb1 = fake_backend.FakeBackend(response_text=payload)
+        ext1 = _make_extractor(backend=fb1)
+        result_call = ext1("story text")
+        fb2 = fake_backend.FakeBackend(response_text=payload)
+        ext2 = _make_extractor(backend=fb2)
         result_extract = ext2.extract("story text")
         self.assertEqual(
             result_call["extracted_output"], result_extract["extracted_output"]
@@ -492,20 +529,16 @@ class TestExtractErrorPaths(unittest.TestCase):
     """Tests for extract() error/edge cases."""
 
     def test_api_exception_sets_api_error(self):
-        """When the client raises, api_error is set and extraction_error='api_error'."""
-        client = MagicMock()
-        client.chat.completions.create.side_effect = RuntimeError("network failure")
-        ext = _make_extractor(client=client)
+        """When the backend raises, api_error is set and extraction_error='api_error'."""
+        ext = _make_extractor(backend=_RaisingBackend(RuntimeError("network failure")))
         result = ext.extract("story")
         self.assertIsNotNone(result["api_error"])
         self.assertEqual(result["extraction_error"], "api_error")
         self.assertIsNone(result["extracted_output"])
 
     def test_api_exception_result_has_all_keys(self):
-        """Even on API exception, result dict has all expected keys."""
-        client = MagicMock()
-        client.chat.completions.create.side_effect = Exception("fail")
-        ext = _make_extractor(client=client)
+        """Even on backend exception, result dict has all expected keys."""
+        ext = _make_extractor(backend=_RaisingBackend(Exception("fail")))
         result = ext.extract("story")
         expected_keys = {
             "story_text",
@@ -529,11 +562,9 @@ class TestExtractErrorPaths(unittest.TestCase):
 
     def test_missing_output_key_sets_extraction_error(self):
         """When JSON is valid but missing output_key, extraction_error is set."""
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"other_key": []})
+        ext = _make_extractor(
+            response_text=json.dumps({"other_key": []}), output_key="segments"
         )
-        ext = _make_extractor(client=client, output_key="segments")
         result = ext.extract("story")
         self.assertIsNotNone(result["extraction_error"])
         self.assertIn("segments", result["extraction_error"])
@@ -541,35 +572,21 @@ class TestExtractErrorPaths(unittest.TestCase):
 
     def test_invalid_json_sets_parsing_error(self):
         """When model returns fenced invalid JSON, parsing_error is set."""
-        # Wrap in a fenced block so extract_json attempts json.loads on the content
-        # and raises JSONDecodeError (which extract() catches as parsing_error).
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            "```json\nnot valid json here\n```"
-        )
-        ext = _make_extractor(client=client)
+        ext = _make_extractor(response_text="```json\nnot valid json here\n```")
         result = ext.extract("story")
         self.assertEqual(result["extraction_error"], "parsing_error")
         self.assertIsNone(result["extracted_output"])
 
-    def test_empty_response_choices_sets_api_error(self):
-        """When response has no choices, api_error is set."""
-        client = MagicMock()
-        response = MagicMock()
-        response.choices = []
-        response.id = None
-        response.usage = None
-        client.chat.completions.create.return_value = response
-        ext = _make_extractor(client=client)
+    def test_empty_response_text_sets_api_error(self):
+        """When backend returns empty text, api_error is set."""
+        ext = _make_extractor(response_text="")
         result = ext.extract("story")
         self.assertIsNotNone(result["api_error"])
         self.assertEqual(result["api_error"]["code"], "empty_response")
 
     def test_story_text_preserved_in_result(self):
         """story_text in result matches the input."""
-        client = MagicMock()
-        client.chat.completions.create.side_effect = Exception("fail")
-        ext = _make_extractor(client=client)
+        ext = _make_extractor(backend=_RaisingBackend(Exception("fail")))
         result = ext.extract("my unique story")
         self.assertEqual(result["story_text"], "my unique story")
 
@@ -586,12 +603,9 @@ class TestExtractWithIndexer(unittest.TestCase):
         """text_indexer receives the raw story_text."""
         index_meta = {"canonical_text": "hello", "para_spans": [], "n_paragraphs": 1}
         indexer = MagicMock(return_value=("[P0001] hello", index_meta))
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": []})
-        )
+        fb = fake_backend.FakeBackend(response_text=json.dumps({"segments": []}))
         ext = _make_extractor(
-            client=client,
+            backend=fb,
             text_indexer=indexer,
             user_prompt_template="{story_text}",
         )
@@ -602,12 +616,9 @@ class TestExtractWithIndexer(unittest.TestCase):
         """index_meta from the indexer is stored in the result."""
         index_meta = {"n_paragraphs": 2}
         indexer = MagicMock(return_value=("[P0001] hello\n\n[P0002] world", index_meta))
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": []})
-        )
+        fb = fake_backend.FakeBackend(response_text=json.dumps({"segments": []}))
         ext = _make_extractor(
-            client=client,
+            backend=fb,
             text_indexer=indexer,
             user_prompt_template="{story_text}",
         )
@@ -628,12 +639,11 @@ class TestExtractWithAligner(unittest.TestCase):
         index_meta = {"n_paragraphs": 1}
         indexer = MagicMock(return_value=("[P0001] hello", index_meta))
         aligner = MagicMock(side_effect=lambda parsed, text, meta: parsed)
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": [{"id": 1}]})
+        fb = fake_backend.FakeBackend(
+            response_text=json.dumps({"segments": [{"id": 1}]})
         )
         ext = _make_extractor(
-            client=client,
+            backend=fb,
             text_indexer=indexer,
             result_aligner=aligner,
             user_prompt_template="{story_text}",
@@ -644,11 +654,10 @@ class TestExtractWithAligner(unittest.TestCase):
     def test_aligner_not_called_without_index_meta(self):
         """result_aligner is NOT invoked when there is no text_indexer (index_meta=None)."""
         aligner = MagicMock(side_effect=lambda parsed, text, meta: parsed)
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": [{"id": 1}]})
+        fb = fake_backend.FakeBackend(
+            response_text=json.dumps({"segments": [{"id": 1}]})
         )
-        ext = _make_extractor(client=client, result_aligner=aligner)
+        ext = _make_extractor(backend=fb, result_aligner=aligner)
         ext.extract("hello")
         aligner.assert_not_called()
 
@@ -657,12 +666,11 @@ class TestExtractWithAligner(unittest.TestCase):
         index_meta = {"n_paragraphs": 1}
         indexer = MagicMock(return_value=("[P0001] hello", index_meta))
         aligner = MagicMock(side_effect=RuntimeError("align failed"))
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": [{"id": 1}]})
+        fb = fake_backend.FakeBackend(
+            response_text=json.dumps({"segments": [{"id": 1}]})
         )
         ext = _make_extractor(
-            client=client,
+            backend=fb,
             text_indexer=indexer,
             result_aligner=aligner,
             user_prompt_template="{story_text}",
@@ -686,12 +694,11 @@ class TestExtractWithValidator(unittest.TestCase):
         indexer = MagicMock(return_value=("[P0001] hello", index_meta))
         report = {"score": 1.0}
         validator = MagicMock(return_value=report)
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": [{"id": 1}]})
+        fb = fake_backend.FakeBackend(
+            response_text=json.dumps({"segments": [{"id": 1}]})
         )
         ext = _make_extractor(
-            client=client,
+            backend=fb,
             text_indexer=indexer,
             result_validator=validator,
             user_prompt_template="{story_text}",
@@ -703,11 +710,10 @@ class TestExtractWithValidator(unittest.TestCase):
     def test_validator_not_called_without_index_meta(self):
         """result_validator is NOT invoked when index_meta is None."""
         validator = MagicMock(return_value={})
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": [{"id": 1}]})
+        fb = fake_backend.FakeBackend(
+            response_text=json.dumps({"segments": [{"id": 1}]})
         )
-        ext = _make_extractor(client=client, result_validator=validator)
+        ext = _make_extractor(backend=fb, result_validator=validator)
         ext.extract("hello")
         validator.assert_not_called()
 
@@ -716,12 +722,11 @@ class TestExtractWithValidator(unittest.TestCase):
         index_meta = {"n_paragraphs": 1}
         indexer = MagicMock(return_value=("[P0001] hello", index_meta))
         validator = MagicMock(side_effect=RuntimeError("validate failed"))
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": [{"id": 1}]})
+        fb = fake_backend.FakeBackend(
+            response_text=json.dumps({"segments": [{"id": 1}]})
         )
         ext = _make_extractor(
-            client=client,
+            backend=fb,
             text_indexer=indexer,
             result_validator=validator,
             user_prompt_template="{story_text}",
@@ -736,12 +741,11 @@ class TestExtractWithValidator(unittest.TestCase):
         indexer = MagicMock(return_value=("[P0001] hello", index_meta))
         report = {"ok": True}
         validator = MagicMock(return_value=report)
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": [{"id": 1}]})
+        fb = fake_backend.FakeBackend(
+            response_text=json.dumps({"segments": [{"id": 1}]})
         )
         ext = _make_extractor(
-            client=client,
+            backend=fb,
             text_indexer=indexer,
             result_validator=validator,
             user_prompt_template="{story_text}",
@@ -760,22 +764,20 @@ class TestResultSerializable(unittest.TestCase):
 
     def test_success_result_serializable(self):
         """Success result without 'response' key is JSON-serializable."""
-        client = MagicMock()
-        client.chat.completions.create.return_value = _make_mock_response(
-            json.dumps({"segments": [{"id": 1, "text": "hello"}]})
+        fb = fake_backend.FakeBackend(
+            response_text=json.dumps({"segments": [{"id": 1, "text": "hello"}]}),
+            input_tokens=5,
+            output_tokens=10,
         )
-        ext = _make_extractor(client=client)
+        ext = _make_extractor(backend=fb)
         result = ext.extract("story")
         result_copy = {k: v for k, v in result.items() if k != "response"}
-        # Should not raise
         serialized = json.dumps(result_copy)
         self.assertIsInstance(serialized, str)
 
     def test_error_result_serializable(self):
         """Error result (api_error path) without 'response' key is JSON-serializable."""
-        client = MagicMock()
-        client.chat.completions.create.side_effect = RuntimeError("boom")
-        ext = _make_extractor(client=client)
+        ext = _make_extractor(backend=_RaisingBackend(RuntimeError("boom")))
         result = ext.extract("story")
         result_copy = {k: v for k, v in result.items() if k != "response"}
         serialized = json.dumps(result_copy)

--- a/lcats/tests/analysis_tests/scene_analysis_test.py
+++ b/lcats/tests/analysis_tests/scene_analysis_test.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from parameterized import parameterized
 
 from lcats.analysis import scene_analysis
+from lcats.llm import fake_backend
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -214,34 +215,34 @@ class TestMakeSegmentExtractor(unittest.TestCase):
     def test_returns_json_prompt_extractor(self):
         from lcats.analysis import llm_extractor
 
-        client = MagicMock()
-        extractor = scene_analysis.make_segment_extractor(client)
+        fb = fake_backend.FakeBackend()
+        extractor = scene_analysis.make_segment_extractor(fb)
         self.assertIsInstance(extractor, llm_extractor.JSONPromptExtractor)
 
     def test_output_key_is_segments(self):
-        extractor = scene_analysis.make_segment_extractor(MagicMock())
+        extractor = scene_analysis.make_segment_extractor(fake_backend.FakeBackend())
         self.assertEqual(extractor.output_key, "segments")
 
     def test_default_model_is_gpt4o(self):
-        extractor = scene_analysis.make_segment_extractor(MagicMock())
+        extractor = scene_analysis.make_segment_extractor(fake_backend.FakeBackend())
         self.assertEqual(extractor.default_model, "gpt-4o")
 
     def test_text_indexer_is_set(self):
         from lcats.analysis import text_segmenter
 
-        extractor = scene_analysis.make_segment_extractor(MagicMock())
+        extractor = scene_analysis.make_segment_extractor(fake_backend.FakeBackend())
         self.assertIs(extractor.text_indexer, text_segmenter.paragraph_text_indexer)
 
     def test_result_aligner_is_set(self):
         from lcats.analysis import text_segmenter
 
-        extractor = scene_analysis.make_segment_extractor(MagicMock())
+        extractor = scene_analysis.make_segment_extractor(fake_backend.FakeBackend())
         self.assertIs(extractor.result_aligner, text_segmenter.segments_result_aligner)
 
     def test_result_validator_is_set(self):
         from lcats.analysis import text_segmenter
 
-        extractor = scene_analysis.make_segment_extractor(MagicMock())
+        extractor = scene_analysis.make_segment_extractor(fake_backend.FakeBackend())
         self.assertIs(extractor.result_validator, text_segmenter.segments_auditor)
 
 
@@ -256,24 +257,24 @@ class TestMakeSemanticsExtractor(unittest.TestCase):
     def test_returns_json_prompt_extractor(self):
         from lcats.analysis import llm_extractor
 
-        client = MagicMock()
-        extractor = scene_analysis.make_semantics_extractor(client)
+        fb = fake_backend.FakeBackend()
+        extractor = scene_analysis.make_semantics_extractor(fb)
         self.assertIsInstance(extractor, llm_extractor.JSONPromptExtractor)
 
     def test_output_key_is_judgment(self):
-        extractor = scene_analysis.make_semantics_extractor(MagicMock())
+        extractor = scene_analysis.make_semantics_extractor(fake_backend.FakeBackend())
         self.assertEqual(extractor.output_key, "judgment")
 
     def test_text_indexer_is_none(self):
-        extractor = scene_analysis.make_semantics_extractor(MagicMock())
+        extractor = scene_analysis.make_semantics_extractor(fake_backend.FakeBackend())
         self.assertIsNone(extractor.text_indexer)
 
     def test_result_aligner_is_none(self):
-        extractor = scene_analysis.make_semantics_extractor(MagicMock())
+        extractor = scene_analysis.make_semantics_extractor(fake_backend.FakeBackend())
         self.assertIsNone(extractor.result_aligner)
 
     def test_default_model_is_gpt4o(self):
-        extractor = scene_analysis.make_semantics_extractor(MagicMock())
+        extractor = scene_analysis.make_semantics_extractor(fake_backend.FakeBackend())
         self.assertEqual(extractor.default_model, "gpt-4o")
 
 

--- a/lcats/tests/analysis_tests/story_analysis_test.py
+++ b/lcats/tests/analysis_tests/story_analysis_test.py
@@ -3,6 +3,7 @@
 import unittest
 import unittest.mock
 from lcats.analysis import story_analysis
+from lcats.llm import fake_backend
 import lcats.utils.tokenizer_test_utils as tokenizer_test_utils
 
 # ---------------------------------------------------------------------------
@@ -554,27 +555,27 @@ class TestMakeDocClassificationExtractor(unittest.TestCase):
     def test_returns_json_prompt_extractor(self):
         from lcats.analysis import llm_extractor
 
-        client = unittest.mock.MagicMock()
+        client = fake_backend.FakeBackend()
         extractor = story_analysis.make_doc_classification_extractor(client)
         self.assertIsInstance(extractor, llm_extractor.JSONPromptExtractor)
 
     def test_output_key_is_classification(self):
-        client = unittest.mock.MagicMock()
+        client = fake_backend.FakeBackend()
         extractor = story_analysis.make_doc_classification_extractor(client)
         self.assertEqual(extractor.output_key, "classification")
 
     def test_default_model_is_gpt4o(self):
-        client = unittest.mock.MagicMock()
+        client = fake_backend.FakeBackend()
         extractor = story_analysis.make_doc_classification_extractor(client)
         self.assertEqual(extractor.default_model, "gpt-4o")
 
     def test_text_indexer_is_none(self):
-        client = unittest.mock.MagicMock()
+        client = fake_backend.FakeBackend()
         extractor = story_analysis.make_doc_classification_extractor(client)
         self.assertIsNone(extractor.text_indexer)
 
     def test_result_aligner_is_none(self):
-        client = unittest.mock.MagicMock()
+        client = fake_backend.FakeBackend()
         extractor = story_analysis.make_doc_classification_extractor(client)
         self.assertIsNone(extractor.result_aligner)
 

--- a/lcats/tests/analysis_tests/story_processors_test.py
+++ b/lcats/tests/analysis_tests/story_processors_test.py
@@ -6,6 +6,7 @@ import unittest.mock
 from unittest.mock import MagicMock, patch
 
 from lcats.analysis import story_processors
+from lcats.llm import fake_backend
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -149,13 +150,13 @@ class TestMakeAnnotatedSegmentExtractorFactory(unittest.TestCase):
     """Tests for make_annotated_segment_extractor factory (not the inner callable)."""
 
     def test_returns_callable(self):
-        client = MagicMock()
+        client = fake_backend.FakeBackend()
         processor = story_processors.make_annotated_segment_extractor(client)
         self.assertTrue(callable(processor))
 
     def test_default_models_stored(self):
         """Returned processor captures default model names from factory."""
-        client = MagicMock()
+        client = fake_backend.FakeBackend()
         with patch("lcats.analysis.scene_analysis.make_segment_extractor") as ms, patch(
             "lcats.analysis.scene_analysis.make_semantics_extractor"
         ) as mm:
@@ -168,14 +169,14 @@ class TestMakeAnnotatedSegmentExtractorFactory(unittest.TestCase):
         self.assertTrue(callable(processor))
 
     def test_custom_model_names_accepted(self):
-        client = MagicMock()
+        client = fake_backend.FakeBackend()
         processor = story_processors.make_annotated_segment_extractor(
             client, segment_model="gpt-3.5", semantic_model="gpt-3.5"
         )
         self.assertTrue(callable(processor))
 
     def test_include_validation_false_accepted(self):
-        client = MagicMock()
+        client = fake_backend.FakeBackend()
         processor = story_processors.make_annotated_segment_extractor(
             client, include_validation=False
         )
@@ -218,7 +219,7 @@ class TestProcessorFunction(unittest.TestCase):
         mock_sem_extractor = MagicMock()
         mock_encoder = _make_mock_encoder()
 
-        client = MagicMock()
+        client = fake_backend.FakeBackend()
 
         if raise_in_annotate is not None:
             annotate_kwargs = {"side_effect": raise_in_annotate}
@@ -289,7 +290,7 @@ class TestProcessorFunction(unittest.TestCase):
         mock_sem = MagicMock()
         mock_enc = _make_mock_encoder()
 
-        client = MagicMock()
+        client = fake_backend.FakeBackend()
         with patch(
             "lcats.analysis.scene_analysis.make_segment_extractor",
             return_value=mock_seg,

--- a/lcats/tests/extraction_test.py
+++ b/lcats/tests/extraction_test.py
@@ -1,6 +1,8 @@
+import json
 import unittest
-from unittest.mock import Mock
+
 from lcats import extraction
+from lcats.llm import fake_backend
 
 
 class TestExtraction(unittest.TestCase):
@@ -14,25 +16,17 @@ class TestExtraction(unittest.TestCase):
             user_template='Story to process:\n"""{story_text}"""',
         )
 
-        self.valid_response_json = {
-            "events": [
-                {"type": "scene", "text": "Alice opened the door."},
-                {"type": "none", "text": "She stepped into a world of wonder."},
-            ]
-        }
+        self.valid_events_json = json.dumps(
+            {
+                "events": [
+                    {"type": "scene", "text": "Alice opened the door."},
+                    {"type": "none", "text": "She stepped into a world of wonder."},
+                ]
+            }
+        )
 
-        self.fake_client = Mock()
-        self.fake_client.chat.completions.create.return_value = Mock(
-            choices=[
-                Mock(
-                    message=Mock(
-                        content='{"events": ['
-                        '{"type": "scene", "text": "Alice opened the door."}, '
-                        '{"type": "none", "text": "She stepped into a world of wonder."}'
-                        "]}"
-                    )
-                )
-            ]
+        self.fake_backend = fake_backend.FakeBackend(
+            response_text=self.valid_events_json
         )
 
     def test_prompt_template_renders_correctly(self):
@@ -44,35 +38,44 @@ class TestExtraction(unittest.TestCase):
 
     def test_extract_successful(self):
         result = extraction.extract_from_story(
-            story_text=self.story, template=self.template, client=self.fake_client
+            story_text=self.story,
+            template=self.template,
+            backend=self.fake_backend,
         )
-        self.assertEqual(result.model_name, "gpt-3.5-turbo")
         self.assertEqual(len(result.extracted_output), 2)
         self.assertIsNone(result.parsing_error)
         self.assertIsNone(result.extraction_error)
         self.assertEqual(result.extracted_output[0]["type"], "scene")
 
-    def test_extract_fails_on_invalid_json(self):
-        # Patch the client's output to return invalid JSON
-        message = self.fake_client.chat.completions.create.return_value.choices[
-            0
-        ].message
-        message.content = "this is not JSON"
+    def test_extract_model_name_from_backend_response(self):
+        """model_name in ExtractionResult comes from BackendResponse.model."""
+        fb = fake_backend.FakeBackend(
+            response_text=self.valid_events_json, model="test-model-v1"
+        )
         result = extraction.extract_from_story(
-            story_text=self.story, template=self.template, client=self.fake_client
+            story_text=self.story,
+            template=self.template,
+            backend=fb,
+        )
+        self.assertEqual(result.model_name, "test-model-v1")
+
+    def test_extract_fails_on_invalid_json(self):
+        fb = fake_backend.FakeBackend(response_text="this is not JSON")
+        result = extraction.extract_from_story(
+            story_text=self.story,
+            template=self.template,
+            backend=fb,
         )
         self.assertIsNone(result.parsed_output)
         self.assertIsNotNone(result.parsing_error)
         self.assertIn("No parsed JSON", result.extraction_error)
 
     def test_extract_fails_on_missing_events_key(self):
-        # Return valid JSON but missing "events"
-        message = self.fake_client.chat.completions.create.return_value.choices[
-            0
-        ].message
-        message.content = '{"not_events": []}'
+        fb = fake_backend.FakeBackend(response_text='{"not_events": []}')
         result = extraction.extract_from_story(
-            story_text=self.story, template=self.template, client=self.fake_client
+            story_text=self.story,
+            template=self.template,
+            backend=fb,
         )
         self.assertIsNotNone(result.parsed_output)
         self.assertIsNone(result.extracted_output)
@@ -80,58 +83,35 @@ class TestExtraction(unittest.TestCase):
 
     def test_summary(self):
         result = extraction.extract_from_story(
-            story_text=self.story, template=self.template, client=self.fake_client
+            story_text=self.story,
+            template=self.template,
+            backend=self.fake_backend,
         )
         summary = result.summary()
-        self.assertIn("Model: gpt-3.5-turbo", summary)
         self.assertIn("Events extracted: 2", summary)
+
+    def test_backend_called_with_correct_system_prompt(self):
+        """extract_from_story passes system template as system= arg."""
+        fb = fake_backend.FakeBackend(response_text=self.valid_events_json)
+        extraction.extract_from_story(
+            story_text=self.story,
+            template=self.template,
+            backend=fb,
+        )
+        self.assertEqual(len(fb.calls), 1)
+        self.assertEqual(fb.calls[0]["system"], "System prompt here.")
+
+    def test_backend_called_with_story_in_messages(self):
+        """extract_from_story passes story text inside messages."""
+        fb = fake_backend.FakeBackend(response_text=self.valid_events_json)
+        extraction.extract_from_story(
+            story_text=self.story,
+            template=self.template,
+            backend=fb,
+        )
+        user_content = fb.calls[0]["messages"][0]["content"]
+        self.assertIn(self.story, user_content)
 
 
 if __name__ == "__main__":
     unittest.main()
-
-    def test_extract_fails_on_invalid_json(self):
-        self.fake_client.chat.completions.create.return_value.choices[
-            0
-        ].message.content = "not valid json"
-        result = extraction.extract_from_story(
-            story_text=self.story, template=self.template, client=self.fake_client
-        )
-        self.assertIsNone(result.parsed_output)
-        self.assertIsNone(result.extracted_output)
-        self.assertIsNotNone(result.parsing_error)
-        self.assertIn("No parsed JSON", result.extraction_error)
-
-    def test_extract_fails_on_missing_events_key(self):
-        self.fake_client.chat.completions.create.return_value.choices[
-            0
-        ].message.content = '{"unexpected": []}'
-        result = extraction.extract_from_story(
-            story_text=self.story, template=self.template, client=self.fake_client
-        )
-        self.assertIsNotNone(result.parsed_output)
-        self.assertIsNone(result.extracted_output)
-        self.assertIn("missing 'events' key", result.extraction_error)
-
-    def test_summary_and_validation(self):
-        result = extraction.extract_from_story(
-            story_text=self.story, template=self.template, client=self.fake_client
-        )
-        summary = result.summary()
-        self.assertIn("Model: gpt-3.5-turbo", summary)
-        self.assertIn("Events extracted: 2", summary)
-        self.assertEqual(result.validate_events(), [])
-
-    def test_validate_events_reports_missing_fields(self):
-        # Provide malformed event data
-        malformed_json = '{"events": [{"text": "no type"}, "not a dict"]}'
-        self.fake_client.chat.completions.create.return_value.choices[
-            0
-        ].message.content = malformed_json
-        result = extraction.extract_from_story(
-            story_text=self.story, template=self.template, client=self.fake_client
-        )
-        errors = result.validate_events()
-        self.assertEqual(len(errors), 2)
-        self.assertIn("missing 'text' or 'type'", errors[0])
-        self.assertIn("not a dictionary", errors[1])


### PR DESCRIPTION
## Summary

- Replaces all `client.chat.completions.create` calls in `llm_extractor.py` and `extraction.py` with `backend.complete()` via the `LLMBackend` Protocol introduced in WI-LLM-0007
- Renames the `client` parameter to `backend` in `JSONPromptExtractor.__init__` and all four factory functions (`make_segment_extractor`, `make_semantics_extractor`, `make_doc_classification_extractor`, `make_annotated_segment_extractor`)
- Deprecates the `force_json=` parameter with an `_UNSET` sentinel and `DeprecationWarning`; removes it from all factory callers
- Normalizes the result shape: `model_name` from `BackendResponse.model`, `usage` as `{"input_tokens": N, "output_tokens": N}`, `response` as `BackendResponse.raw`
- Replaces all `MagicMock`/`Mock` client stubs across five test files with `FakeBackend` stubs

## Prompt ID

`PROMPT(WI-LLM-0008:WI_LLM_0008_MIGRATE_EXTRACTOR)[2026-06-30T22:16:01-04:00]`

## Validation

- `black --check`: passes on all changed files
- `ruff check`: passes on all changed files  
- `scripts/test`: 1213 tests passing

## Test plan

- [ ] Review `llm_extractor_test.py` — all paths covered: success, error, deprecation warning, JSON serializable result
- [ ] Review `extraction_test.py` — success, invalid JSON, missing events key, model_name from BackendResponse
- [ ] Run `scripts/test` locally: 1213 tests
- [ ] Confirm no `chat.completions.create` outside `lcats/llm/` (only in `openai_backend.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)