### PR TITLE
Add workstream WS-SPECIALS-CLEANUP: special-character cleanup via pipeline-replayable repairs

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_09_16_30_56_WS_SPECIALS_CLEANUP_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_09_16_30_56_WS_SPECIALS_CLEANUP_REVIEW.md
@@ -1,0 +1,60 @@
+---
+execution_id: 2026_07_09_16_30_56_WS_SPECIALS_CLEANUP_REVIEW
+prompt_id: PROMPT(AD_HOC:WS_SPECIALS_CLEANUP_REVIEW)[2026-07-09T16:25:31-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/116
+commit: b1d7a0e
+created_at: 2026-07-09T16:30:56-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/116
+session_transcript: pending
+---
+
+# Summary
+
+Address open review comments on PR #116 (Add workstream WS-SPECIALS-CLEANUP)
+via `lrh request review_response`. Two comments from
+copilot-pull-request-reviewer, both flagging module paths written as
+`lcats/analysis/corpus/...` where the repo-root-relative convention is
+`lcats/lcats/analysis/corpus/...`.
+
+`rerun_of` is empty: PR #116 was created by the `/lrh-workstream` skill,
+which does not produce a primary execution record, so there is no original
+execution to link.
+
+# Result
+
+Both comments fixed in
+`project/workstreams/proposed/WS-SPECIALS-CLEANUP.md` (commit b1d7a0e):
+
+- r3554501774 — exit criterion now cites
+  `lcats/lcats/analysis/corpus/repairs.py`.
+- r3554501791 — Purpose section now cites
+  `lcats/lcats/analysis/corpus/`.
+
+No comments skipped.
+
+# Validation
+
+- `scripts/version tools` — absent in LCATS; equivalents recorded:
+  black 26.3.1, ruff 0.15.12, Python 3.11.8.
+- `scripts/format --check --diff` — fails only on
+  `lcats/gettenberg/metadata.py`, which is byte-identical to origin/main
+  (this PR touches only the workstream markdown). Pre-existing drift from
+  unpinned Black (26.3.1 prefers hugging-parens style); left unformatted per
+  AGENTS.md "Do not reformat unrelated files."
+- `scripts/lint` — ruff: all checks passed; black check reports the same
+  pre-existing file; script exit 0.
+- `scripts/test` — 1248 tests OK (9.98s).
+- `lrh validate` — 0 errors, 19 pre-existing owner-role warnings.
+
+# Follow-up
+
+- Pre-existing Black drift in `lcats/gettenberg/metadata.py` (unpinned Black
+  version) should be fixed in a separate formatting-only change or by pinning
+  Black in pyproject.toml.
+- Update `session_transcript` from `pending` to `claude-app:<session-id>`
+  after the session ends.
+- On merge: set this record and PR metadata to `landed`.

--- a/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+++ b/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
@@ -19,7 +19,7 @@ work_items:
 exit_criteria:
   - lcats survey --mode specials over freshly regenerated data/ reports zero unaddressed mojibake findings — every measured residual occurrence is repaired by rule, covered by a per-story override, or explicitly allowlisted
   - Repair rules and per-story overrides are versioned repo inputs applied during gathering, so clearing the cache and regenerating data/ reproduces the same repaired output deterministically
-  - DEFAULT_REPAIR_RULES in lcats/analysis/corpus/repairs.py targets the encoding families measured in the live corpus, with tests against real sampled story contexts (the unmatched cp1252-form rules are replaced)
+  - DEFAULT_REPAIR_RULES in lcats/lcats/analysis/corpus/repairs.py targets the encoding families measured in the live corpus, with tests against real sampled story contexts (the unmatched cp1252-form rules are replaced)
   - Promotion from data/ to corpora/ is gated by a passing specials survey, and the stale corpora/ snapshot is superseded by promotion at the next release rather than repaired in place
   - project/memory/decision_log.md and design.md's State and Persistence Boundary section record the pivot from offset-keyed span-op persistence to rule/override-keyed replayable repairs
 ---
@@ -32,7 +32,7 @@ Coordinate the work that takes LCATS from "known encoding damage in the
 corpus" to "regenerated data/ passes the specials survey and can be promoted
 to corpora/ at release." This workstream connects the already-built detection,
 classification, repair-proposal, span-operation, and review machinery
-(`lcats/analysis/corpus/`) to the gather pipeline, so repairs are replayable
+(`lcats/lcats/analysis/corpus/`) to the gather pipeline, so repairs are replayable
 inputs to regeneration rather than one-off edits to stored files.
 
 ## Background / Rationale

--- a/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+++ b/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
@@ -1,0 +1,117 @@
+---
+id: WS-SPECIALS-CLEANUP
+kind: planning_node
+title: Special-character cleanup via pipeline-replayable repairs
+status: proposed
+stage: assessed
+origin: ad_hoc
+summary: Coordinate the release-oriented special-character cleanup — measured repair rules, a gather-time normalization hook, per-story overrides, residual human review, and survey-gated promotion — so regenerated data/ and promoted corpora/ are free of encoding damage.
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_design:
+  - project/design/design.md
+  - project/audits/2026-06-16-special-character-cleanup-workstream-audit.md
+  - project/audits/2026-06-18-phase-4-repair-review-application-integration-audit.md
+work_items:
+  - WI-SPANOPS-0002
+  - WI-REVIEW-0003
+  - WI-APPLY-0005
+exit_criteria:
+  - lcats survey --mode specials over freshly regenerated data/ reports zero unaddressed mojibake findings — every measured residual occurrence is repaired by rule, covered by a per-story override, or explicitly allowlisted
+  - Repair rules and per-story overrides are versioned repo inputs applied during gathering, so clearing the cache and regenerating data/ reproduces the same repaired output deterministically
+  - DEFAULT_REPAIR_RULES in lcats/analysis/corpus/repairs.py targets the encoding families measured in the live corpus, with tests against real sampled story contexts (the unmatched cp1252-form rules are replaced)
+  - Promotion from data/ to corpora/ is gated by a passing specials survey, and the stale corpora/ snapshot is superseded by promotion at the next release rather than repaired in place
+  - project/memory/decision_log.md and design.md's State and Persistence Boundary section record the pivot from offset-keyed span-op persistence to rule/override-keyed replayable repairs
+---
+
+# Workstream: Special-character cleanup via pipeline-replayable repairs
+
+## Purpose
+
+Coordinate the work that takes LCATS from "known encoding damage in the
+corpus" to "regenerated data/ passes the specials survey and can be promoted
+to corpora/ at release." This workstream connects the already-built detection,
+classification, repair-proposal, span-operation, and review machinery
+(`lcats/analysis/corpus/`) to the gather pipeline, so repairs are replayable
+inputs to regeneration rather than one-off edits to stored files.
+
+## Background / Rationale
+
+A 2026-07-09 assessment measured the actual damage and overturned two
+assumptions:
+
+- The systemic mojibake in the repo `corpora/` snapshot (148 stories, ~19,800
+  occurrences, dominated by latin-1-decoded UTF-8) is **stale history from old
+  gather runs**. The freshly regenerated `data/` tree contains **35 stories
+  with exactly one occurrence each**, all in `mass_quantities`, all byte-for-
+  byte present in the upstream Project Gutenberg sources (three families:
+  `Ã©`-form, Mac-Roman `√©`-form, `Â°`-form).
+- The six `DEFAULT_REPAIR_RULES` target a cp1252-decoded form that occurs
+  **zero times** in either corpora/ or data/ — the repair engine is currently
+  a silent no-op on real data.
+
+Because `data/` is cleared and regenerated after major changes (and users
+regenerate with their own customizations), durable fixes must live in the
+pipeline as versioned rule tables and per-story overrides, not in stored
+JSON. This supersedes the 2026-06-18 decision to keep application workflows
+out of scope, and amends the persistence boundary in project/design/design.md.
+The 2026-06-16 special-character cleanup audit remains the governing survey of
+reusable machinery; this workstream executes its "reuse, don't reinvent"
+strategy with the corrected facts.
+
+## Scope
+
+- Add a post-extraction normalization step to the gather pipeline that applies
+  repair rules and per-story overrides deterministically, recording applied
+  rule ids in story metadata for provenance.
+- Replace the dead repair-rule table with rules for the three measured
+  encoding families, tested against real corpus samples.
+- Add a versioned per-story overrides file for residual judgment calls that
+  rules cannot safely cover.
+- Human review of the ~35 measured residuals (rule-level approval, not
+  per-occurrence).
+- Gate promotion from data/ to corpora/ on a passing specials survey.
+- Record the persistence-model pivot in the decision log and design.md.
+
+## Work Items
+
+Existing active items to re-scope under this workstream:
+
+- **WI-SPANOPS-0002** — span-operation library work is complete; remaining
+  scope is its role as the ephemeral execution layer under replayable rules.
+- **WI-REVIEW-0003** — review decision models are complete; remaining scope is
+  persisting decisions as rule/override-keyed versioned files.
+- **WI-APPLY-0005** — the application library landed 2026-06-18 (decision log)
+  but the item is still active; remaining scope is pipeline integration, or
+  resolve it and open a successor.
+
+New items to be created via /lrh-work-item (IDs assigned at creation):
+the gather-time normalization hook; the measured rule table; the per-story
+overrides file; the residual review pass and regeneration; the survey-gated
+promotion step.
+
+## Exit Criteria
+
+(See frontmatter `exit_criteria` — authoritative list.)
+
+## Non-Goals
+
+- Does not perform the bucket/story-directory layout migration
+  (project/design/flat_story_layout_migration_impact_report.md) — deferred
+  post-release; the overrides and decision files are forward-compatible with
+  that layout.
+- Does not repair the stale corpora/ snapshot in place — it is superseded by
+  promotion.
+- Does not use LLM-based repair; `lcats assess` remains a triage layer for
+  non-mojibake issue classes (transcriber notes, missing quotations), which
+  are tracked separately from this workstream's encoding scope.
+- Does not implement an interactive review UI.
+
+## Open Questions
+
+- Where should the 2026-07-09 measurement evidence live —
+  project/audits/ or project/evidence/? (A dated note should be written and
+  linked from `related_design` or `evidence`.)
+- Collection naming differs between data/ (ohenry-four_million,
+  wilde_happy_prince) and corpora/ (ohenry, wilde) — the promotion mapping
+  should be confirmed before the survey gate is defined.


### PR DESCRIPTION
## Summary

Adds a proposed workstream (`stage: assessed`) coordinating the release-oriented special-character cleanup: measured repair rules, a gather-time normalization hook, per-story overrides, residual human review, and survey-gated promotion from `data/` to `corpora/`.

## Key facts motivating the workstream (2026-07-09 assessment)

- The systemic mojibake in the repo `corpora/` snapshot (148 stories, ~19,800 occurrences) is stale damage from old gather runs; the freshly regenerated `data/` contains only **35 single-occurrence upstream defects**, all in `mass_quantities`.
- The six `DEFAULT_REPAIR_RULES` target a cp1252-decoded mojibake form that occurs **zero times** in either tree — the repair engine is currently a no-op on real data.
- Because `data/` is regenerated after major changes, durable fixes must be versioned pipeline inputs (rules + per-story overrides), not edits to stored JSON.

## Contents

- `project/workstreams/proposed/WS-SPECIALS-CLEANUP.md` — planning node linked to `FOCUS-WORLDCON-2026`, adopting active items WI-SPANOPS-0002 / WI-REVIEW-0003 / WI-APPLY-0005 and describing five new work items to be created via `/lrh-work-item`.

## Validation

- `lrh validate`: 0 errors, 19 warnings (all pre-existing owner-role warnings). Attaching the three active WIs to this planning node cleared their orphaned-work-item warnings.

## Follow-ups (not in this PR)

- Decision-log entry + design.md persistence-boundary amendment for the offsets→rules pivot.
- Dated evidence note with the 2026-07-09 measurements.
- New work items via `/lrh-work-item`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)