### PR TITLE
Extend lcats assess: optional --genre and always-on genre detection (WI-ASSESS-0012)

### DIFF
--- a/experiments/02_llm_backend_comparison/compare_results.py
+++ b/experiments/02_llm_backend_comparison/compare_results.py
@@ -4,7 +4,7 @@ Usage:
     python compare_results.py results/anthropic-*.jsonl results/openai-*.jsonl
 
 Prints a per-story comparison table and summary agreement rates for
-`verdict` and `genre_match`.
+`verdict` and `genre_verdict`.
 """
 
 from __future__ import annotations
@@ -49,7 +49,7 @@ def compare(file_a: pathlib.Path, file_b: pathlib.Path) -> int:
     label_b = _short(file_b)
 
     verdict_agree = 0
-    genre_match_agree = 0
+    genre_verdict_agree = 0
     errors_a = 0
     errors_b = 0
     n_valid = 0
@@ -82,8 +82,8 @@ def compare(file_a: pathlib.Path, file_b: pathlib.Path) -> int:
         n_valid += 1
         v_a = a.get("verdict", "?")
         v_b = b.get("verdict", "?")
-        gm_a = a.get("genre_match", "?")
-        gm_b = b.get("genre_match", "?")
+        gm_a = a.get("genre_verdict", "?")
+        gm_b = b.get("genre_verdict", "?")
 
         v_ok = v_a == v_b
         gm_ok = gm_a == gm_b
@@ -91,7 +91,7 @@ def compare(file_a: pathlib.Path, file_b: pathlib.Path) -> int:
         if v_ok:
             verdict_agree += 1
         if gm_ok:
-            genre_match_agree += 1
+            genre_verdict_agree += 1
 
         print(
             f"{title:<45} {v_a:<10} {v_b:<10} {'✓' if v_ok else '✗':<9} "
@@ -107,12 +107,12 @@ def compare(file_a: pathlib.Path, file_b: pathlib.Path) -> int:
             f"({100*verdict_agree/n_valid:.0f}%)"
         )
         print(
-            f"Genre-match agree:  {genre_match_agree}/{n_valid} "
-            f"({100*genre_match_agree/n_valid:.0f}%)"
+            f"Genre-verdict agree: {genre_verdict_agree}/{n_valid} "
+            f"({100*genre_verdict_agree/n_valid:.0f}%)"
         )
     else:
-        print("Verdict agreement:  n/a (no valid rows)")
-        print("Genre-match agree:  n/a (no valid rows)")
+        print("Verdict agreement:   n/a (no valid rows)")
+        print("Genre-verdict agree: n/a (no valid rows)")
     if errors_a or errors_b:
         print(f"Errors (A / B):     {errors_a} / {errors_b}")
 

--- a/experiments/02_llm_backend_comparison/compare_results.py
+++ b/experiments/02_llm_backend_comparison/compare_results.py
@@ -82,8 +82,8 @@ def compare(file_a: pathlib.Path, file_b: pathlib.Path) -> int:
         n_valid += 1
         v_a = a.get("verdict", "?")
         v_b = b.get("verdict", "?")
-        gm_a = a.get("genre_verdict", "?")
-        gm_b = b.get("genre_verdict", "?")
+        gm_a = a.get("genre_verdict") or a.get("genre_match", "?")
+        gm_b = b.get("genre_verdict") or b.get("genre_match", "?")
 
         v_ok = v_a == v_b
         gm_ok = gm_a == gm_b

--- a/lcats/lcats/analysis/corpus/assess.py
+++ b/lcats/lcats/analysis/corpus/assess.py
@@ -7,6 +7,27 @@ from dataclasses import asdict, dataclass, field
 
 VALID_GENRES = ("science fiction", "horror", "western", "romance")
 
+_GENRE_DEFINITIONS = """\
+  - science fiction: speculative technology, space, aliens, time travel, future societies
+  - horror: dread, supernatural threat, psychological terror, monsters, dark atmosphere
+  - western: frontier American West, cowboys, outlaws, settlers, frontier justice
+  - romance: central love story with emotional relationship development as the primary plot
+  - other: does not fit any of the four target genres"""
+
+_SPECIALS_SECTION = """\
+SPECIAL CHARACTERS: If the story contains non-ASCII or unusual characters, are they:
+  - author_intentional: dialect spelling, verse, period typography, accented names
+  - extraction_artifact: mojibake, garbled encoding, OCR errors, encoding artifacts
+  - error: clearly corrupted, unreadable text passages
+  - none: no unusual characters"""
+
+_QUALITY_SECTION = """\
+QUALITY ISSUES: Flag any:
+  - Transcriber notes, editor commentary, or Project Gutenberg boilerplate inside the body
+  - Copyright notices, disclaimers, or legal text embedded in the story body
+  - Tables of contents, chapter listings, or front matter inside the text
+  - Significant formatting artifacts (stray markup, repeated separators, etc.)"""
+
 ASSESSMENT_TOOL = {
     "name": "record_story_assessment",
     "description": "Record a structured quality and genre assessment for a story.",
@@ -36,20 +57,35 @@ ASSESSMENT_TOOL = {
                     "as a complete standalone narrative."
                 ),
             },
-            "genre_match": {
+            "detected_genre": {
                 "type": "string",
-                "enum": ["confirmed", "disputed", "wrong"],
-                "description": "Whether the story belongs to the claimed target genre.",
+                "enum": list(VALID_GENRES) + ["other"],
+                "description": (
+                    "The genre this story most likely belongs to, determined by "
+                    "independent analysis without reference to any claimed genre. "
+                    "Use 'other' if the story does not fit any of the four target genres."
+                ),
             },
-            "genre_confidence": {
+            "detected_genre_confidence": {
                 "type": "number",
-                "description": "Confidence in the genre assessment, 0.0 to 1.0.",
+                "description": "Confidence in the detected genre, 0.0 to 1.0.",
+            },
+            "genre_verdict": {
+                "type": "string",
+                "enum": ["confirmed", "disputed", "wrong", "detected"],
+                "description": (
+                    "confirmed: story belongs to the claimed target genre. "
+                    "disputed: story has genre elements but is borderline or mixed. "
+                    "wrong: story does not belong to the claimed genre. "
+                    "detected: no genre was claimed; use this value in detect-only mode."
+                ),
             },
             "genre_suggestion": {
                 "type": "string",
                 "description": (
-                    "If genre_match is wrong or disputed, the most likely actual genre. "
-                    "Omit or leave empty otherwise."
+                    "If genre_verdict is wrong or disputed, any additional nuance "
+                    "about the actual genre beyond the detected_genre enum value "
+                    "(e.g. 'Gothic mystery-horror hybrid'). Omit or leave empty otherwise."
                 ),
             },
             "specials_verdict": {
@@ -93,8 +129,9 @@ ASSESSMENT_TOOL = {
         "required": [
             "verdict",
             "wellformed",
-            "genre_match",
-            "genre_confidence",
+            "detected_genre",
+            "detected_genre_confidence",
+            "genre_verdict",
             "specials_verdict",
             "summary",
             "issues",
@@ -102,35 +139,64 @@ ASSESSMENT_TOOL = {
     },
 }
 
-SYSTEM_PROMPT_TEMPLATE = """\
-You are a literary corpus quality assessor for a {genre} fiction research project.
+# Detect mode: no claimed genre; model identifies genre independently.
+DETECT_SYSTEM_PROMPT = f"""\
+You are a literary corpus quality assessor identifying genre and quality \
+for a mixed research corpus.
+
+The corpus targets four genres: science fiction, horror, western, and romance.
 
 Assess the provided story for inclusion in a curated corpus:
 
-WELLFORMEDNESS: Does the story have a clear beginning and ending? Is it a complete \
-standalone narrative — not a chapter fragment, excerpt, or part of a longer work?
+GENRE DETECTION: Identify which of the four target genres best describes \
+this story, or "other" if none fits.
+{_GENRE_DEFINITIONS}
 
-GENRE ACCURACY: Does the story actually belong to the genre "{genre}"?
-  - science fiction: speculative technology, space, aliens, time travel, future societies
-  - horror: dread, supernatural threat, psychological terror, monsters, dark atmosphere
-  - western: frontier American West, cowboys, outlaws, settlers, frontier justice
-  - romance: central love story with emotional relationship development as the primary plot
+WELLFORMEDNESS: Does the story have a clear beginning and ending? Is it a \
+complete standalone narrative — not a chapter fragment, excerpt, or part of \
+a longer work?
 
-SPECIAL CHARACTERS: If the story contains non-ASCII or unusual characters, are they:
-  - author_intentional: dialect spelling, verse, period typography, accented names
-  - extraction_artifact: mojibake, garbled encoding, OCR errors, encoding artifacts
-  - error: clearly corrupted, unreadable text passages
-  - none: no unusual characters
+{_SPECIALS_SECTION}
 
-QUALITY ISSUES: Flag any:
-  - Transcriber notes, editor commentary, or Project Gutenberg boilerplate inside the body
-  - Copyright notices, disclaimers, or legal text embedded in the story body
-  - Tables of contents, chapter listings, or front matter inside the text
-  - Significant formatting artifacts (stray markup, repeated separators, etc.)
+{_QUALITY_SECTION}
 
 VERDICT RULES:
-  - include: wellformed + correct genre + no disqualifying issues
-  - exclude: incomplete story, wrong genre, or serious quality problems
+  - include: wellformed + detected genre is one of the four targets + no disqualifying issues
+  - exclude: story does not fit any target genre (detected_genre: other), \
+incomplete, or serious quality problems
+  - review: borderline case — reasonable people could disagree
+
+Record your assessment using the record_story_assessment tool. \
+Set genre_verdict to "detected". Keep the summary to one or two sentences.\
+"""
+
+# Lens mode: a genre is claimed; model detects independently then evaluates the claim.
+SYSTEM_PROMPT_TEMPLATE = f"""\
+You are a literary corpus quality assessor for a {{genre}} fiction research project.
+
+Assess the provided story for inclusion in a curated corpus:
+
+GENRE DETECTION: First, independently identify which of the four target genres \
+best describes this story — without reference to the claimed genre.
+{_GENRE_DEFINITIONS}
+
+GENRE ACCURACY: Having made your independent detection above, now evaluate \
+the claimed genre "{{genre}}". Does the story actually belong to that genre?
+  - confirmed: story clearly belongs to the claimed genre
+  - disputed: story has some genre elements but is borderline or mixed
+  - wrong: story does not belong to the claimed genre
+
+WELLFORMEDNESS: Does the story have a clear beginning and ending? Is it a \
+complete standalone narrative — not a chapter fragment, excerpt, or part of \
+a longer work?
+
+{_SPECIALS_SECTION}
+
+{_QUALITY_SECTION}
+
+VERDICT RULES:
+  - include: wellformed + genre_verdict confirmed or disputed + no disqualifying issues
+  - exclude: incomplete story, genre_verdict wrong, or serious quality problems
   - review: borderline case — reasonable people could disagree
 
 Record your assessment using the record_story_assessment tool. \
@@ -148,8 +214,9 @@ class AssessmentResult:
     verdict: str
     exclude_reason: str = ""
     wellformed: bool = True
-    genre_match: str = "confirmed"
-    genre_confidence: float = 1.0
+    detected_genre: str = "other"
+    detected_genre_confidence: float = 0.0
+    genre_verdict: str = "detected"
     genre_suggestion: str = ""
     specials_verdict: str = "none"
     summary: str = ""
@@ -198,12 +265,18 @@ def run_preflight(
 
 def assess_story(
     file_path: pathlib.Path,
-    genre: str,
-    backend,
+    genre: str = "",
+    backend=None,
     model: str = "claude-opus-4-8",
     max_body_chars: int = 100_000,
 ) -> AssessmentResult:
-    """Assess a single corpus JSON file for quality and genre fit."""
+    """Assess a single corpus JSON file for quality and genre fit.
+
+    When genre is empty, runs in detect mode: the model identifies the genre
+    independently and sets genre_verdict to "detected". When genre is provided,
+    runs in lens mode: the model detects genre independently then evaluates
+    whether the story matches the claimed genre.
+    """
     title = file_path.stem
     author = "Unknown"
     url = ""
@@ -216,13 +289,19 @@ def assess_story(
         if max_body_chars and len(body) > max_body_chars:
             body = body[:max_body_chars] + "\n\n[... text truncated ...]"
 
-        system_prompt = SYSTEM_PROMPT_TEMPLATE.format(genre=genre)
+        if genre:
+            system_prompt = SYSTEM_PROMPT_TEMPLATE.format(genre=genre)
+            genre_line = f"Claimed genre: {genre}\n"
+        else:
+            system_prompt = DETECT_SYSTEM_PROMPT
+            genre_line = ""
+
         user_message = (
             f"STORY METADATA:\n"
             f"Title: {title}\n"
             f"Author: {author}\n"
             f"Source URL: {url}\n"
-            f"Claimed genre: {genre}\n"
+            f"{genre_line}"
             f"\nPRE-FLIGHT QA FINDINGS:\n{findings_text}\n"
             f"\nSTORY TEXT:\n{body}"
         )
@@ -256,8 +335,9 @@ def assess_story(
             verdict=a.get("verdict", "review"),
             exclude_reason=a.get("exclude_reason", ""),
             wellformed=bool(a.get("wellformed", True)),
-            genre_match=a.get("genre_match", "confirmed"),
-            genre_confidence=float(a.get("genre_confidence", 1.0)),
+            detected_genre=a.get("detected_genre", "other"),
+            detected_genre_confidence=float(a.get("detected_genre_confidence", 0.0)),
+            genre_verdict=a.get("genre_verdict", "detected"),
             genre_suggestion=a.get("genre_suggestion", ""),
             specials_verdict=a.get("specials_verdict", "none"),
             summary=a.get("summary", ""),

--- a/lcats/lcats/analysis/corpus/assess.py
+++ b/lcats/lcats/analysis/corpus/assess.py
@@ -68,6 +68,8 @@ ASSESSMENT_TOOL = {
             },
             "detected_genre_confidence": {
                 "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
                 "description": "Confidence in the detected genre, 0.0 to 1.0.",
             },
             "genre_verdict": {
@@ -195,9 +197,9 @@ a longer work?
 {_QUALITY_SECTION}
 
 VERDICT RULES:
-  - include: wellformed + genre_verdict confirmed or disputed + no disqualifying issues
+  - include: wellformed + genre_verdict confirmed + no disqualifying issues
   - exclude: incomplete story, genre_verdict wrong, or serious quality problems
-  - review: borderline case — reasonable people could disagree
+  - review: borderline case or genre_verdict disputed — reasonable people could disagree
 
 Record your assessment using the record_story_assessment tool. \
 Keep the summary to one or two sentences.\
@@ -277,6 +279,9 @@ def assess_story(
     runs in lens mode: the model detects genre independently then evaluates
     whether the story matches the claimed genre.
     """
+    if backend is None:
+        raise ValueError("assess_story requires a backend instance")
+
     title = file_path.stem
     author = "Unknown"
     url = ""

--- a/lcats/lcats/analysis/corpus/assess_cli.py
+++ b/lcats/lcats/analysis/corpus/assess_cli.py
@@ -26,8 +26,9 @@ TSV_COLUMNS = [
     "author",
     "target_genre",
     "verdict",
-    "genre_match",
-    "genre_confidence",
+    "detected_genre",
+    "detected_genre_confidence",
+    "genre_verdict",
     "wellformed",
     "specials_verdict",
     "summary",
@@ -51,7 +52,9 @@ def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
             "  lcats assess corpora/sherlock --genre 'science fiction'\n"
             "  lcats assess data/ --genre horror --format tsv --output horror_assessment.tsv\n"
             "  lcats assess corpora/sherlock --genre western --dry-run\n"
-            "  ANTHROPIC_API_KEY=sk-... lcats assess data/ --genre romance --model claude-haiku-4-5"
+            "  ANTHROPIC_API_KEY=sk-... lcats assess data/ --genre romance --model claude-haiku-4-5\n"
+            "  lcats assess data/ --format tsv --output detected.tsv  # detect mode (no --genre)\n"
+            "  lcats assess data/ --dry-run  # detect mode dry-run"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -63,12 +66,13 @@ def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--genre",
-        required=True,
+        default="",
         choices=list(VALID_GENRES),
         metavar="GENRE",
         help=(
-            f"Target genre for assessment. Choices: {', '.join(VALID_GENRES)}. "
-            "Quote multi-word genres: --genre 'science fiction'."
+            f"Target genre for curation (lens mode). Choices: {', '.join(VALID_GENRES)}. "
+            "Quote multi-word genres: --genre 'science fiction'. "
+            "Omit to detect genre automatically (detect mode)."
         ),
     )
     parser.add_argument(
@@ -117,8 +121,9 @@ def _result_to_tsv_row(result: AssessmentResult) -> dict:
         "author": result.author,
         "target_genre": result.target_genre,
         "verdict": result.verdict,
-        "genre_match": result.genre_match,
-        "genre_confidence": f"{result.genre_confidence:.2f}",
+        "detected_genre": result.detected_genre,
+        "detected_genre_confidence": f"{result.detected_genre_confidence:.2f}",
+        "genre_verdict": result.genre_verdict,
         "wellformed": "yes" if result.wellformed else "no",
         "specials_verdict": result.specials_verdict,
         "summary": result.summary,
@@ -136,7 +141,7 @@ def _dry_run_preview(file_path: pathlib.Path, genre: str, out) -> None:
         print(f"[dry-run] {file_path}", file=out)
         print(f"  Title:    {title}", file=out)
         print(f"  Author:   {author}", file=out)
-        print(f"  Genre:    {genre}", file=out)
+        print(f"  Genre:    {genre if genre else '(detect mode)'}", file=out)
         if findings:
             print(f"  QA findings ({len(findings)}):", file=out)
             for f in findings:
@@ -153,10 +158,15 @@ def _write_human(out, result: AssessmentResult) -> None:
     print(f"{symbol} [{result.verdict.upper()}] {result.title}", file=out)
     print(f"  Author:  {result.author}", file=out)
     print(
-        f"  Genre:   {result.target_genre} → {result.genre_match} "
-        f"({result.genre_confidence:.0%})",
+        f"  Detected: {result.detected_genre} "
+        f"({result.detected_genre_confidence:.0%})",
         file=out,
     )
+    if result.target_genre:
+        print(
+            f"  Claimed:  {result.target_genre} → {result.genre_verdict}",
+            file=out,
+        )
     if result.summary:
         print(f"  Summary: {result.summary}", file=out)
     for issue in result.issues:

--- a/lcats/project/executions/AD_HOC/2026_07_05_11_58_07_WI_ASSESS_0012_IMPL_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_05_11_58_07_WI_ASSESS_0012_IMPL_REVIEW.md
@@ -1,0 +1,55 @@
+---
+execution_id: 2026_07_05_11_58_07_WI_ASSESS_0012_IMPL_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_ASSESS_0012_IMPL_REVIEW)[2026-07-05T11:43:13-04:00]
+work_item: AD_HOC
+status: in_progress
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/107
+session_transcript: claude-app:8262c583-24b6-47f3-b8ca-38f4751775a6
+rerun_of: 2026_07_05_02_58_35_WI_ASSESS_0012
+pr: https://github.com/xenotaur/LCATS/pull/107
+commit: caddbca
+created_at: 2026-07-05T11:58:07-04:00
+---
+
+# Summary
+
+Address 4 reviewer comments on WI-ASSESS-0012-impl (PR #107): tighten the
+lens-mode verdict rule so disputed genre → review, add a legacy field fallback
+in compare_results.py, add JSON schema range constraints on
+detected_genre_confidence, and add a fast-fail guard when assess_story is
+called without a backend.
+
+# Result
+
+Single commit `caddbca` on `xenotaur/feat/wi-assess-0012-impl`:
+
+**C1 (P1 — chatgpt-codex-connector):** Lens-mode VERDICT RULES changed so
+`genre_verdict: disputed` routes to `review` instead of `include`, preventing
+borderline/mixed-genre texts from silently entering the curated corpus.
+
+**C2/C5 (P2 — chatgpt-codex-connector + copilot):** `compare_results.py`
+now reads `a.get("genre_verdict") or a.get("genre_match", "?")` so historical
+JSONL files (which still carry `genre_match`) compare correctly against each
+other. Mixed old/new file comparisons read each side's own field.
+
+**C3 (copilot):** Added `"minimum": 0.0, "maximum": 1.0` to the
+`detected_genre_confidence` JSON schema property, enforcing the 0.0–1.0 range
+at the tool-call boundary.
+
+**C4 (copilot):** Added `if backend is None: raise ValueError(...)` before the
+try block in `assess_story()`, so a missing backend propagates as a clear error
+rather than being swallowed into a generic `review` result.
+
+`lcats/gettenberg/metadata.py` also reformatted by Black hook (pre-existing drift).
+
+# Validation
+
+- `scripts/format --check --diff` — 141 files unchanged
+- `scripts/lint` — all checks passed
+- `scripts/test` — 1248 tests OK
+- `lrh validate` — 0 errors, 16 pre-existing warnings
+
+# Follow-up
+
+None — all four comments addressed.

--- a/lcats/project/executions/WI-ASSESS-0012/2026_07_05_02_58_35_WI_ASSESS_0012.md
+++ b/lcats/project/executions/WI-ASSESS-0012/2026_07_05_02_58_35_WI_ASSESS_0012.md
@@ -1,0 +1,62 @@
+---
+execution_id: 2026_07_05_02_58_35_WI_ASSESS_0012
+prompt_id: PROMPT(WI-ASSESS-0012:WI_ASSESS_0012)[2026-07-05T02:24:18-04:00]
+work_item: WI-ASSESS-0012
+status: in_progress
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-ASSESS-0012.md
+session_transcript: claude-app:8262c583-24b6-47f3-b8ca-38f4751775a6
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/107
+commit: 7288d29
+created_at: 2026-07-05T02:58:35-04:00
+---
+
+# Summary
+
+Implement WI-ASSESS-0012: extend `lcats assess` with optional `--genre` and
+always-on genre detection (Option D, unified single-call design). In detect
+mode (no `--genre`), the model identifies the genre independently. In lens
+mode (with `--genre`), the model detects genre first, then evaluates the
+claimed genre. Both modes return `detected_genre` and
+`detected_genre_confidence` in every result.
+
+# Result
+
+All changes implemented in a single commit on branch
+`xenotaur/feat/wi-assess-0012-impl`, PR #107.
+
+**`lcats/lcats/analysis/corpus/assess.py`:**
+- Added `detected_genre` (enum VALID_GENRES + "other") and
+  `detected_genre_confidence` (0.0–1.0) as always-required tool schema fields
+- Renamed `genre_match` → `genre_verdict` (added `"detected"` sentinel for
+  detect mode)
+- Added `DETECT_SYSTEM_PROMPT` for detect mode (no `{genre}` placeholder)
+- Updated `SYSTEM_PROMPT_TEMPLATE` with detect-first framing in lens mode
+- Made `genre` parameter optional, defaulting to `""` (detect mode)
+- Error-path `AssessmentResult` uses `detected_genre: "other"` default
+
+**`lcats/lcats/analysis/corpus/assess_cli.py`:**
+- Removed `required=True` from `--genre`; default `""`
+- Updated `TSV_COLUMNS`, `_result_to_tsv_row`, `_write_human`, `_dry_run_preview`
+- Dry-run shows `(detect mode)` when no genre provided
+
+**`experiments/02_llm_backend_comparison/compare_results.py`:**
+- Updated `genre_match` → `genre_verdict` field read and variable names
+
+**`lcats/tests/analysis_tests/assess_test.py`:**
+- Updated `_SAMPLE_TOOL_RESULT` and field assertions for renamed fields
+
+# Validation
+
+- `scripts/format --check --diff` — 141 files unchanged
+- `scripts/lint` — all checks passed
+- `scripts/test` — 1248 tests OK
+- `lrh validate` — 0 errors, 16 pre-existing warnings
+- `lcats assess data/ --dry-run` — shows `(detect mode)` ✓
+- `lcats assess data/ --genre horror --dry-run` — shows `Genre: horror` ✓
+
+# Follow-up
+
+- Manual validation on 2–3 real stories per mode recommended before merge
+  (prompt quality check per WI risk notes)

--- a/lcats/tests/analysis_tests/assess_test.py
+++ b/lcats/tests/analysis_tests/assess_test.py
@@ -10,8 +10,9 @@ from lcats.llm import fake_backend
 _SAMPLE_TOOL_RESULT = {
     "verdict": "include",
     "wellformed": True,
-    "genre_match": "confirmed",
-    "genre_confidence": 0.95,
+    "detected_genre": "science fiction",
+    "detected_genre_confidence": 0.95,
+    "genre_verdict": "confirmed",
     "specials_verdict": "none",
     "summary": "A complete story about frontier life.",
     "issues": [],
@@ -56,7 +57,9 @@ class TestAssessStorySuccess(unittest.TestCase):
         self.assertEqual(result.verdict, "include")
         self.assertEqual(result.title, "The Test Story")
         self.assertEqual(result.author, "Test Author")
-        self.assertAlmostEqual(result.genre_confidence, 0.95)
+        self.assertEqual(result.detected_genre, "science fiction")
+        self.assertAlmostEqual(result.detected_genre_confidence, 0.95)
+        self.assertEqual(result.genre_verdict, "confirmed")
         self.assertTrue(result.wellformed)
         self.assertEqual(result.error, "")
 


### PR DESCRIPTION
## Summary

Implements WI-ASSESS-0012: extends `lcats assess` so that `--genre` is optional.

- **Detect mode** (no `--genre`): model independently identifies genre from the story text, returns `genre_verdict: "detected"`
- **Lens mode** (`--genre horror` etc.): model detects genre independently *first*, then evaluates whether the story matches the claimed genre — preserving all current curation behavior while adding independent detection

Prompt ID: `PROMPT(WI-ASSESS-0012:WI_ASSESS_0012)[2026-07-05T02:24:18-04:00]`

## Changes

**`lcats/lcats/analysis/corpus/assess.py`**
- New always-required tool schema fields: `detected_genre` (enum: VALID_GENRES + "other") and `detected_genre_confidence` (0.0–1.0)
- `genre_match` → `genre_verdict` (adds `"detected"` sentinel for detect mode)
- `genre_confidence` → `detected_genre_confidence`
- New `DETECT_SYSTEM_PROMPT` for detect mode
- Updated `SYSTEM_PROMPT_TEMPLATE` (lens mode): detect-first framing reduces anchoring bias
- `assess_story(genre="")` defaults to detect mode; error-path results use `detected_genre: "other"` to satisfy schema constraints

**`lcats/lcats/analysis/corpus/assess_cli.py`**
- `--genre` is now optional (detect mode when omitted)
- Updated `TSV_COLUMNS`, `_result_to_tsv_row`, `_write_human`, `_dry_run_preview`
- Dry-run shows `(detect mode)` when no genre is provided

**`experiments/02_llm_backend_comparison/compare_results.py`**
- `genre_match` → `genre_verdict` (field rename follow-up)

**`lcats/tests/analysis_tests/assess_test.py`**
- Updated `_SAMPLE_TOOL_RESULT` and assertions for renamed fields

## Acceptance Criteria

- [x] `lcats assess <files>` (without `--genre`) returns `detected_genre` and `detected_genre_confidence` with `genre_verdict: "detected"`
- [x] `lcats assess <files> --genre horror` returns `genre_verdict` in `[confirmed, disputed, wrong]` plus `detected_genre` and `detected_genre_confidence`
- [x] TSV column headers identical regardless of `--genre`
- [x] `detected_genre` constrained to VALID_GENRES + `"other"`
- [x] `detected_genre_confidence` is the sole numeric genre confidence field
- [x] `scripts/test` passes — 1248 tests OK
- [x] `lrh validate` — 0 errors

## Validation

- `scripts/format --check --diff` — 141 files unchanged
- `scripts/lint` — all checks passed
- `scripts/test` — 1248 tests OK
- `lrh validate` — 0 errors, 16 pre-existing warnings
- `lcats assess data/ --dry-run` — shows `(detect mode)` ✓
- `lcats assess data/ --genre horror --dry-run` — shows `Genre: horror` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)