### PR TITLE
docs: update for PR #110 audit (Phase 2a navigation fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ LCATS/
 └── experiments/           # Research experiments
 ```
 
+## Documentation
+
+LCATS documentation is being organized under `lcats/docs/`.
+
+- Docs hub: [`lcats/docs/index.md`](lcats/docs/index.md)
+- CLI implementation status reference: [`lcats/docs/reference/cli-status.md`](lcats/docs/reference/cli-status.md)
+- LRH control-plane docs: [`lcats/project/README.md`](lcats/project/README.md)
+
+The execution root is `lcats/` (for example: `cd LCATS/lcats`).
+
 ## Corpora
 
 LCATS includes a substantial collection of public domain literature:

--- a/lcats/docs/index.md
+++ b/lcats/docs/index.md
@@ -18,7 +18,8 @@ Tutorials are not scaffolded in this phase.
 
 ### How-to guides
 
-How-to guides are not scaffolded in this phase.
+- [Set up API keys](secrets-setup.md)
+- [Run `lcats assess`](../lcats/analysis/corpus/README.md#9-story-assessment-lcats-assess) — usage, manual prompt validation, and dry-run guidance (interim location; pending extraction into `docs/how-to/` in a future phase)
 
 ### Reference
 

--- a/lcats/docs/reference/README.md
+++ b/lcats/docs/reference/README.md
@@ -3,3 +3,5 @@
 Reference pages describe exact interfaces and current behavior.
 
 - [CLI status matrix](cli-status.md)
+
+See also: [API key setup](../secrets-setup.md) (how-to, not reference).

--- a/lcats/project/executions/AD_HOC/2026_07_08_01_15_06_DOC_WORK_PR_110.md
+++ b/lcats/project/executions/AD_HOC/2026_07_08_01_15_06_DOC_WORK_PR_110.md
@@ -1,0 +1,81 @@
+---
+execution_id: 2026_07_08_01_15_06_DOC_WORK_PR_110
+prompt_id: PROMPT(AD_HOC:DOC_WORK_PR_110)[2026-07-08T01:08:46-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/111
+commit: b02c251
+created_at: 2026-07-08T01:15:06-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/110
+session_transcript: pending
+---
+
+# Summary
+
+Implemented the "Proposed first PR scope" (Phase 2a) from the 2026-07-07
+docs audit landed in PR #110: navigation fixes only, no new content
+authored, linking existing-but-orphaned documentation into the
+`lcats/docs/` hub. `rerun_of` left empty — this is `/lrh-doc-work` acting
+on a merged docs-audit PR, not a rerun of a prior `/lrh-doc-work`
+invocation; no matching `*DOC_WORK_PR_110*.md` record existed before this
+one.
+
+# Result
+
+Four edits, opened as PR #111 on branch `xenotaur/chore/doc-work-pr-110`:
+
+1. `/README.md` (repo root) — added a "Documentation" pointer section
+   linking to `lcats/docs/index.md`, `lcats/docs/reference/cli-status.md`,
+   and `lcats/project/README.md`, mirroring the equivalent section already
+   in `lcats/README.md`. Previously the repo-root README had no links into
+   the docs hub at all.
+2. `lcats/docs/index.md` — added `docs/secrets-setup.md` under "How-to
+   guides" (was orphaned from the hub per the audit's navigation finding).
+3. `lcats/docs/index.md` — replaced the stale "How-to guides are not
+   scaffolded in this phase" text with a link to
+   `lcats/analysis/corpus/README.md#9-story-assessment-lcats-assess`,
+   marked as an interim location pending Phase 3 extraction into
+   `docs/how-to/`.
+4. `lcats/docs/reference/README.md` — added a "See also" cross-reference to
+   `../secrets-setup.md`, explicitly labeled how-to (not reclassified as
+   Reference), satisfying the audit's second orphan-link finding without
+   misclassifying the page.
+
+Deferred (explicitly out of scope, per the audit's own scope note and this
+skill's minimal-update rule): Phase 3 extraction of Section 9 into a
+standalone `docs/how-to/run-assess.md`; any new reference docs (CLI flags,
+`LLMBackend`); tutorial content (Phase 4); no rewrites of
+`docs/reference/cli-status.md` or `lcats/README.md`'s existing
+documentation section.
+
+# Validation
+
+- `scripts/version tools` — not present in this repository (no
+  `scripts/version` script exists, confirmed during the prior
+  `/lrh-review-response` run on PR #110 as well).
+- `scripts/format`, `scripts/lint`, `scripts/test` — not run; only
+  Markdown files changed (`git status --short` showed 3 modified `.md`
+  files, no Python).
+- Link check (same custom filesystem-resolution script used in the
+  original audit) — every link added in this PR resolves on disk
+  (`README.md` L125-127, `docs/index.md` L21-22, `docs/reference/README.md`
+  L7); verified the `#9-story-assessment-lcats-assess` anchor against the
+  actual heading text
+  (`## 9. Story Assessment (`lcats assess`)`) in
+  `lcats/lcats/analysis/corpus/README.md`.
+- `lrh validate` — 0 errors, 16 pre-existing warnings (all
+  `OWNER_ROLE_INSUFFICIENT` / `PLANNING_ORPHANED_ACTIVE_WORK_ITEM` on
+  unrelated work items, unchanged from before this PR).
+
+# Follow-up
+
+- `session_transcript` is `pending` — update to `claude-app:<session-id>`
+  after this session ends.
+- After PR #111 merges: set this record's `status` to `landed` and record
+  the merge commit via `lrh prompt update-execution` (same pattern as the
+  PR #110 closeout).
+- Phases 3 and 4 of the 2026-07-07 audit's plan remain untracked by any
+  work item — see `[[project_lcats_docs_audit_status]]` memory for context
+  if picking this up in a future session.


### PR DESCRIPTION
## Summary
- Implements the "Proposed first PR scope" from the 2026-07-07 docs audit in PR #110 (`lcats/project/audits/docs/2026-07-07-docs-audit.md`).
- Adds a "Documentation" pointer section to the repo-root `README.md`, linking to `lcats/docs/index.md`, `lcats/docs/reference/cli-status.md`, and `lcats/project/README.md` — mirroring the section already present in `lcats/README.md`. Previously the repo-root README had zero links into the docs hub.
- Fixes `lcats/docs/index.md`'s "How-to guides" section, which said "not scaffolded" even though how-to content already existed: adds links to `docs/secrets-setup.md` (previously orphaned from the hub) and to the `lcats assess` usage guide (Section 9 of `lcats/lcats/analysis/corpus/README.md`), marked as an interim location pending future extraction into `docs/how-to/`.
- Adds a "See also" cross-reference to `docs/secrets-setup.md` from `lcats/docs/reference/README.md`, labeled explicitly as how-to (not reclassified as reference).

## Deferred (out of scope for this PR, per the audit)
- Extracting Section 9 of the corpus README into a standalone `docs/how-to/run-assess.md` — deferred to the audit's Phase 3.
- Any reference-doc additions (CLI flags, `LLMBackend` reference) — Phase 3.
- Tutorial content — Phase 4.

## Test plan
- [x] Verified the new `#9-story-assessment-lcats-assess` anchor matches the actual heading (`## 9. Story Assessment (\`lcats assess\`)`) in `lcats/lcats/analysis/corpus/README.md`
- [x] Checked all links added in this PR resolve on the filesystem (README.md, docs/index.md, docs/reference/README.md)
- [x] `lrh validate`: 0 errors, 16 pre-existing warnings unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)