### PR TITLE
Implement WI-INFRA-0011: secrets utility and contributor guide

### DIFF
--- a/experiments/02_llm_backend_comparison/smoke_test.py
+++ b/experiments/02_llm_backend_comparison/smoke_test.py
@@ -17,8 +17,9 @@ Optional flags:
 
 Requires:
     - lcats installed (run scripts/develop if not)
-    - ANTHROPIC_API_KEY set in environment
-    - OPENAI_API_KEY set in environment
+    - ANTHROPIC_API_KEY and OPENAI_API_KEY set in environment OR present in
+      .secrets/anthropic_api_keys.env and .secrets/openai_api_keys.env
+      (see lcats/docs/secrets-setup.md)
 
 Exit codes:
     0   all legs completed (individual story errors are noted, not fatal)
@@ -54,6 +55,10 @@ except ImportError:
         "error: lcats package not found.\n"
         "       Activate your conda environment and run: scripts/develop"
     )
+
+from lcats.utils.secrets import load_secrets  # noqa: E402
+
+load_secrets()  # no-op if .secrets/ absent or keys already exported
 
 import run_comparison  # noqa: E402  (local module, after path bootstrap)
 import compare_results  # noqa: E402

--- a/lcats/docs/secrets-setup.md
+++ b/lcats/docs/secrets-setup.md
@@ -1,0 +1,96 @@
+# API Key Setup — `.secrets/` Pattern
+
+LCATS uses a gitignored `.secrets/` directory at the repo root to store API
+keys locally. This lets you run notebooks and experiment scripts without
+exporting keys in your shell each time, and without any risk of accidentally
+committing them.
+
+## Why `.secrets/` and not `export`?
+
+Sourcing a `.env` file with `source .secrets/file.env` sets *shell* variables.
+Python's `os.environ` only sees *process environment* variables (those marked
+with `export`). The `.secrets/` pattern uses `python-dotenv` to load files
+directly into `os.environ`, so keys are available to Python without the
+manual `export` step.
+
+Shell-exported keys always take precedence — `python-dotenv` does not override
+variables already present in the environment, so CI/CD secrets managers and
+explicit `export` commands continue to work unchanged.
+
+## Directory structure
+
+```
+.secrets/                          ← gitignored; never committed
+├── anthropic_api_keys.env         ← Anthropic API key
+└── openai_api_keys.env            ← OpenAI API key
+```
+
+The `.secrets/` directory is listed in `.gitignore` at the repo root. Git will
+never stage or commit its contents.
+
+## Setup
+
+Create the directory and one file per provider:
+
+```bash
+mkdir -p .secrets
+
+# Anthropic
+echo "ANTHROPIC_API_KEY=sk-ant-..." > .secrets/anthropic_api_keys.env
+
+# OpenAI
+echo "OPENAI_API_KEY=sk-proj-..." > .secrets/openai_api_keys.env
+```
+
+Replace `sk-ant-...` and `sk-proj-...` with your actual keys. Get them from:
+
+- Anthropic: https://console.anthropic.com/settings/keys
+- OpenAI: https://platform.openai.com/api-keys
+
+## How it works
+
+`lcats.utils.secrets.load_secrets()` globs all `*.env` files in `.secrets/`
+alphabetically and calls `dotenv.load_dotenv()` on each. It is called
+automatically at the top of experiment scripts such as
+`experiments/02_llm_backend_comparison/smoke_test.py`.
+
+You can also call it directly:
+
+```python
+from lcats.utils.secrets import load_secrets
+
+load_secrets()  # loads from <repo_root>/.secrets/ by default
+```
+
+Or point it at a different directory:
+
+```python
+load_secrets(secrets_dir=pathlib.Path("/path/to/my/keys"))
+```
+
+If `.secrets/` does not exist, `load_secrets()` silently no-ops — no error,
+no warning. This is the correct behaviour in CI/CD environments where keys
+come from the environment directly.
+
+## Notebooks
+
+Notebooks in `lcats/notebooks/` pre-date this utility and load the OpenAI key
+directly via `dotenv.load_dotenv()`. They continue to work without change.
+Migrating them to `load_secrets()` is welcome but not required.
+
+## Verifying setup
+
+After populating `.secrets/`, run:
+
+```bash
+python -c "
+from lcats.utils.secrets import load_secrets
+import os
+load_secrets()
+print('ANTHROPIC_API_KEY:', 'set' if os.environ.get('ANTHROPIC_API_KEY') else 'MISSING')
+print('OPENAI_API_KEY:', 'set' if os.environ.get('OPENAI_API_KEY') else 'MISSING')
+"
+```
+
+Both lines should print `set`. If a key shows `MISSING`, check that the
+corresponding `.env` file exists and contains a non-empty value.

--- a/lcats/docs/secrets-setup.md
+++ b/lcats/docs/secrets-setup.md
@@ -65,6 +65,7 @@ load_secrets()  # loads from <repo_root>/.secrets/ by default
 Or point it at a different directory:
 
 ```python
+import pathlib
 load_secrets(secrets_dir=pathlib.Path("/path/to/my/keys"))
 ```
 

--- a/lcats/lcats/utils/secrets.py
+++ b/lcats/lcats/utils/secrets.py
@@ -1,0 +1,46 @@
+"""Load API keys from the project's gitignored .secrets/ directory.
+
+The .secrets/ directory lives at the repo root and is excluded from version
+control. Each provider has its own .env file:
+
+    .secrets/anthropic_api_keys.env   — ANTHROPIC_API_KEY=sk-ant-...
+    .secrets/openai_api_keys.env      — OPENAI_API_KEY=sk-proj-...
+
+call load_secrets() early in any script that needs API keys. It does not
+override keys that are already set in the environment, so shell exports and
+CI/CD secrets managers take precedence automatically.
+
+See lcats/docs/secrets-setup.md for setup instructions.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+# .secrets/ is three package dirs above this file, then one more to the repo root:
+#   lcats/lcats/utils/secrets.py
+#       parents[0] = lcats/lcats/utils/
+#       parents[1] = lcats/lcats/
+#       parents[2] = lcats/        (package root, contains pyproject.toml)
+#       parents[3] = LCATS/LCATS/  (repo root, contains .secrets/)
+_DEFAULT_SECRETS_DIR = pathlib.Path(__file__).resolve().parents[3] / ".secrets"
+
+
+def load_secrets(secrets_dir: pathlib.Path | None = None) -> None:
+    """Load *.env files from secrets_dir into os.environ.
+
+    Already-exported variables are not overridden (python-dotenv default).
+    Silently no-ops if secrets_dir does not exist, so CI/CD environments
+    that inject keys via the environment work without any local .secrets/ dir.
+
+    Args:
+        secrets_dir: directory containing .env files. Defaults to
+            <repo_root>/.secrets/ relative to this file's location.
+    """
+    import dotenv
+
+    target = secrets_dir if secrets_dir is not None else _DEFAULT_SECRETS_DIR
+    if not target.is_dir():
+        return
+    for env_file in sorted(target.glob("*.env")):
+        dotenv.load_dotenv(env_file)

--- a/lcats/lcats/utils/secrets.py
+++ b/lcats/lcats/utils/secrets.py
@@ -6,7 +6,7 @@ control. Each provider has its own .env file:
     .secrets/anthropic_api_keys.env   — ANTHROPIC_API_KEY=sk-ant-...
     .secrets/openai_api_keys.env      — OPENAI_API_KEY=sk-proj-...
 
-call load_secrets() early in any script that needs API keys. It does not
+Call load_secrets() early in any script that needs API keys. It does not
 override keys that are already set in the environment, so shell exports and
 CI/CD secrets managers take precedence automatically.
 
@@ -37,10 +37,10 @@ def load_secrets(secrets_dir: pathlib.Path | None = None) -> None:
         secrets_dir: directory containing .env files. Defaults to
             <repo_root>/.secrets/ relative to this file's location.
     """
-    import dotenv
-
     target = secrets_dir if secrets_dir is not None else _DEFAULT_SECRETS_DIR
     if not target.is_dir():
         return
+    import dotenv
+
     for env_file in sorted(target.glob("*.env")):
-        dotenv.load_dotenv(env_file)
+        dotenv.load_dotenv(env_file, override=False)

--- a/lcats/project/executions/AD_HOC/2026_07_02_19_17_13_WI_INFRA_0011_REVIEW_2.md
+++ b/lcats/project/executions/AD_HOC/2026_07_02_19_17_13_WI_INFRA_0011_REVIEW_2.md
@@ -1,0 +1,46 @@
+---
+execution_id: 2026_07_02_19_17_13_WI_INFRA_0011_REVIEW_2
+prompt_id: PROMPT(AD_HOC:WI_INFRA_0011_REVIEW_2)[2026-07-02T19:13:12-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_02_17_37_48_WI_INFRA_0011
+pr: https://github.com/xenotaur/LCATS/pull/105
+commit: 
+created_at: 2026-07-02T19:17:13-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/105
+session_transcript: pending
+---
+
+# Summary
+
+Address review comments on PR #105 (WI-INFRA-0011 implementation).
+
+# Result
+
+Fixed 4 comments; skipped 1 (intentional LRH protocol).
+
+- `secrets.py`: moved `import dotenv` after `is_dir()` guard — missing-dir
+  no-op no longer requires `python-dotenv` to be importable.
+- `secrets.py`: added `override=False` to `dotenv.load_dotenv()` — makes
+  the no-override guarantee explicit rather than relying on upstream default.
+- `secrets.py`: capitalized module docstring "call" → "Call".
+- `secrets_test.py`: added `TestLoadSecretsDefaultDir` — patches
+  `_DEFAULT_SECRETS_DIR` and asserts it is used when no arg is passed.
+- `docs/secrets-setup.md`: added `import pathlib` to the explicit-dir
+  code snippet so it is self-contained.
+- Skipped comment about execution record `status: in_progress` / empty
+  `commit:` — this is correct LRH protocol for an open PR; `/lrh-closeout`
+  populates `commit:` and sets `status: landed` after the PR merges.
+
+# Validation
+
+- `scripts/format --check --diff` — 141 files unchanged
+- `scripts/lint` — all checks passed
+- `scripts/test` — 1248 tests OK
+- `lrh validate` — 0 errors, 16 warnings (all pre-existing)
+
+# Follow-up
+
+- Update `session_transcript: pending` to `claude-app:<session-id>` after
+  session ends.

--- a/lcats/project/executions/WI-INFRA-0011/2026_07_02_17_37_48_WI_INFRA_0011.md
+++ b/lcats/project/executions/WI-INFRA-0011/2026_07_02_17_37_48_WI_INFRA_0011.md
@@ -1,0 +1,47 @@
+---
+execution_id: 2026_07_02_17_37_48_WI_INFRA_0011
+prompt_id: PROMPT(WI-INFRA-0011:WI_INFRA_0011)[2026-07-02T17:28:53-04:00]
+work_item: WI-INFRA-0011
+status: in_progress
+rerun_of: null
+pr: https://github.com/xenotaur/LCATS/pull/105
+commit: 
+created_at: 2026-07-02T17:37:48-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-INFRA-0011.md
+session_transcript: pending
+---
+
+# Summary
+
+Implement `load_secrets()` utility in `lcats/lcats/utils/secrets.py`, add
+`python-dotenv` to main dependencies, update `smoke_test.py` to call the
+utility, write `lcats/docs/secrets-setup.md`, and add unittest coverage.
+
+# Result
+
+All five artifacts delivered:
+
+- `lcats/lcats/utils/secrets.py` — `load_secrets(secrets_dir=None)` globs
+  `.secrets/*.env` alphabetically, loads via `dotenv.load_dotenv()` (no
+  override of existing env vars), silently no-ops if dir is absent.
+- `lcats/pyproject.toml` — `python-dotenv` added to `[project.dependencies]`.
+- `lcats/tests/utils_tests/secrets_test.py` — 5 unittest cases.
+- `experiments/02_llm_backend_comparison/smoke_test.py` — `load_secrets()`
+  called before `_check_keys()`; `Requires:` docstring updated.
+- `lcats/docs/secrets-setup.md` — contributor guide.
+
+# Validation
+
+- Black 26.3.1, Ruff 0.15.12, Python 3.11.8
+- `scripts/format --check --diff` — 141 files unchanged
+- `scripts/lint` — all checks passed
+- `scripts/test` — 1247 tests OK (9.9s)
+- `lrh validate` — 0 errors, 16 warnings (all pre-existing)
+- `python -c "from lcats.utils.secrets import load_secrets; print('ok')"` — ok
+
+# Follow-up
+
+- Update `session_transcript: pending` to `claude-app:<session-id>` after
+  session ends.
+- Merge PR #105 and run `/lrh-closeout` to resolve WI-INFRA-0011.

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
    "gutenbergpy @ git+https://github.com/xenotaur/gutenbergpy.git@LCATS/TitleFix",
    "anthropic",
    "openai>=1.0.0",
+   "python-dotenv",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/lcats/tests/utils_tests/secrets_test.py
+++ b/lcats/tests/utils_tests/secrets_test.py
@@ -1,0 +1,86 @@
+"""Tests for lcats.utils.secrets.load_secrets."""
+
+import os
+import pathlib
+import tempfile
+import unittest
+
+from lcats.utils import secrets
+
+
+class TestLoadSecretsFromFile(unittest.TestCase):
+    """Keys not in the environment are loaded from .env files."""
+
+    def test_loads_key_from_env_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = pathlib.Path(tmpdir) / "test_api_keys.env"
+            env_file.write_text("TEST_LCATS_KEY=sentinel-value\n")
+            os.environ.pop("TEST_LCATS_KEY", None)
+            try:
+                secrets.load_secrets(secrets_dir=pathlib.Path(tmpdir))
+                self.assertEqual(os.environ.get("TEST_LCATS_KEY"), "sentinel-value")
+            finally:
+                os.environ.pop("TEST_LCATS_KEY", None)
+
+
+class TestLoadSecretsNoOverride(unittest.TestCase):
+    """Already-exported variables are not overridden."""
+
+    def test_does_not_override_existing_env_var(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = pathlib.Path(tmpdir) / "test_api_keys.env"
+            env_file.write_text("TEST_LCATS_KEY=from-file\n")
+            os.environ["TEST_LCATS_KEY"] = "from-shell"
+            try:
+                secrets.load_secrets(secrets_dir=pathlib.Path(tmpdir))
+                self.assertEqual(os.environ.get("TEST_LCATS_KEY"), "from-shell")
+            finally:
+                os.environ.pop("TEST_LCATS_KEY", None)
+
+
+class TestLoadSecretsMissingDir(unittest.TestCase):
+    """Missing secrets_dir is a silent no-op."""
+
+    def test_missing_dir_does_not_raise(self):
+        nonexistent = pathlib.Path("/tmp/lcats_test_no_such_dir_xyz")
+        try:
+            secrets.load_secrets(secrets_dir=nonexistent)
+        except Exception as exc:  # pragma: no cover
+            self.fail(f"load_secrets raised unexpectedly: {exc}")
+
+
+class TestLoadSecretsMultipleFiles(unittest.TestCase):
+    """All .env files in secrets_dir are loaded."""
+
+    def test_loads_from_multiple_env_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (pathlib.Path(tmpdir) / "a_keys.env").write_text("TEST_LCATS_A=val-a\n")
+            (pathlib.Path(tmpdir) / "b_keys.env").write_text("TEST_LCATS_B=val-b\n")
+            for key in ("TEST_LCATS_A", "TEST_LCATS_B"):
+                os.environ.pop(key, None)
+            try:
+                secrets.load_secrets(secrets_dir=pathlib.Path(tmpdir))
+                self.assertEqual(os.environ.get("TEST_LCATS_A"), "val-a")
+                self.assertEqual(os.environ.get("TEST_LCATS_B"), "val-b")
+            finally:
+                for key in ("TEST_LCATS_A", "TEST_LCATS_B"):
+                    os.environ.pop(key, None)
+
+
+class TestLoadSecretsExplicitDir(unittest.TestCase):
+    """Explicit secrets_dir argument is respected over the default."""
+
+    def test_explicit_dir_overrides_default(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = pathlib.Path(tmpdir) / "explicit.env"
+            env_file.write_text("TEST_LCATS_EXPLICIT=explicit-val\n")
+            os.environ.pop("TEST_LCATS_EXPLICIT", None)
+            try:
+                secrets.load_secrets(secrets_dir=pathlib.Path(tmpdir))
+                self.assertEqual(os.environ.get("TEST_LCATS_EXPLICIT"), "explicit-val")
+            finally:
+                os.environ.pop("TEST_LCATS_EXPLICIT", None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/utils_tests/secrets_test.py
+++ b/lcats/tests/utils_tests/secrets_test.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import tempfile
 import unittest
+import unittest.mock
 
 from lcats.utils import secrets
 
@@ -65,6 +66,24 @@ class TestLoadSecretsMultipleFiles(unittest.TestCase):
             finally:
                 for key in ("TEST_LCATS_A", "TEST_LCATS_B"):
                     os.environ.pop(key, None)
+
+
+class TestLoadSecretsDefaultDir(unittest.TestCase):
+    """load_secrets() with no args uses _DEFAULT_SECRETS_DIR."""
+
+    def test_default_dir_is_used_when_no_arg_given(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_file = pathlib.Path(tmpdir) / "default.env"
+            env_file.write_text("TEST_LCATS_DEFAULT=default-val\n")
+            os.environ.pop("TEST_LCATS_DEFAULT", None)
+            try:
+                with unittest.mock.patch.object(
+                    secrets, "_DEFAULT_SECRETS_DIR", pathlib.Path(tmpdir)
+                ):
+                    secrets.load_secrets()
+                self.assertEqual(os.environ.get("TEST_LCATS_DEFAULT"), "default-val")
+            finally:
+                os.environ.pop("TEST_LCATS_DEFAULT", None)
 
 
 class TestLoadSecretsExplicitDir(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements [WI-INFRA-0011](lcats/project/work_items/proposed/WI-INFRA-0011.md) — secrets utility and contributor guide for the `.secrets/` pattern.

Prompt ID: `PROMPT(WI-INFRA-0011:WI_INFRA_0011)[2026-07-02T17:28:53-04:00]`

## Changes

- **`lcats/lcats/utils/secrets.py`** (new) — `load_secrets(secrets_dir=None)` globs `.secrets/*.env` alphabetically and loads via `python-dotenv`; does not override already-exported vars; silently no-ops if dir absent
- **`lcats/pyproject.toml`** — adds `python-dotenv` to `[project.dependencies]`
- **`lcats/tests/utils_tests/secrets_test.py`** (new) — 5 unittest cases: load from file, no-override of existing vars, missing dir no-op, multiple files, explicit dir arg
- **`experiments/02_llm_backend_comparison/smoke_test.py`** — calls `load_secrets()` before `_check_keys()`; updates `Requires:` docstring to document `.secrets/` as the alternative to `export`
- **`lcats/docs/secrets-setup.md`** (new) — contributor guide covering setup, how it works, CI/CD behaviour, notebook note, and a verification snippet

## Validation

- `scripts/format --check --diff` — 141 files unchanged
- `scripts/lint` — all checks passed
- `scripts/test` — 1247 tests OK (9.9s)
- `lrh validate` — 0 errors, 16 warnings (all pre-existing)
- `python -c "from lcats.utils.secrets import load_secrets; print('ok')"` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)