### PR TITLE
Stand up WS-DOCS workstream and broaden active focus for WorldCon 2026

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_08_16_58_20_DOCS_COMPLETION_WORKSTREAM_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_08_16_58_20_DOCS_COMPLETION_WORKSTREAM_REVIEW.md
@@ -1,0 +1,70 @@
+---
+execution_id: 2026_07_08_16_58_20_DOCS_COMPLETION_WORKSTREAM_REVIEW
+prompt_id: PROMPT(AD_HOC:DOCS_COMPLETION_WORKSTREAM_REVIEW)[2026-07-08T16:08:50-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/113
+commit: 350e4a3
+created_at: 2026-07-08T16:58:20-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/113
+session_transcript: pending
+---
+
+# Summary
+
+Addressed 9 open review comments on PR #113 (`WS-DOCS` workstream + `FOCUS-WORLDCON-2026` focus
+restructure + `WI-DOCS-0013/0014/0015`), from `chatgpt-codex-connector` and
+`copilot-pull-request-reviewer`. All 9 were self-inflicted inconsistencies introduced by PR #113
+itself — no design tension, all fixed.
+
+`rerun_of` left empty: PR #113 was assembled directly in this session (goal/focus/roadmap edits +
+workstream + 3 WIs), not via `/lrh-implement` from a pre-existing `WI-*` record, so there is no
+primary execution record to link back to. Searched `project/executions/` for
+`*DOCS_COMPLETION_WORKSTREAM*.md` excluding `_REVIEW.md` files and found none.
+
+# Result
+
+All 9 comments were valid (presence + validity + feasibility checks passed) and grouped into 4
+fixes:
+
+1. **Dangling `linked_focus` references** (2 comments) — renaming the focus id from
+   `FOCUS-REPAIR-REVIEW` to `FOCUS-WORLDCON-2026` left 6 work items (`WI-SPANOPS-0002`,
+   `WI-REVIEW-0003`, `WI-APPLY-0005`, `WI-META-0006`, `WI-PERSIST-0004`, `WI-REPAIR-0001`)
+   pointing at an id that no longer exists anywhere. Retargeted all 6 to `FOCUS-WORLDCON-2026`.
+   Note: confirmed by reading `src/lrh/control/validator.py` that `linked_focus` (unlike
+   `related_focus`) is not actually a validated field in the current schema, so this didn't
+   produce an `lrh validate` error as the reviewers described — but the traceability concern was
+   real and worth fixing regardless.
+2. **`WORKSTREAM-DOCS` vs `WS-DOCS`** (4 comments) — `current_focus.md` (×3) and `roadmap.md` (×1)
+   referenced the workstream as `WORKSTREAM-DOCS`; the actual workstream id/filename is `WS-DOCS`.
+   Fixed all 4 occurrences.
+3. **`lcats/llm/` path ambiguity** (2 comments) — `WS-DOCS.md` and `WI-DOCS-0013.md` both wrote the
+   backend package path as `lcats/llm/`; corrected to the real path `lcats/lcats/llm/` in both.
+4. **"13 implemented commands" miscount** (2 comments) — `WI-DOCS-0013.md`'s `acceptance:`
+   frontmatter list and `## Acceptance Criteria` body section both said "13 implemented commands
+   ... plus the 3 placeholders," which is self-contradictory. Reworded both to "10 implemented ...
+   plus the 3 placeholders, 13 total."
+
+No comments were skipped.
+
+# Validation
+
+- Only Markdown files changed (`git status --short` showed 10 modified `.md` files, no Python) —
+  `scripts/format`, `scripts/lint`, `scripts/test` not applicable.
+- Re-ran `grep` across `project/` after the fixes to confirm zero remaining occurrences of
+  `WORKSTREAM-DOCS`, `FOCUS-REPAIR-REVIEW`, and the bare `13 implemented` phrasing; confirmed
+  `lcats/llm/` only remains as a substring of the now-correct `lcats/lcats/llm/`.
+- `lrh validate` — 0 errors, 22 warnings (identical count and pattern to before this round — all
+  pre-existing `OWNER_ROLE_INSUFFICIENT` / `OWNER_NOT_IN_CONTRIBUTORS` / `PLANNING_ORPHANED_ACTIVE_WORK_ITEM`,
+  unchanged by these fixes since `linked_focus` isn't validated).
+
+# Follow-up
+
+- `session_transcript` is `pending` — update to `claude-app:<session-id>` after this session ends.
+- After PR #113 merges: set this record's `status` to `landed` and record the merge commit.
+- Unrelated finding from the original PR (not part of this review round, noted in the PR body):
+  `project/workstreams/resolved/WORKSTREAM-LLM-BACKEND.md` still uses the old naming convention
+  and is invisible to `lrh validate`'s `WS-*.md` discovery glob — a good candidate for a small
+  follow-up rename.

--- a/lcats/project/focus/current_focus.md
+++ b/lcats/project/focus/current_focus.md
@@ -1,6 +1,6 @@
 ---
-id: FOCUS-REPAIR-REVIEW
-title: Repair and review pipeline execution
+id: FOCUS-WORLDCON-2026
+title: WorldCon 2026 readiness — repair/review, story analysis foundations, and docs cleanup
 status: active
 priority: high
 owner: unassigned
@@ -8,25 +8,49 @@ owner: unassigned
 
 # Current Focus
 
-## Active Priority
-Build the repair and review pipeline.
+## Active Priorities
+LCATS is tracking three parallel active priorities on the way to WorldCon 2026:
+
+1. **Repair and review pipeline** (roadmap Phase 4) — conservative repair engine, span operations,
+   human review/override, and approved application.
+2. **Story analysis pipeline foundations** — `lcats assess` and scene/story analysis modules, in
+   support of the Medium-Term Goal in `goal/project_goal.md`.
+3. **Documentation cleanup** (`WORKSTREAM-DOCS`) — bring `lcats/docs/` and the repo-root README up
+   to date with everything already implemented, to speed up team collaboration.
 
 ## Focus Scope (Now)
+
+### 1. Repair and review pipeline
 1. Conservative repair engine.
 2. Dry-run-first workflows.
 3. Span-based transformations.
 4. Human review and override system.
 5. Deterministic application of approved repairs.
 
+### 2. Story analysis pipeline foundations
+- Continue exercising `lcats assess` across corpora.
+- No new design or work items until the feature-extraction library is decided.
+
+### 3. Documentation cleanup
+- Execute `WORKSTREAM-DOCS` (Phase 2b/3/4 of the 2026-07-07 docs audit).
+
 ## Why This Is Current
-- Survey/classification and immediate correctness fixes are complete.
-- The next critical capability is safe correction with auditable human control.
+- Survey/classification and immediate correctness fixes are complete; repair/review is the next
+  critical capability for corpus trust.
+- WorldCon 2026 submission needs a working story-analysis foundation and documentation solid
+  enough for collaborators to build on.
 
 ## Non-Goals
-- Narrative reasoning feature development in this phase.
+- Full narrative reasoning engine implementation (`project_goal.md` Long-Term Goal) in this phase.
 - Persistence layer implementation beyond design decisions needed for current work.
+- Formal design/workstream for story-feature extraction before the feature library is decided.
 
 ## Exit Criteria
+
+### Repair and review pipeline
 - Repair plans can be generated and previewed without mutation.
 - Span operations support precise, explainable text changes.
 - Review decisions can approve, reject, or override proposed repairs with rationale.
+
+### Documentation cleanup
+- `WORKSTREAM-DOCS` exit criteria met (see workstream file).

--- a/lcats/project/focus/current_focus.md
+++ b/lcats/project/focus/current_focus.md
@@ -15,7 +15,7 @@ LCATS is tracking three parallel active priorities on the way to WorldCon 2026:
    human review/override, and approved application.
 2. **Story analysis pipeline foundations** — `lcats assess` and scene/story analysis modules, in
    support of the Medium-Term Goal in `goal/project_goal.md`.
-3. **Documentation cleanup** (`WORKSTREAM-DOCS`) — bring `lcats/docs/` and the repo-root README up
+3. **Documentation cleanup** (`WS-DOCS`) — bring `lcats/docs/` and the repo-root README up
    to date with everything already implemented, to speed up team collaboration.
 
 ## Focus Scope (Now)
@@ -32,7 +32,7 @@ LCATS is tracking three parallel active priorities on the way to WorldCon 2026:
 - No new design or work items until the feature-extraction library is decided.
 
 ### 3. Documentation cleanup
-- Execute `WORKSTREAM-DOCS` (Phase 2b/3/4 of the 2026-07-07 docs audit).
+- Execute `WS-DOCS` (Phase 2b/3/4 of the 2026-07-07 docs audit).
 
 ## Why This Is Current
 - Survey/classification and immediate correctness fixes are complete; repair/review is the next
@@ -53,4 +53,4 @@ LCATS is tracking three parallel active priorities on the way to WorldCon 2026:
 - Review decisions can approve, reject, or override proposed repairs with rationale.
 
 ### Documentation cleanup
-- `WORKSTREAM-DOCS` exit criteria met (see workstream file).
+- `WS-DOCS` exit criteria met (see workstream file).

--- a/lcats/project/goal/project_goal.md
+++ b/lcats/project/goal/project_goal.md
@@ -19,6 +19,23 @@ Establish corpus correctness and operational trust through a conservative, non-d
 - Auditability for every corpus-changing operation.
 - Repair + review workflows that preserve provenance and allow human override.
 
+## Medium-Term Goal (WorldCon 2026)
+Create a story feature-extraction pipeline for digital-humanities analysis, targeting the
+WorldCon 2026 Academic Track paper on "The Shape of Science Fiction."
+
+### Medium-Term Emphasis
+- Extract structured, comparable features from story text at scale.
+- Build on `lcats assess` (genre/quality verdicts) and the `scene_analysis.py` / `story_analysis.py`
+  modules as foundations.
+- The feature library is not yet decided — under active design discussion outside this repo
+  (external design threads); not yet ready for a `project/design/proposals/` entry.
+
+### Status
+- No design proposal, workstream, or work items exist yet for this goal, intentionally. Formalize
+  once the feature-extraction library is decided.
+- Related existing work: `lcats assess` (`WI-LLM-0009`, `WI-ASSESS-0012`), scene/story analysis
+  module migration (`WI-LLM-0008`).
+
 ## Long-Term Goal (Later)
 Layer structured narrative representation and reasoning capabilities on top of the trustworthy corpus substrate.
 
@@ -39,6 +56,7 @@ Layer structured narrative representation and reasoning capabilities on top of t
 - Corpus survey and classification-driven repair planning.
 - Repair engine, span operations, and human review loop.
 - Evidence-backed project governance via LRH artifacts.
+- Exploratory foundations for story feature extraction (not yet a formal design).
 
 ## Out of Scope (Current Horizon)
 - Full narrative reasoning engine implementation in the current focus window.

--- a/lcats/project/roadmap/roadmap.md
+++ b/lcats/project/roadmap/roadmap.md
@@ -81,5 +81,5 @@ first full corpus quality and genre assessment pipeline.
 ## Alignment Notes
 - Completed phases are logged in `project/memory/decision_log.md`.
 - Active work spans Phase 4 (repair/review), story-analysis-pipeline foundations feeding the
-  Medium-Term Goal, and the WORKSTREAM-DOCS documentation cleanup — see
+  Medium-Term Goal, and the WS-DOCS documentation cleanup — see
   `project/focus/current_focus.md` for the current multi-priority focus.

--- a/lcats/project/roadmap/roadmap.md
+++ b/lcats/project/roadmap/roadmap.md
@@ -80,4 +80,6 @@ first full corpus quality and genre assessment pipeline.
 
 ## Alignment Notes
 - Completed phases are logged in `project/memory/decision_log.md`.
-- Active work is constrained to Phase 4 work items.
+- Active work spans Phase 4 (repair/review), story-analysis-pipeline foundations feeding the
+  Medium-Term Goal, and the WORKSTREAM-DOCS documentation cleanup — see
+  `project/focus/current_focus.md` for the current multi-priority focus.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -17,10 +17,15 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md`
-- `proposed/WI-LLM-0008.md` — Migrate `JSONPromptExtractor` to `LLMBackend`
-- `proposed/WI-LLM-0009.md` — Migrate `assess.py` / `assess_cli.py` to `LLMBackend`
-- `proposed/WI-LLM-0010.md` — Side-by-side model comparison dry run
+- `proposed/WI-DOCS-0013.md` — Fix accuracy issues in repo-root README.md and lcats/README.md
+- `proposed/WI-DOCS-0014.md` — Normalize CLI, LLM-backend, and assess reference docs
+- `proposed/WI-DOCS-0015.md` — Add a quickstart tutorial
 
 ## Resolved Items
 - `resolved/WI-REPAIR-0001.md`
 - `resolved/WI-LLM-0007.md` — Create `lcats/llm/` package (Protocol + backends)
+- `resolved/WI-LLM-0008.md` — Migrate `JSONPromptExtractor` to `LLMBackend`
+- `resolved/WI-LLM-0009.md` — Migrate `assess.py` / `assess_cli.py` to `LLMBackend`
+- `resolved/WI-LLM-0010.md` — Side-by-side model comparison dry run
+- `resolved/WI-INFRA-0011.md` — Add secrets utility and contributor guide for `.secrets/` pattern
+- `resolved/WI-ASSESS-0012.md` — Extend `lcats assess` with optional `--genre` and always-on genre detection

--- a/lcats/project/work_items/active/WI-APPLY-0005.md
+++ b/lcats/project/work_items/active/WI-APPLY-0005.md
@@ -5,7 +5,7 @@ type: deliverable
 status: active
 priority: high
 owner: unassigned
-linked_focus: FOCUS-REPAIR-REVIEW
+linked_focus: FOCUS-WORLDCON-2026
 blocked: false
 blocked_reason: null
 resolution: null

--- a/lcats/project/work_items/active/WI-META-0006.md
+++ b/lcats/project/work_items/active/WI-META-0006.md
@@ -5,7 +5,7 @@ type: deliverable
 status: active
 priority: high
 owner: unassigned
-linked_focus: FOCUS-REPAIR-REVIEW
+linked_focus: FOCUS-WORLDCON-2026
 blocked: false
 blocked_reason: null
 resolution: null

--- a/lcats/project/work_items/active/WI-REVIEW-0003.md
+++ b/lcats/project/work_items/active/WI-REVIEW-0003.md
@@ -5,7 +5,7 @@ type: deliverable
 status: active
 priority: high
 owner: unassigned
-linked_focus: FOCUS-REPAIR-REVIEW
+linked_focus: FOCUS-WORLDCON-2026
 blocked: false
 blocked_reason: null
 resolution: null

--- a/lcats/project/work_items/active/WI-SPANOPS-0002.md
+++ b/lcats/project/work_items/active/WI-SPANOPS-0002.md
@@ -5,7 +5,7 @@ type: deliverable
 status: active
 priority: high
 owner: unassigned
-linked_focus: FOCUS-REPAIR-REVIEW
+linked_focus: FOCUS-WORLDCON-2026
 blocked: false
 blocked_reason: null
 resolution: null

--- a/lcats/project/work_items/proposed/WI-DOCS-0013.md
+++ b/lcats/project/work_items/proposed/WI-DOCS-0013.md
@@ -1,0 +1,108 @@
+---
+id: WI-DOCS-0013
+title: Fix accuracy issues in repo-root README.md and lcats/README.md
+type: deliverable
+status: proposed
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-DOCS
+related_design: []
+depends_on: []
+blocked_by: []
+blocked: false
+blocked_reason: null
+resolution: null
+expected_actions:
+  - edit_file
+  - write_docs
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - implement_wi_docs_0014
+  - implement_wi_docs_0015
+  - overhaul_unrelated_sections
+acceptance:
+  - "/README.md's CLI command table lists all 13 implemented commands (help, info, gather, inspect, display, survey, assess, stats, repair-specials, meta register) plus the 3 placeholders (index, advise, eval), matching lcats/docs/reference/cli-status.md"
+  - "/README.md's LLM Integration section mentions both Anthropic and OpenAI backends"
+  - "lcats/README.md's Requirements section states an unambiguous Python version and does not reference installing pytest via conda"
+  - "project/executions/README.md no longer references scripts/prompts/record-execution as if it exists, or explicitly notes it is intentionally deferred"
+  - "lrh validate reports 0 errors"
+required_evidence:
+  - manual_review
+  - lrh_validate
+artifacts_expected:
+  - README.md
+  - lcats/README.md
+  - lcats/project/executions/README.md
+---
+
+# Work Item: WI-DOCS-0013
+
+## Summary
+Fix four accuracy issues flagged by the 2026-07-07 docs audit (Phase 2b): the repo-root README's
+stale CLI command table and OpenAI-only LLM description, `lcats/README.md`'s stale Python-version/
+pytest wording, and `project/executions/README.md`'s reference to a nonexistent helper script.
+
+## Problem / Context
+The 2026-07-07 docs audit (`project/audits/docs/2026-07-07-docs-audit.md`, "Accuracy findings")
+found that the repo-root `README.md` undercounts the CLI surface by 6 of 13 commands and describes
+LLM integration as OpenAI-only, even though an Anthropic backend has existed since `WI-LLM-0007`
+closed. `lcats/README.md`'s Requirements section still says "Python > 3.6(ish)" and lists
+installing `pytest` via conda, though `STYLE.md` Section 8 mandates `unittest` only and the
+canonical test command is `scripts/test`. `project/executions/README.md` references a
+`scripts/prompts/record-execution` helper that was never built; 12 execution records have been
+maintained manually since without it. Phase 2a of this audit (navigation fixes) already landed in
+PR #111; this item is Phase 2b (accuracy fixes), the next item in the `WS-DOCS` workstream.
+
+## Scope
+- Correct factual claims in `/README.md` (repo root) and `lcats/README.md` against current source
+  (`lcats/lcats/cli.py`, `lcats/llm/`, `STYLE.md`).
+- Note the deferred helper-script gap in `project/executions/README.md` rather than leaving it
+  silently wrong.
+- Do not touch any other documentation file — that is Phase 3 (`WI-DOCS-0014`).
+
+## Required Changes
+1. `/README.md` (repo root) — replace the "CLI Commands" table with all 13 commands from
+   `lcats/docs/reference/cli-status.md` (10 implemented, 3 placeholder), preserving the
+   implemented/placeholder distinction.
+2. `/README.md` (repo root) — update the "LLM Integration" bullet list under Features to mention
+   both Anthropic and OpenAI, not OpenAI alone.
+3. `lcats/README.md` — reword the Requirements section: state the Python version requirement
+   unambiguously (match `pyproject.toml`'s `requires-python = ">=3.6"` without the informal
+   "(ish)"), and remove or replace the `conda install -c anaconda pytest` line so it doesn't
+   contradict `STYLE.md`'s `unittest`-only framework.
+4. `project/executions/README.md` — either remove the `scripts/prompts/record-execution`
+   reference or add a one-line note that it is intentionally deferred and records are currently
+   written manually.
+
+## Non-Goals
+- Do not extract Section 9 of the corpus README into `docs/how-to/` — that is `WI-DOCS-0014`
+  (Phase 3).
+- Do not add new reference docs (CLI flags, LLM-backend reference) — that is `WI-DOCS-0014`.
+- Do not add tutorial content — that is `WI-DOCS-0015` (Phase 4).
+- Do not rewrite sections of either README that are still accurate (Quick Start, Python API
+  example, Project Structure, etc.).
+
+## Acceptance Criteria
+- `/README.md`'s CLI command table lists all 13 implemented commands, matching
+  `lcats/docs/reference/cli-status.md`.
+- `/README.md` mentions both Anthropic and OpenAI as supported LLM providers.
+- `lcats/README.md`'s Requirements section has unambiguous Python-version wording and no longer
+  instructs installing `pytest`.
+- `project/executions/README.md` no longer misrepresents `scripts/prompts/record-execution` as
+  present.
+- `lrh validate` reports 0 errors.
+
+## Validation
+- `scripts/version tools`
+- `lrh validate`
+
+## Risk Notes
+- `/README.md` is the GitHub-visible landing page; double-check the CLI table against
+  `lcats <command> --help` at implementation time, not just against `cli-status.md`, in case the
+  CLI surface changed again since the audit.

--- a/lcats/project/work_items/proposed/WI-DOCS-0013.md
+++ b/lcats/project/work_items/proposed/WI-DOCS-0013.md
@@ -27,7 +27,7 @@ forbidden_actions:
   - implement_wi_docs_0015
   - overhaul_unrelated_sections
 acceptance:
-  - "/README.md's CLI command table lists all 13 implemented commands (help, info, gather, inspect, display, survey, assess, stats, repair-specials, meta register) plus the 3 placeholders (index, advise, eval), matching lcats/docs/reference/cli-status.md"
+  - "/README.md's CLI command table lists all 10 implemented commands (help, info, gather, inspect, display, survey, assess, stats, repair-specials, meta register) plus the 3 placeholders (index, advise, eval), 13 total, matching lcats/docs/reference/cli-status.md"
   - "/README.md's LLM Integration section mentions both Anthropic and OpenAI backends"
   - "lcats/README.md's Requirements section states an unambiguous Python version and does not reference installing pytest via conda"
   - "project/executions/README.md no longer references scripts/prompts/record-execution as if it exists, or explicitly notes it is intentionally deferred"
@@ -61,7 +61,7 @@ PR #111; this item is Phase 2b (accuracy fixes), the next item in the `WS-DOCS` 
 
 ## Scope
 - Correct factual claims in `/README.md` (repo root) and `lcats/README.md` against current source
-  (`lcats/lcats/cli.py`, `lcats/llm/`, `STYLE.md`).
+  (`lcats/lcats/cli.py`, `lcats/lcats/llm/`, `STYLE.md`).
 - Note the deferred helper-script gap in `project/executions/README.md` rather than leaving it
   silently wrong.
 - Do not touch any other documentation file — that is Phase 3 (`WI-DOCS-0014`).
@@ -89,8 +89,8 @@ PR #111; this item is Phase 2b (accuracy fixes), the next item in the `WS-DOCS` 
   example, Project Structure, etc.).
 
 ## Acceptance Criteria
-- `/README.md`'s CLI command table lists all 13 implemented commands, matching
-  `lcats/docs/reference/cli-status.md`.
+- `/README.md`'s CLI command table lists all 10 implemented commands plus the 3 placeholders
+  (13 total), matching `lcats/docs/reference/cli-status.md`.
 - `/README.md` mentions both Anthropic and OpenAI as supported LLM providers.
 - `lcats/README.md`'s Requirements section has unambiguous Python-version wording and no longer
   instructs installing `pytest`.

--- a/lcats/project/work_items/proposed/WI-DOCS-0014.md
+++ b/lcats/project/work_items/proposed/WI-DOCS-0014.md
@@ -1,0 +1,123 @@
+---
+id: WI-DOCS-0014
+title: Normalize CLI, LLM-backend, and assess reference docs
+type: deliverable
+status: proposed
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-DOCS
+related_design:
+  - project/design/unified-llm-backend-design.md
+depends_on:
+  - WI-DOCS-0013
+blocked_by: []
+blocked: false
+blocked_reason: null
+resolution: null
+expected_actions:
+  - create_file
+  - edit_file
+  - write_docs
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - implement_wi_docs_0015
+  - rewrite_unrelated_docs
+acceptance:
+  - "docs/how-to/run-assess.md exists with Section 9 content extracted from the corpus README, and Section 9 is replaced with a short pointer to it"
+  - "docs/index.md's How-to guides link for lcats assess points at docs/how-to/run-assess.md, not the corpus-README anchor"
+  - "docs/reference/cli-commands.md exists, documenting flags/arguments for all 13 lcats subcommands, verified against lcats <command> --help"
+  - "docs/reference/llm-backend.md exists, documenting the LLMBackend Protocol and its Anthropic/OpenAI/Fake providers, derived from project/design/unified-llm-backend-design.md"
+  - "docs/reference/README.md links both new reference pages"
+  - "lrh validate reports 0 errors"
+required_evidence:
+  - manual_review
+  - lrh_validate
+artifacts_expected:
+  - lcats/docs/how-to/run-assess.md
+  - lcats/docs/index.md
+  - lcats/docs/reference/cli-commands.md
+  - lcats/docs/reference/llm-backend.md
+  - lcats/docs/reference/README.md
+  - lcats/lcats/analysis/corpus/README.md
+---
+
+# Work Item: WI-DOCS-0014
+
+## Summary
+Normalize LCATS's reference documentation: extract the `lcats assess` how-to content into its own
+page, and add reference docs for the CLI's per-command flags and the `LLMBackend` abstraction —
+Phase 3 of the 2026-07-07 docs audit.
+
+## Problem / Context
+Phase 2a (PR #111) linked `lcats assess` how-to content from `docs/index.md`, but left it living
+inside Section 9 of `lcats/lcats/analysis/corpus/README.md` — an Explanation-dominant document —
+as an interim measure "pending Phase 3 extraction" (per the audit). Separately, the audit found no
+reference doc for individual CLI command flags (only the implemented/placeholder status matrix in
+`docs/reference/cli-status.md`), and no reference doc for the `LLMBackend` Protocol delivered by
+`WORKSTREAM-LLM-BACKEND`, despite `project/design/unified-llm-backend-design.md` already
+describing its design. This item depends on `WI-DOCS-0013` landing first so the reference docs
+describe already-accurate source material.
+
+## Scope
+- Move (not rewrite) the `lcats assess` how-to content out of the corpus README into
+  `docs/how-to/`.
+- Add two new reference pages: CLI command flags, and the `LLMBackend` abstraction.
+- Do not touch the tutorial gap (`WI-DOCS-0015`) or re-run the Phase 2b accuracy fixes.
+
+## Required Changes
+1. Create `lcats/docs/how-to/run-assess.md` containing the content currently in Section 9 of
+   `lcats/lcats/analysis/corpus/README.md` (modes, manual prompt validation, dry run) — copy and
+   link, not rewrite, per the audit's Risks and Cautions note that this content was carefully
+   reviewed.
+2. Replace Section 9 of `lcats/lcats/analysis/corpus/README.md` with a one-line pointer to the new
+   how-to page.
+3. Update `docs/index.md`'s How-to guides entry for `lcats assess` to link
+   `how-to/run-assess.md` instead of the corpus-README anchor.
+4. Create `lcats/docs/reference/cli-commands.md`: run `lcats <command> --help` for all 13
+   subcommands (`help`, `info`, `gather`, `inspect`, `display`, `survey`, `assess`, `stats`,
+   `repair-specials`, `meta register`, `index`, `advise`, `eval`) and document flags/arguments for
+   each, verified against actual `--help` output (not assumed from source).
+5. Create `lcats/docs/reference/llm-backend.md`: document the `LLMBackend` Protocol and its
+   `AnthropicBackend`/`OpenAIBackend`/`FakeBackend` implementations, derived from
+   `project/design/unified-llm-backend-design.md`.
+6. Link both new reference pages from `lcats/docs/reference/README.md`.
+
+## Non-Goals
+- Do not add tutorial content — that is `WI-DOCS-0015` (Phase 4).
+- Do not redo any Phase 2b accuracy fix — that is `WI-DOCS-0013`.
+- Do not rewrite Sections 1–8 of the corpus README (the Explanation content) — only Section 9
+  moves.
+- Do not add a full worked example beyond what already exists in Section 9's content.
+
+## Acceptance Criteria
+- `docs/how-to/run-assess.md` exists with the extracted content; Section 9 is a pointer, not a
+  duplicate.
+- `docs/index.md` links the new how-to page, not the old anchor.
+- `docs/reference/cli-commands.md` exists and covers all 13 subcommands, verified against
+  `--help` output.
+- `docs/reference/llm-backend.md` exists and covers the `LLMBackend` Protocol and all three
+  providers.
+- `docs/reference/README.md` links both new pages.
+- `lrh validate` reports 0 errors.
+
+## Validation
+- `scripts/version tools`
+- `lrh validate`
+- `lcats <command> --help` for each of the 13 subcommands, to verify `cli-commands.md` accuracy
+
+## Dependencies / Order
+Depends on `WI-DOCS-0013` landing first — the reference docs this item adds should describe
+already-corrected source material (accurate README, correct provider description) rather than
+documenting against text that's about to change underneath them.
+
+## Risk Notes
+- `docs/reference/cli-commands.md` will need re-verification if the CLI surface changes again
+  before this item lands — same risk flagged on `WI-DOCS-0013`.
+- Extracting Section 9 touches a file with recent, carefully-reviewed content (3 commits landed
+  it); keep the extraction a copy-and-link operation, not a rewrite.

--- a/lcats/project/work_items/proposed/WI-DOCS-0015.md
+++ b/lcats/project/work_items/proposed/WI-DOCS-0015.md
@@ -1,0 +1,103 @@
+---
+id: WI-DOCS-0015
+title: Add a quickstart tutorial
+type: deliverable
+status: proposed
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-DOCS
+related_design: []
+depends_on:
+  - WI-DOCS-0013
+  - WI-DOCS-0014
+blocked_by: []
+blocked: false
+blocked_reason: null
+resolution: null
+expected_actions:
+  - create_file
+  - edit_file
+  - write_docs
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - rewrite_unrelated_docs
+  - publish_untested_commands
+acceptance:
+  - "docs/tutorials/quickstart.md exists and takes a new contributor from environment setup through a first successful lcats survey or lcats assess --dry-run run"
+  - "every command in the tutorial was actually run end-to-end in a clean environment and verified to succeed before landing"
+  - "docs/index.md's Tutorials section links the new page instead of stating tutorials are not scaffolded"
+  - "lrh validate reports 0 errors"
+required_evidence:
+  - manual_review
+  - lrh_validate
+artifacts_expected:
+  - lcats/docs/tutorials/quickstart.md
+  - lcats/docs/index.md
+---
+
+# Work Item: WI-DOCS-0015
+
+## Summary
+Add `docs/tutorials/quickstart.md`, LCATS's first Tutorial-quadrant document: a reproducible,
+step-by-step walkthrough from environment setup to a first working command, closing the last
+empty Diataxis quadrant identified by the 2026-07-07 docs audit.
+
+## Problem / Context
+`docs/index.md` currently states "Tutorials are not scaffolded in this phase" — accurate as of
+Phase 1, but a real gap for new contributors. The audit (Phase 4) recommends reusing content
+already proven correct in `lcats/README.md` and `docs/secrets-setup.md` rather than writing new,
+unverified instructions. This item depends on `WI-DOCS-0013` (accurate README) and `WI-DOCS-0014`
+(CLI/LLM-backend reference docs to link into, and the finished `docs/how-to/run-assess.md`) so the
+tutorial can point to settled, corrected material instead of documenting soon-to-change text.
+
+## Scope
+- One tutorial: environment setup through a first successful command with an interpretable result.
+- Reuse existing verified content (`lcats/README.md`, `docs/secrets-setup.md`) rather than
+  authoring new setup instructions from scratch.
+- Do not attempt full CLI coverage — that's what `docs/reference/cli-commands.md` is for.
+
+## Required Changes
+1. Create `lcats/docs/tutorials/quickstart.md` covering, in order: cloning the repo, `cd LCATS/lcats`,
+   `scripts/clean && scripts/build && scripts/develop`, `lcats info` to verify the install, then a
+   first `lcats survey` (no API key required) as the primary path, with `lcats assess --dry-run`
+   (also no API key required) offered as an alternative or follow-on step. Link to
+   `docs/secrets-setup.md` for readers who want to continue to a live `lcats assess` call.
+2. Update `docs/index.md`'s "Tutorials" section to link the new page instead of stating tutorials
+   are not scaffolded.
+
+## Non-Goals
+- Do not cover the full CLI surface in the tutorial — link to `docs/reference/cli-commands.md`
+  (`WI-DOCS-0014`) instead.
+- Do not add a second tutorial in this item — one complete quickstart is the Phase 4 scope.
+- Do not require a live API call as the tutorial's primary path — `survey`/`assess --dry-run` let
+  a new contributor succeed without provisioning keys first; live `assess` is an optional next step.
+
+## Acceptance Criteria
+- `docs/tutorials/quickstart.md` exists and reaches a concrete, working outcome.
+- Every command in the tutorial was run end-to-end in a clean environment and confirmed to work
+  exactly as written before this item is considered done.
+- `docs/index.md`'s Tutorials section links the new page.
+- `lrh validate` reports 0 errors.
+
+## Validation
+- `scripts/version tools`
+- `lrh validate`
+- Manually execute every command in `quickstart.md` in order, in a clean checkout, and confirm
+  each one produces the output described
+
+## Dependencies / Order
+Depends on `WI-DOCS-0013` and `WI-DOCS-0014` — the tutorial should link to (not duplicate) the
+corrected README and the Phase 3 reference docs, and should not be written against text that's
+about to change underneath it.
+
+## Risk Notes
+- Tutorials are the quadrant most likely to silently rot (a command that worked at write-time
+  breaks later without anyone noticing, since it's read start-to-finish rather than scanned like
+  reference). No automated check enforces this; re-verification is a manual, recurring cost future
+  contributors should be aware of.

--- a/lcats/project/work_items/proposed/WI-PERSIST-0004.md
+++ b/lcats/project/work_items/proposed/WI-PERSIST-0004.md
@@ -5,7 +5,7 @@ type: investigation
 status: proposed
 priority: medium
 owner: unassigned
-linked_focus: FOCUS-REPAIR-REVIEW
+linked_focus: FOCUS-WORLDCON-2026
 blocked: false
 blocked_reason: null
 resolution: null

--- a/lcats/project/work_items/resolved/WI-REPAIR-0001.md
+++ b/lcats/project/work_items/resolved/WI-REPAIR-0001.md
@@ -6,7 +6,7 @@ status: resolved
 resolution: "Implemented conservative repair proposal generation in lcats.analysis.corpus.repairs with deterministic dry-run plan models and TSV/JSONL reporting helpers; non-destructive-by-default behavior preserved."
 priority: high
 owner: unassigned
-linked_focus: FOCUS-REPAIR-REVIEW
+linked_focus: FOCUS-WORLDCON-2026
 blocked: false
 blocked_reason: null
 ---

--- a/lcats/project/workstreams/active/WS-DOCS.md
+++ b/lcats/project/workstreams/active/WS-DOCS.md
@@ -1,0 +1,56 @@
+---
+id: WS-DOCS
+kind: planning_node
+title: LCATS Documentation Completion (Docs Audit Phase 2b-4)
+status: active
+stage: planned
+related_focus:
+  - FOCUS-WORLDCON-2026
+work_items:
+  - WI-DOCS-0013
+  - WI-DOCS-0014
+  - WI-DOCS-0015
+exit_criteria:
+  - Repo-root README.md's CLI command table and LLM-provider description match current lcats/lcats/cli.py and lcats/llm/ (WI-DOCS-0013)
+  - lcats/README.md's Requirements section matches STYLE.md's unittest-only testing framework and accurate Python version wording (WI-DOCS-0013)
+  - docs/how-to/run-assess.md exists with Section 9 content extracted from the corpus README (WI-DOCS-0014)
+  - docs/reference/cli-commands.md exists, verified against `lcats <command> --help` for every implemented command (WI-DOCS-0014)
+  - docs/reference/llm-backend.md exists, derived from project/design/unified-llm-backend-design.md (WI-DOCS-0014)
+  - docs/tutorials/quickstart.md exists and takes a new contributor from environment setup through a first successful `lcats survey` or `lcats assess --dry-run` run (WI-DOCS-0015)
+---
+
+# Workstream: LCATS Documentation Completion
+
+## Purpose
+
+Bring `lcats/docs/` and the repo-root `README.md` up to date with everything already implemented
+in LCATS, so team collaborators can find accurate documentation for any shipped feature. This is
+priority 3 of `FOCUS-WORLDCON-2026` (`project/focus/current_focus.md`): LCATS needs to be in a
+clean, documented state for WorldCon 2026.
+
+This workstream executes Phases 2b, 3, and 4 of the 2026-07-07 docs audit
+(`project/audits/docs/2026-07-07-docs-audit.md`). Phase 1 (scaffold) and Phase 2a (navigation
+fixes) already landed in PR #110 and PR #111.
+
+## Work Items
+
+| ID | Title | Status | Audit Phase |
+|---|---|---|---|
+| WI-DOCS-0013 | Fix accuracy issues in repo-root and lcats/README.md | proposed | Phase 2b |
+| WI-DOCS-0014 | Normalize CLI, LLM-backend, and assess reference docs | proposed | Phase 3 |
+| WI-DOCS-0015 | Add a quickstart tutorial | proposed | Phase 4 |
+
+## Governing Audit
+
+See `project/audits/docs/2026-07-07-docs-audit.md`, sections "Recommended phased PRs" (Phase 2b,
+3, 4) and "Recommended target documentation structure". No formal `project/design/proposals/`
+entry governs this workstream — the audit itself serves that role, since the scope is a
+well-evidenced accuracy/coverage backlog rather than a new architectural decision.
+
+## Notes
+
+- `WI-DOCS-0013` has no dependencies and can start immediately.
+- `WI-DOCS-0014` should follow `WI-DOCS-0013` (Section 3's reference docs should describe
+  already-accurate source material).
+- `WI-DOCS-0015` should follow `WI-DOCS-0013` and `WI-DOCS-0014` — the audit recommends the
+  tutorial reuse content "already proven correct" by the earlier phases.

--- a/lcats/project/workstreams/active/WS-DOCS.md
+++ b/lcats/project/workstreams/active/WS-DOCS.md
@@ -11,7 +11,7 @@ work_items:
   - WI-DOCS-0014
   - WI-DOCS-0015
 exit_criteria:
-  - Repo-root README.md's CLI command table and LLM-provider description match current lcats/lcats/cli.py and lcats/llm/ (WI-DOCS-0013)
+  - Repo-root README.md's CLI command table and LLM-provider description match current lcats/lcats/cli.py and lcats/lcats/llm/ (WI-DOCS-0013)
   - lcats/README.md's Requirements section matches STYLE.md's unittest-only testing framework and accurate Python version wording (WI-DOCS-0013)
   - docs/how-to/run-assess.md exists with Section 9 content extracted from the corpus README (WI-DOCS-0014)
   - docs/reference/cli-commands.md exists, verified against `lcats <command> --help` for every implemented command (WI-DOCS-0014)


### PR DESCRIPTION
## Summary
- Broadens `project/focus/current_focus.md` from a single priority (repair/review) to three parallel active priorities: repair/review pipeline, story analysis pipeline foundations, and documentation cleanup — reflecting that LCATS needs to be in a clean, documented state for WorldCon 2026.
- Adds a **Medium-Term Goal (WorldCon 2026)** section to `project/goal/project_goal.md`: a story feature-extraction pipeline for the Academic Track paper on "The Shape of Science Fiction." Explicitly not yet a design proposal or workstream — the feature library isn't decided yet (tracked in external design threads); this is intent-level tracking only.
- Fixes `project/roadmap/roadmap.md`'s now-contradictory Alignment Note ("Active work is constrained to Phase 4 work items").
- Creates `WS-DOCS` (`project/workstreams/active/WS-DOCS.md`) to execute Phase 2b/3/4 of the 2026-07-07 docs audit (`project/audits/docs/2026-07-07-docs-audit.md`), with three proposed work items:
  - `WI-DOCS-0013` — accuracy fixes (repo-root README CLI table + LLM-provider description, `lcats/README.md` requirements wording)
  - `WI-DOCS-0014` — reference-doc normalization (extract `lcats assess` how-to, add CLI-flags and LLM-backend reference docs)
  - `WI-DOCS-0015` — quickstart tutorial (closes the last empty Diataxis quadrant)
- Refreshes `project/work_items/README.md`'s index, which had drifted (listed already-resolved `WI-LLM-0008/9/10` as still proposed).

## Note on workstream naming
While building this, found that `lrh validate`'s workstream discovery only recognizes `WS-*.md` filenames with an `id:` starting with `WS-` (per `src/lrh/control/validator.py`). The existing `project/workstreams/resolved/WORKSTREAM-LLM-BACKEND.md` doesn't match that pattern and has never actually been picked up by `lrh validate` — it's silently invisible. Not fixed in this PR (out of scope), but worth a follow-up to rename it for consistency and actual validation coverage.

## Test plan
- [x] `lrh validate`: 0 errors, 22 warnings (all pre-existing `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS`/`PLANNING_ORPHANED_ACTIVE_WORK_ITEM` patterns already present on other work items, plus the same pattern now also on the 3 new `WI-DOCS-*` items — no new categories of warning introduced)
- [x] Confirmed `WS-DOCS`'s `work_items:` list resolves cleanly against the 3 new WI files (no `PLANNING_UNKNOWN_CHILD_ID` errors)
- [x] Confirmed no `PLANNING_ACTIVE_WORKSTREAM_NO_ACTIONABLE_LEAF` warning (3 proposed WIs exist under the active workstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
