### PR TITLE
Add work items WI-RULES-0016..WI-PROMOTE-0020 under WS-SPECIALS-CLEANUP

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_11_21_24_30_WI_SPECIALS_CLEANUP_ITEMS_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_11_21_24_30_WI_SPECIALS_CLEANUP_ITEMS_REVIEW.md
@@ -1,0 +1,57 @@
+---
+execution_id: 2026_07_11_21_24_30_WI_SPECIALS_CLEANUP_ITEMS_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_SPECIALS_CLEANUP_ITEMS_REVIEW)[2026-07-11T16:43:29-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/118
+commit: 7e9c825
+created_at: 2026-07-11T21:24:30-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/118
+session_transcript: claude-app:57066b9f-0531-43f0-a6e1-c96446ed1b15
+---
+
+# Summary
+
+Address the open review comment on PR #118 (five WS-SPECIALS-CLEANUP work
+items) via `lrh request review_response`. One P2 comment from
+chatgpt-codex-connector (r3564985701): the WI-RULES-0016 dry-run evidence
+command scans raw story JSON, but both gather write paths call `json.dump`
+without `ensure_ascii=False`, so body defects are stored as `\uXXXX` escapes
+and raw-text scans match nothing.
+
+`rerun_of` is empty: PR #118 was created by the `/lrh-work-item` skill flow,
+which does not produce a primary execution record.
+
+# Result
+
+Comment verified against code and data (raw file contains `√`, decoded
+body contains `√`; `repairs_cli.py:41` reads raw text; `downloaders.py:247`
+and `parser.py:955` dump with ASCII escapes) and fixed in commit 7e9c825:
+
+- WI-RULES-0016 — Scope and Required Changes now include extending
+  `lcats repair-specials` to scan decoded story JSON bodies; acceptance and
+  Validation specify decoded-body evidence; Risk Notes record the
+  false-negative trap.
+- WI-RESIDUAL-0019 — Validation bullet notes the dependency on the
+  WI-RULES-0016 decoding extension.
+
+No comments skipped.
+
+# Validation
+
+- `scripts/format --check --diff` — fails only on
+  `lcats/gettenberg/metadata.py`, untouched by this branch (diff vs
+  origin/main is markdown-only). Environment version skew: repo pins
+  black==25.11.0 (PR #117), local has 26.3.1. Not a regression.
+- `scripts/lint` — ruff: all checks passed.
+- `scripts/test` — OK (full suite).
+- `lrh validate` — 0 errors, 24 pre-existing owner-role warnings.
+- `lrh work-items readiness` — all five new items remain prompt_ready: yes.
+
+# Follow-up
+
+- Local environment should reinstall pinned tools (`scripts/develop`) to
+  clear the black 26.3.1 vs 25.11.0 skew.
+- On merge: set this record to `landed` with the merge commit.

--- a/lcats/project/executions/AD_HOC/2026_07_11_21_24_30_WI_SPECIALS_CLEANUP_ITEMS_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_11_21_24_30_WI_SPECIALS_CLEANUP_ITEMS_REVIEW.md
@@ -9,7 +9,7 @@ commit: 7e9c825
 created_at: 2026-07-11T21:24:30-04:00
 agent: claude_app
 instruction_source: https://github.com/xenotaur/LCATS/pull/118
-session_transcript: claude-app:57066b9f-0531-43f0-a6e1-c96446ed1b15
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
 ---
 
 # Summary

--- a/lcats/project/work_items/proposed/WI-NORMALIZE-0017.md
+++ b/lcats/project/work_items/proposed/WI-NORMALIZE-0017.md
@@ -1,0 +1,74 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-NORMALIZE-0017
+title: Apply repair rules at gather time with provenance metadata
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_workstreams:
+  - WS-SPECIALS-CLEANUP
+related_design:
+  - project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+  - project/design/design.md
+depends_on:
+  - WI-RULES-0016
+forbidden_actions:
+  - rewrite_corpus_json_in_place
+  - modify_ci_pipeline
+acceptance:
+  - Regenerating a story with a known upstream defect produces a repaired body and metadata listing the applied rule ids
+  - Stories with no findings pass through byte-identical
+  - Two consecutive regenerations from the same cached source produce identical output
+required_evidence:
+  - test_output
+  - lrh_validate
+artifacts_expected:
+  - lcats/lcats/gatherers/parser.py
+  - lcats/lcats/gatherers/downloaders.py
+  - lcats/tests/gatherers_tests/
+---
+
+# Work Item: WI-NORMALIZE-0017
+
+## Summary
+Add a deterministic post-extraction normalization step to the gather pipeline that applies the measured repair rules (and, later, per-story overrides) before story JSON is written, stamping applied rule ids into story metadata.
+
+## Problem / Context
+`data/` is cleared and regenerated after major changes, so edits to stored JSON are transient; durable fixes must be replayable pipeline inputs (see WS-SPECIALS-CLEANUP Background and the data/-vs-corpora/ lifecycle). The 35 measured defects are byte-for-byte present in upstream Gutenberg sources (verified: `parser.py` decodes strict UTF-8), so they can only be fixed after extraction. This supersedes the 2026-06-18 decision to keep application out of scope; a decision-log entry accompanies this item.
+
+## Scope
+- One normalization entry point in the gather write path shared by all gatherers.
+- Provenance: applied rule ids recorded in story `metadata`.
+- A decision-log entry and design.md persistence-boundary amendment recording the offsets→rules pivot.
+
+## Required Changes
+1. Add a normalization function (e.g. in `lcats/lcats/gatherers/gatherlib.py` or a new module) that applies `DEFAULT_REPAIR_RULES` to extracted body text deterministically.
+2. Wire it into the story-write path used by both `DataGatherer` (`lcats/lcats/gatherers/downloaders.py`) and the mass_quantities parser (`lcats/lcats/gatherers/parser.py`).
+3. Record applied rule ids (and counts) in the story JSON `metadata` field.
+4. Add tests covering: repaired story, untouched story, determinism across runs.
+5. Add the decision-log entry in `project/memory/decision_log.md` and amend the State and Persistence Boundary section of `project/design/design.md`.
+
+## Non-Goals
+- Do not implement the per-story overrides file — that is WI-OVERRIDES-0018 (but design the hook so overrides can plug in).
+- Do not modify stored corpus/data JSON directly.
+- Do not change detector or survey behavior.
+
+## Acceptance Criteria
+- Known-defect story regenerates repaired, with rule ids in metadata.
+- Clean stories are byte-identical through the hook.
+- Regeneration is deterministic (identical output twice from the same cache).
+- Decision log and design.md updated.
+
+## Validation
+- `scripts/lint`
+- `scripts/test`
+- `lrh validate`
+
+## Risk Notes
+- The hook must run on decoded text after extraction, not raw bytes, or family patterns will not match.
+- Gatherers have multiple write paths; missing one leaves inconsistent output between collections.

--- a/lcats/project/work_items/proposed/WI-OVERRIDES-0018.md
+++ b/lcats/project/work_items/proposed/WI-OVERRIDES-0018.md
@@ -1,0 +1,70 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-OVERRIDES-0018
+title: Versioned per-story overrides consumed at gather time
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_workstreams:
+  - WS-SPECIALS-CLEANUP
+related_design:
+  - project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+depends_on:
+  - WI-NORMALIZE-0017
+forbidden_actions:
+  - rewrite_corpus_json_in_place
+  - modify_ci_pipeline
+acceptance:
+  - An override entry for a real judgment-call defect (e.g. Ângstrom in f_o_b_venus__bond) is applied during regeneration with provenance in story metadata
+  - Overrides live outside data/ so they are never discovered as story JSON and never wiped by regeneration
+  - Override schema is documented and covered by tests
+required_evidence:
+  - test_output
+  - lrh_validate
+artifacts_expected:
+  - per-collection overrides file under lcats/lcats/gatherers/ (exact location decided at implementation)
+  - lcats/tests/gatherers_tests/
+---
+
+# Work Item: WI-OVERRIDES-0018
+
+## Summary
+Add a small, versioned per-story overrides file (story id → find/replace entries with rationale) that the gather-time normalization hook applies after rule-based repairs, for defects rules cannot safely cover.
+
+## Problem / Context
+A handful of the 35 measured defects are judgment calls rather than clean family decodes (e.g. `Ângstrom` → `Ångstrom`, `Tha√ºle`), and future upstream defects will need one-off fixes. Because `data/` regenerates, these fixes must be replayable repo inputs — this is the durable home for human review decisions from WI-RESIDUAL-0019. Forward-compatible with the deferred bucket layout (the overrides content later migrates into per-story audit files).
+
+## Scope
+- Define the override file schema (story identifier, match text with context, replacement, rationale, reviewer).
+- Consume overrides in the WI-NORMALIZE-0017 hook, after rules.
+- Document the schema for contributors.
+
+## Required Changes
+1. Create the overrides file location and schema (proposed: per-collection JSON under `lcats/lcats/gatherers/`, exact form decided at implementation; must not live under `data/`).
+2. Extend the normalization hook to load and apply overrides deterministically, recording provenance in story metadata.
+3. Tests: applied override, non-matching override (warn, don't fail silently), determinism.
+4. Document the schema in the gatherers README or `docs/`.
+
+## Non-Goals
+- Do not perform the human review that populates the file — that is WI-RESIDUAL-0019.
+- Do not implement the bucket/story-directory migration.
+- Do not allow overrides to run against stored corpus files outside the gather flow.
+
+## Acceptance Criteria
+- Real judgment-call override applies during regeneration with provenance.
+- Overrides survive cache-clear + regeneration (they are repo-versioned inputs).
+- Non-matching overrides surface a visible warning.
+
+## Validation
+- `scripts/lint`
+- `scripts/test`
+- `lrh validate`
+
+## Risk Notes
+- Match-by-text needs enough context to be unique within the story; bare single-character matches would misfire.
+- Story identity must be stable across regenerations (filename stem today; revisit if the bucket migration lands).

--- a/lcats/project/work_items/proposed/WI-PROMOTE-0020.md
+++ b/lcats/project/work_items/proposed/WI-PROMOTE-0020.md
@@ -1,0 +1,71 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-PROMOTE-0020
+title: Survey-gated promotion from data/ to corpora/
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_workstreams:
+  - WS-SPECIALS-CLEANUP
+related_design:
+  - project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+depends_on:
+  - WI-RESIDUAL-0019
+forbidden_actions:
+  - force_push
+  - modify_ci_pipeline
+acceptance:
+  - A promotion command copies data/ collections to corpora/ only when the specials survey passes, and refuses with a clear report when it fails
+  - The data/-to-corpora/ collection-name mapping (ohenry-four_million vs ohenry, wilde_happy_prince vs wilde) is explicit and documented
+  - A seeded-defect test proves the gate blocks promotion of damaged text
+required_evidence:
+  - test_output
+  - manual_review
+  - lrh_validate
+artifacts_expected:
+  - promotion script or lcats CLI subcommand
+  - collection mapping documentation
+---
+
+# Work Item: WI-PROMOTE-0020
+
+## Summary
+Build the survey-gated promotion step that copies a verified `data/` tree into the repo `corpora/` snapshot at release time, refusing to promote when the specials survey fails.
+
+## Problem / Context
+The current `corpora/` snapshot carries 148 stories of stale encoding damage precisely because promotion happened without a quality gate. Making the gate part of the promotion tool makes this class of drift self-detecting at every future release. Promotion also currently implies renaming/merging collections (data/ `ohenry-four_million` + `ohenry-whirligigs` vs corpora/ `ohenry`; `wilde_happy_prince` vs `wilde`), which is undocumented — an open question inherited from WS-SPECIALS-CLEANUP.
+
+## Scope
+- Promotion command (script or `lcats` subcommand — decide at implementation).
+- Survey gate wired in, with clear failure reporting.
+- Explicit, documented collection mapping.
+
+## Required Changes
+1. Implement the promotion step: run `lcats survey --mode specials` over the source tree; on pass, copy collections into `corpora/` per the mapping; on fail, exit non-zero with the findings report.
+2. Resolve and document the collection-name mapping (confirm with maintainer whether ohenry sub-collections merge).
+3. Test with a seeded mojibake fixture proving the gate refuses promotion.
+4. Document the release-promotion procedure in `docs/` or the corpora README.
+
+## Non-Goals
+- Do not perform the actual release promotion — that is a release-time human action using this tool.
+- Do not extend the gate to non-mojibake checks in this item (structural/boundary checks can be added later).
+- Do not modify CI.
+
+## Acceptance Criteria
+- Gate demonstrably blocks damaged input and passes clean input.
+- Mapping documented; promotion procedure written down.
+- `scripts/test` passes with the new fixture test.
+
+## Validation
+- `scripts/lint`
+- `scripts/test`
+- `lrh validate`
+
+## Risk Notes
+- The stale corpora/ snapshot will be wholesale replaced at first gated promotion; downstream consumers of current corpora/ paths should be flagged in the PR that performs it.
+- Collection-mapping ambiguity (ohenry merge) needs a maintainer answer before the tool hardcodes it.

--- a/lcats/project/work_items/proposed/WI-RESIDUAL-0019.md
+++ b/lcats/project/work_items/proposed/WI-RESIDUAL-0019.md
@@ -66,7 +66,7 @@ This is the execution pass that turns the WI-RULES-0016/0017/0018 machinery into
 
 ## Validation
 - `lcats survey --mode specials data/ --no-progress`
-- `lcats repair-specials data/mass_quantities/*.json --format jsonl`
+- `lcats repair-specials data/mass_quantities/*.json --format jsonl` (requires the story-JSON decoding extension from WI-RULES-0016; raw story files store defects as `\uXXXX` escapes, so raw-text scans are false negatives)
 - `lrh validate`
 
 ## Risk Notes

--- a/lcats/project/work_items/proposed/WI-RESIDUAL-0019.md
+++ b/lcats/project/work_items/proposed/WI-RESIDUAL-0019.md
@@ -1,0 +1,74 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-RESIDUAL-0019
+title: Review residual defects and regenerate a clean data/ tree
+type: operation
+status: proposed
+priority: high
+owner: unassigned
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_workstreams:
+  - WS-SPECIALS-CLEANUP
+related_design:
+  - project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+depends_on:
+  - WI-RULES-0016
+  - WI-NORMALIZE-0017
+  - WI-OVERRIDES-0018
+forbidden_actions:
+  - rewrite_corpus_json_in_place
+  - force_push
+acceptance:
+  - Every one of the measured residual defects has an explicit disposition — repaired by rule, covered by an override, or allowlisted with rationale
+  - After cache-clear and full regeneration, lcats survey --mode specials over data/ reports zero unaddressed mojibake findings
+  - Legitimate characters (é, æ, ñ, °, ¢, £, accented names) are allowlisted so they stop generating survey noise
+required_evidence:
+  - manual_review
+  - validation_output
+  - lrh_validate
+artifacts_expected:
+  - allowlist config file(s)
+  - override entries
+  - dated survey-output evidence artifact
+---
+
+# Work Item: WI-RESIDUAL-0019
+
+## Summary
+Run the finished repair pipeline over the corpus, human-review the residual findings at rule level, record decisions as allowlist/override entries, and regenerate `data/` until the specials survey is clean.
+
+## Problem / Context
+This is the execution pass that turns the WI-RULES-0016/0017/0018 machinery into a clean corpus. The 2026-07-09 scan already extracted the 35 residual contexts (nearly all unambiguous accented-character fixes; 2–3 judgment calls such as `Ângstrom`). Review is at rule/story level, not per-occurrence — expected effort is about an hour of human time. The earlier overbroad-exclusion problem is fixed here by seeding the allowlist (`specials.AllowlistConfig`, `lcats/lcats/analysis/corpus/specials.py`) with legitimate characters.
+
+## Scope
+- Dry-run repair + survey over freshly regenerated data/.
+- Human disposition of every residual finding (repair rule, override, or allowlist).
+- Final cache-clear, regeneration, and clean survey run captured as evidence.
+
+## Required Changes
+1. Run `lcats repair-specials` dry-run and `lcats survey --mode specials` over regenerated `data/`; collate findings.
+2. Human review: approve rules, add override entries (WI-OVERRIDES-0018 format), extend the allowlist config for legitimate characters.
+3. Clear cache, regenerate `data/`, re-run the survey; iterate until zero unaddressed findings.
+4. Record the final survey output as evidence (e.g. under `project/evidence/` with a dated filename).
+
+## Non-Goals
+- Do not edit story JSON by hand — all fixes flow through rules, overrides, or allowlist.
+- Do not touch the stale `corpora/` snapshot.
+- Do not review non-mojibake issue classes (transcriber notes, missing quotations) — separate triage via lcats assess, outside this workstream.
+
+## Acceptance Criteria
+- Zero unaddressed mojibake findings on a fresh regeneration.
+- Every disposition is traceable (rule id, override entry, or allowlist entry with rationale).
+- Evidence artifact committed with a dated filename per control-plane convention.
+
+## Validation
+- `lcats survey --mode specials data/ --no-progress`
+- `lcats repair-specials data/mass_quantities/*.json --format jsonl`
+- `lrh validate`
+
+## Risk Notes
+- Regeneration re-downloads from Project Gutenberg; upstream file changes may shift findings between runs — record the regeneration date with the evidence.
+- Human review is the bottleneck; keep the queue rule-level to avoid per-occurrence fatigue.

--- a/lcats/project/work_items/proposed/WI-RULES-0016.md
+++ b/lcats/project/work_items/proposed/WI-RULES-0016.md
@@ -1,0 +1,70 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-RULES-0016
+title: Replace dead repair rules with measured mojibake encoding families
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_workstreams:
+  - WS-SPECIALS-CLEANUP
+related_design:
+  - project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+  - project/audits/2026-06-16-special-character-cleanup-workstream-audit.md
+depends_on: []
+forbidden_actions:
+  - rewrite_corpus_json_in_place
+  - modify_ci_pipeline
+acceptance:
+  - A dry-run over the live data/ tree produces at least one repair proposal for each of the three measured families (Ã-form, Mac-Roman √-form, Â-form)
+  - The six unmatched cp1252-form rules are removed or corrected with a test proving each replacement matches real corpus bytes
+  - Tests in tests/analysis_tests/repairs_test.py include real sampled story contexts, not synthetic strings
+required_evidence:
+  - test_output
+  - lrh_validate
+artifacts_expected:
+  - lcats/lcats/analysis/corpus/repairs.py
+  - lcats/tests/analysis_tests/repairs_test.py
+---
+
+# Work Item: WI-RULES-0016
+
+## Summary
+Replace `DEFAULT_REPAIR_RULES` in `lcats/lcats/analysis/corpus/repairs.py` with conservative rules for the three mojibake encoding families actually measured in the corpus, tested against real story contexts.
+
+## Problem / Context
+The 2026-07-09 assessment found the six existing rules target a cp1252-decoded form (`â€™` with U+20AC) that occurs zero times in either `data/` or `corpora/` — the repair engine is a silent no-op. The live `data/` tree contains 35 single-character upstream defects in three families: `Ã©`-form (é as `Ã©`, ë as `Ã«`, ê as `Ãª`, ï as `Ã¯`, à as `Ã` + NBSP), Mac-Roman `√`-form (é as `√©`, ö as `√∂`, ò as `√≤`, ü as `√º`, ñ as `√±`, è as `√®`, æ as `√¶`), and `Â`-form (° as `Â°`, ¢ as `Â¢`). See WS-SPECIALS-CLEANUP Background for measurements.
+
+## Scope
+- Rewrite the rule table to cover the three measured families.
+- Keep the conservative, non-destructive proposal semantics unchanged.
+- Test each rule against byte-exact snippets sampled from real stories.
+
+## Required Changes
+1. Replace `DEFAULT_REPAIR_RULES` in `lcats/lcats/analysis/corpus/repairs.py` with rules per measured family, one rule id per source sequence.
+2. Update `lcats/tests/analysis_tests/repairs_test.py` (and `repairs_cli_test.py` if affected) with real sampled contexts, e.g. `resumÃ©`, `blas√©`, `60Â°`, `Ragnar√∂k`, `se√±orita`.
+3. Verify via dry-run (`lcats repair-specials`) over `data/mass_quantities/` that proposals are produced for the 35 known defects.
+
+## Non-Goals
+- Do not apply repairs to stored corpus files — application is WI-NORMALIZE-0017.
+- Do not add ambiguous rules (e.g. bare `Ã` without a following byte that pins the decoding); ambiguous cases go to WI-OVERRIDES-0018 or review.
+- Do not add an ftfy dependency without a separate decision — rules stay explicit and auditable.
+
+## Acceptance Criteria
+- Dry-run over live `data/` yields proposals for all three families (currently zero).
+- Dead cp1252-form rules removed/corrected, each replacement covered by a test using real corpus bytes.
+- `scripts/test` passes; no behavior change to proposal semantics.
+
+## Validation
+- `scripts/lint`
+- `scripts/test`
+- `lcats repair-specials data/mass_quantities/*.json --format jsonl | head`
+- `lrh validate`
+
+## Risk Notes
+- The same wrong-byte-assumption mistake could recur: every rule's `source_text` must be verified against actual corpus bytes, not typed from memory.
+- Over-broad rules risk corrupting legitimate text (e.g. genuine `Ã` in rare loanwords); prefer sequence-anchored rules.

--- a/lcats/project/work_items/proposed/WI-RULES-0016.md
+++ b/lcats/project/work_items/proposed/WI-RULES-0016.md
@@ -20,7 +20,7 @@ forbidden_actions:
   - rewrite_corpus_json_in_place
   - modify_ci_pipeline
 acceptance:
-  - A dry-run over the live data/ tree produces at least one repair proposal for each of the three measured families (Ã-form, Mac-Roman √-form, Â-form)
+  - A dry-run over decoded story bodies from the live data/ tree produces at least one repair proposal for each of the three measured families (Ã-form, Mac-Roman √-form, Â-form)
   - The six unmatched cp1252-form rules are removed or corrected with a test proving each replacement matches real corpus bytes
   - Tests in tests/analysis_tests/repairs_test.py include real sampled story contexts, not synthetic strings
 required_evidence:
@@ -41,13 +41,15 @@ The 2026-07-09 assessment found the six existing rules target a cp1252-decoded f
 
 ## Scope
 - Rewrite the rule table to cover the three measured families.
+- Extend the `repair-specials` dry-run path to scan decoded story JSON bodies.
 - Keep the conservative, non-destructive proposal semantics unchanged.
 - Test each rule against byte-exact snippets sampled from real stories.
 
 ## Required Changes
 1. Replace `DEFAULT_REPAIR_RULES` in `lcats/lcats/analysis/corpus/repairs.py` with rules per measured family, one rule id per source sequence.
 2. Update `lcats/tests/analysis_tests/repairs_test.py` (and `repairs_cli_test.py` if affected) with real sampled contexts, e.g. `resumÃ©`, `blas√©`, `60Â°`, `Ragnar√∂k`, `se√±orita`.
-3. Verify via dry-run (`lcats repair-specials`) over `data/mass_quantities/` that proposals are produced for the 35 known defects.
+3. Extend `lcats repair-specials` (`lcats/lcats/analysis/corpus/repairs_cli.py`) to detect story JSON inputs and scan the decoded `body` field instead of raw file text. Raw story files store non-ASCII as `\uXXXX` escapes because both gather write paths call `json.dump` without `ensure_ascii=False` (`lcats/lcats/gatherers/downloaders.py:247`, `lcats/lcats/gatherers/parser.py:955`), so scanning raw JSON text matches nothing.
+4. Verify via dry-run (`lcats repair-specials`) over decoded `data/mass_quantities/` story bodies that proposals are produced for the 35 known defects.
 
 ## Non-Goals
 - Do not apply repairs to stored corpus files — application is WI-NORMALIZE-0017.
@@ -62,9 +64,10 @@ The 2026-07-09 assessment found the six existing rules target a cp1252-decoded f
 ## Validation
 - `scripts/lint`
 - `scripts/test`
-- `lcats repair-specials data/mass_quantities/*.json --format jsonl | head`
+- `lcats repair-specials data/mass_quantities/*.json --format jsonl | head` (after the story-JSON decoding extension in Required Changes; against raw JSON text this reports zero proposals and is not valid evidence)
 - `lrh validate`
 
 ## Risk Notes
 - The same wrong-byte-assumption mistake could recur: every rule's `source_text` must be verified against actual corpus bytes, not typed from memory.
+- Evidence must come from decoded story bodies: raw story JSON stores defects as `\uXXXX` escapes, so a zero-proposal dry-run over raw file text is a false negative, not a clean corpus.
 - Over-broad rules risk corrupting legitimate text (e.g. genuine `Ã` in rare loanwords); prefer sequence-anchored rules.

--- a/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+++ b/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
@@ -16,6 +16,11 @@ work_items:
   - WI-SPANOPS-0002
   - WI-REVIEW-0003
   - WI-APPLY-0005
+  - WI-RULES-0016
+  - WI-NORMALIZE-0017
+  - WI-OVERRIDES-0018
+  - WI-RESIDUAL-0019
+  - WI-PROMOTE-0020
 exit_criteria:
   - lcats survey --mode specials over freshly regenerated data/ reports zero unaddressed mojibake findings — every measured residual occurrence is repaired by rule, covered by a per-story override, or explicitly allowlisted
   - Repair rules and per-story overrides are versioned repo inputs applied during gathering, so clearing the cache and regenerating data/ reproduces the same repaired output deterministically
@@ -85,10 +90,18 @@ Existing active items to re-scope under this workstream:
   but the item is still active; remaining scope is pipeline integration, or
   resolve it and open a successor.
 
-New items to be created via /lrh-work-item (IDs assigned at creation):
-the gather-time normalization hook; the measured rule table; the per-story
-overrides file; the residual review pass and regeneration; the survey-gated
-promotion step.
+New items created 2026-07-10:
+
+- **WI-RULES-0016** — replace the dead repair-rule table with the three
+  measured encoding families, tested against real corpus bytes.
+- **WI-NORMALIZE-0017** — apply repair rules at gather time with provenance
+  metadata (depends on WI-RULES-0016).
+- **WI-OVERRIDES-0018** — versioned per-story overrides consumed by the
+  normalization hook (depends on WI-NORMALIZE-0017).
+- **WI-RESIDUAL-0019** — human review of residual defects and clean
+  regeneration of data/ (depends on WI-RULES-0016..WI-OVERRIDES-0018).
+- **WI-PROMOTE-0020** — survey-gated promotion from data/ to corpora/
+  (depends on WI-RESIDUAL-0019).
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary

Creates the five planning artifacts that complete the WS-SPECIALS-CLEANUP burn-down (all `status: proposed`, all `prompt_ready: yes` per `lrh work-items readiness`), and registers them in the workstream's `work_items:` list.

| ID | Type | Title | Depends on |
|---|---|---|---|
| WI-RULES-0016 | deliverable | Replace dead repair rules with measured mojibake encoding families | — |
| WI-NORMALIZE-0017 | deliverable | Apply repair rules at gather time with provenance metadata | 0016 |
| WI-OVERRIDES-0018 | deliverable | Versioned per-story overrides consumed at gather time | 0017 |
| WI-RESIDUAL-0019 | operation | Review residual defects and regenerate a clean data/ tree | 0016–0018 |
| WI-PROMOTE-0020 | deliverable | Survey-gated promotion from data/ to corpora/ | 0019 |

## Context

Grounded in the 2026-07-09 measurements recorded in WS-SPECIALS-CLEANUP: the live `data/` tree has 35 single-occurrence upstream defects (three encoding families), the six existing `DEFAULT_REPAIR_RULES` match zero real occurrences, and durable fixes must be replayable pipeline inputs because `data/` regenerates from cache.

## Validation

- `lrh validate` — 0 errors (24 warnings, all the pre-existing `owner: unassigned` class)
- `lrh work-items readiness --status proposed` — all five new items `prompt_ready: yes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)