### PR TITLE
Pin Black to 25.11.0 to match CI and stop formatter version skew

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         files: ^lcats/(lcats|tests|tools)/.*\.py$
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.11.0
     hooks:
       - id: black
         files: ^lcats/(lcats|tests|tools)/.*\.py$

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -39,13 +39,13 @@ lcats = "lcats.cli:main"
 [project.optional-dependencies]
 test = [
     "ruff",
-    "black",
+    "black==25.11.0",
     "coverage",
     "parameterized",
 ]
 dev = [
     "ruff",
-    "black",
+    "black==25.11.0",
     "coverage",
     "parameterized",
 ]


### PR DESCRIPTION
## Problem

`scripts/format --check --diff` fails on a clean checkout of `main`: it wants to reformat `lcats/lcats/gettenberg/metadata.py` (the multi-line f-string SQL calls in `titles_for`, `languages_for`, `authors_split`, etc.) to Black 26's hugging-parens style.

Root cause is formatter version skew — the repo had three Black versions in play:

| Where | Version | Style |
|---|---|---|
| CI (`.github/workflows/lint.yml`) | `black==25.11.0` (pinned) | current repo formatting ✅ |
| pre-commit hook (`.pre-commit-config.yaml`) | `24.10.0` | current repo formatting ✅ |
| Local dev (`pyproject.toml`, unpinned) | 26.3.1 | hugging parens ❌ |

## Fix

CI's pin is the source of truth (and `main` is green under it), so align the other two to it rather than reformatting:

- Pin `black==25.11.0` in the `test` and `dev` extras of `lcats/pyproject.toml`.
- Bump the pre-commit black rev from `24.10.0` to `25.11.0`.

No code is reformatted. Reformatting to Black 26 style was considered and rejected: CI pins 25.11.0, which would reject the 26-style output (verified locally — the two versions disagree on these call sites, and the 24.10.0 pre-commit hook actively reverted the 26-style reformat during commit).

## Validation

With `black==25.11.0` installed via `scripts/develop`:

- `scripts/format --check --diff` — passes, 141 files unchanged
- `scripts/lint` — ruff and black checks pass
- `scripts/test` — 1248 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)