### PR TITLE
Fix accuracy issues in repo-root and lcats READMEs (WI-DOCS-0013)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ LCATS consists of several key components:
 - **Pipeline**: Configurable multi-stage processing workflows
 
 ### 🤖 LLM Integration
-- OpenAI API integration for text analysis and extraction
+- Anthropic and OpenAI API integration for text analysis, extraction, and assessment
 - Template-based prompt engineering for consistent results
 - Structured output parsing and error handling
 - Configurable models and parameters
@@ -260,15 +260,31 @@ All developers should ensure:
 
 ## CLI Commands
 
+Implemented:
+
 | Command | Description |
 |---------|-------------|
 | `lcats help` | Show usage information |
 | `lcats info` | Display system information |
 | `lcats gather [gatherers]` | Collect corpus data |
 | `lcats inspect <file>` | Examine story JSON files |
+| `lcats display <file>` | Display full story JSON content |
+| `lcats survey` | Survey corpus files for quality issues |
+| `lcats assess <files>` | Assess corpus stories for quality and genre fit using the Claude API |
+| `lcats stats` | Compute corpus-level statistics |
+| `lcats repair-specials` | Generate dry-run Unicode/special-character repair proposals |
+| `lcats meta register <repo_locator>` | Register a repository locator in the local workspace registry |
+
+Placeholder (declared, not yet implemented):
+
+| Command | Description |
+|---------|-------------|
 | `lcats index` | Preprocess corpus (planned) |
 | `lcats advise` | AI advisory interface (planned) |
 | `lcats eval` | Benchmark evaluation (planned) |
+
+See [`lcats/docs/reference/cli-status.md`](lcats/docs/reference/cli-status.md) for the
+authoritative status matrix.
 
 ## API Reference
 

--- a/lcats/README.md
+++ b/lcats/README.md
@@ -6,13 +6,15 @@ sophisticated tools built on top of these corpora.
 
 ## Requirements
 Right now, some requirements are via pip and others via conda. :-/
-- Python > 3.6(ish)
+- Python >= 3.6
 - pip install build  # can be conda installed: conda install conda-forge::python-build
 - pip install twine  # can be conda installed: conda install conda-forge::twine
 - pip install beautifulsoup4
 - pip install lxml
-- conda install -c anaconda pytest
 - conda install conda-forge::parameterized
+
+Tests use Python's built-in `unittest` (see `STYLE.md`), not `pytest` — no `pytest` install is
+required.
 
 
 ## Building

--- a/lcats/README.md
+++ b/lcats/README.md
@@ -6,7 +6,9 @@ sophisticated tools built on top of these corpora.
 
 ## Requirements
 Right now, some requirements are via pip and others via conda. :-/
-- Python >= 3.6
+- Python >= 3.10 (several modules use `X | None` union-type syntax evaluated at import time,
+  which requires 3.10+; `pyproject.toml` and `setup.py` still declare `>=3.6` — that's stale and
+  not fixed here, since this is a docs-only change)
 - pip install build  # can be conda installed: conda install conda-forge::python-build
 - pip install twine  # can be conda installed: conda install conda-forge::twine
 - pip install beautifulsoup4
@@ -14,7 +16,7 @@ Right now, some requirements are via pip and others via conda. :-/
 - conda install conda-forge::parameterized
 
 Tests use Python's built-in `unittest` (see `STYLE.md`), not `pytest` — no `pytest` install is
-required.
+required. CI runs Python 3.11.
 
 
 ## Building

--- a/lcats/project/executions/AD_HOC/2026_07_09_11_21_53_WI_DOCS_0013_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_09_11_21_53_WI_DOCS_0013_REVIEW.md
@@ -1,0 +1,55 @@
+---
+execution_id: 2026_07_09_11_21_53_WI_DOCS_0013_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_DOCS_0013_REVIEW)[2026-07-09T11:20:51-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_09_01_46_22_WI_DOCS_0013
+pr: https://github.com/xenotaur/LCATS/pull/114
+commit: 1542536
+created_at: 2026-07-09T11:21:53-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/114
+session_transcript: pending
+---
+
+# Summary
+
+Addressed 1 open `chatgpt-codex-connector` comment on PR #114 (`WI-DOCS-0013` implementation):
+the "Python >= 3.6" wording I wrote in `lcats/README.md` is more actively misleading than the
+"(ish)" it replaced, since the package actually requires Python 3.10+ at import time.
+
+# Result
+
+The comment was valid and confirmed present: `dataclasses` imports need 3.7+, and — the decisive
+issue — `lcats/meta_registry.py`, `lcats/analysis/text_segmenter.py`, and
+`lcats/analysis/graph_plotters.py` all use `X | None` union-type syntax evaluated at class/def
+definition time (no `from __future__ import annotations` in any of the three), which raises
+`TypeError` on any Python before 3.10 (PEP 604 added `|` support to type objects in 3.10).
+
+Fixed `lcats/README.md`: changed the Requirements line to `Python >= 3.10`, with a parenthetical
+explaining the union-syntax evidence, and noted that `pyproject.toml`/`setup.py` still declare
+`>=3.6` — a separate, pre-existing stale constraint, not fixed here since packaging metadata is
+outside `WI-DOCS-0013`'s docs-only scope (`forbidden_actions: overhaul_unrelated_sections`, and
+`artifacts_expected` only lists README/executions-README files). Also added a note that CI runs
+3.11, for a concrete known-working reference point.
+
+No comments were skipped.
+
+# Validation
+
+- Only `lcats/README.md` changed (`git status --short` showed 1 modified `.md` file, no Python) —
+  `scripts/format`, `scripts/lint`, `scripts/test` not applicable.
+- Verified the union-syntax claim directly: `grep` for `| None` usage across `lcats/*.py` and
+  `lcats/**/*.py`, cross-checked each hit against `from __future__ import annotations` presence;
+  confirmed 3 files use the syntax without the future import.
+- `lrh validate` — 0 errors, 22 pre-existing warnings (unchanged from before this PR).
+
+# Follow-up
+
+- `session_transcript` is `pending` — update to `claude-app:<session-id>` after this session ends.
+- After PR #114 merges: set this record's `status` to `landed`, and update the primary record
+  (`2026_07_09_01_46_22_WI_DOCS_0013`) the same way per the closeout protocol.
+- Flagged, not fixed: `pyproject.toml`'s `requires-python = ">=3.6"` and `setup.py`'s
+  `python_requires='>=3.6'` are themselves stale (should be `>=3.10`) — a good candidate for a
+  small follow-up work item, separate from `WS-DOCS` since it's a packaging/code fix, not a docs
+  fix.

--- a/lcats/project/executions/README.md
+++ b/lcats/project/executions/README.md
@@ -4,6 +4,6 @@ This directory stores lightweight records for meaningful prompt-driven work.
 Records should identify the prompt ID, related work item, idempotence check,
 summary of changes, tests run, and intentional deferrals.
 
-The requested helper script `scripts/prompts/record-execution` was not present
-when this convention file was created, so records may be added manually in this
-format until a helper exists.
+A `scripts/prompts/record-execution` helper does not exist. This is intentional: the `lrh prompt
+record-execution` CLI command creates the record stub directly, and records are then edited
+manually to fill in the optional fields. No standalone script is planned.

--- a/lcats/project/executions/WI-DOCS-0013/2026_07_09_01_46_22_WI_DOCS_0013.md
+++ b/lcats/project/executions/WI-DOCS-0013/2026_07_09_01_46_22_WI_DOCS_0013.md
@@ -1,0 +1,53 @@
+---
+execution_id: 2026_07_09_01_46_22_WI_DOCS_0013
+prompt_id: PROMPT(WI-DOCS-0013:WI_DOCS_0013)[2026-07-09T01:41:07-04:00]
+work_item: WI-DOCS-0013
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/114
+commit: 29f951e
+created_at: 2026-07-09T01:46:22-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-DOCS-0013.md
+session_transcript: pending
+---
+
+# Summary
+
+Implemented `WI-DOCS-0013` (Phase 2b of the 2026-07-07 docs audit): fixed four accuracy issues in
+the repo-root `README.md`, `lcats/README.md`, and `project/executions/README.md`.
+
+# Result
+
+- `/README.md` (repo root): replaced the 7-command CLI table with all 13 commands split into
+  "Implemented" (10) and "Placeholder" (3) tables, matching `lcats/docs/reference/cli-status.md`;
+  verified live against `lcats --help` and each placeholder subcommand's actual output before
+  editing (not just against the status matrix, per the work item's Risk Note). Updated the LLM
+  Integration bullets to mention Anthropic alongside OpenAI.
+- `lcats/README.md`: Requirements section now reads `Python >= 3.6` (was "3.6(ish)") and no longer
+  lists installing `pytest` via conda, which contradicted `STYLE.md`'s `unittest`-only framework.
+- `lcats/project/executions/README.md`: reworded to state that `lrh prompt record-execution`
+  already fills the role a standalone helper script would have, rather than implying one is still
+  expected — this matches how execution records have actually been created throughout this
+  session and prior sessions.
+
+No other files touched; `WI-DOCS-0014`/`WI-DOCS-0015` scope (reference-doc extraction, tutorial)
+explicitly out of scope per this item's Non-Goals.
+
+# Validation
+
+- Only Markdown files changed (`git status --short` showed 3 modified `.md` files, no Python) —
+  `scripts/format`, `scripts/lint`, `scripts/test` not applicable.
+- `scripts/version tools` — not present in this repository (no `scripts/version` script exists,
+  consistent with prior sessions); confirmed tool versions directly: Black 26.3.1, Ruff 0.15.12.
+- Item-specific: ran `lcats --help` and `lcats index`/`lcats advise`/`lcats eval` live to confirm
+  the 10-implemented/3-placeholder split before writing the CLI table.
+- `lrh validate` — 0 errors, 22 pre-existing warnings (unchanged from before this PR).
+
+# Follow-up
+
+- `session_transcript` is `pending` — update to `claude-app:<session-id>` after this session ends.
+- After PR #114 merges: set this record's `status` to `landed`, record the merge commit, and move
+  `WI-DOCS-0013` to `project/work_items/resolved/` with `status: resolved` and a `resolution:`
+  note.
+- `WI-DOCS-0014` (depends on this item) is now unblocked and ready to pick up next.


### PR DESCRIPTION
## Summary
Implements `WI-DOCS-0013` (Phase 2b of the 2026-07-07 docs audit) — accuracy fixes only, no navigation or reorganization changes.

- `/README.md` (repo root): CLI command table now lists all 13 commands (10 implemented + 3 placeholder, split into two tables), matching `lcats/docs/reference/cli-status.md`. Verified live against `lcats --help` and each placeholder subcommand's error message before editing, not just against the status matrix. LLM Integration bullets now mention Anthropic alongside OpenAI.
- `lcats/README.md`: Requirements section now says `Python >= 3.6` (was the informal "3.6(ish)") and no longer instructs installing `pytest` via conda — that contradicted `STYLE.md`'s `unittest`-only testing framework.
- `lcats/project/executions/README.md`: no longer implies a future `scripts/prompts/record-execution` script is expected — `lrh prompt record-execution` already fills that role, confirmed by how execution records have actually been created throughout this session.

Prompt ID: `PROMPT(WI-DOCS-0013:WI_DOCS_0013)[2026-07-09T01:41:07-04:00]`

## Test plan
- [x] `lcats --help` and `lcats {index,advise,eval}` run live to confirm the 10 implemented / 3 placeholder split still matches `cli-status.md` before editing the table
- [x] Only Markdown changed — `scripts/format`/`lint`/`test` not applicable (confirmed via `git status --short`)
- [x] `lrh validate`: 0 errors, 22 pre-existing warnings unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
