### PR TITLE
WI-RULES-0016: Replace dead repair rules with measured mojibake encoding families

### DIFF
--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -153,6 +153,12 @@ DEFAULT_REPAIR_RULES = (
         replacement_text="ò",
         description="UTF-8 'ò' decoded as Mac-Roman (Niccol√≤).",
     ),
+    RepairRule(
+        rule_id="mojibake-macroman-ae",
+        source_text="√¶",
+        replacement_text="æ",
+        description="UTF-8 'æ' decoded as Mac-Roman (hypnop√¶dic).",
+    ),
 )
 
 

--- a/lcats/lcats/analysis/corpus/repairs.py
+++ b/lcats/lcats/analysis/corpus/repairs.py
@@ -64,42 +64,94 @@ class RepairPlanEntry:
     finding_offset: int
 
 
+# Every source_text below was verified byte-for-byte against the live data/
+# tree (2026-07-13 scan); do not add rules from memory — measure first.
 DEFAULT_REPAIR_RULES = (
+    # UTF-8 bytes decoded as Latin-1 upstream (é stored as C3 A9 -> "Ã©").
     RepairRule(
-        rule_id="mojibake-right-single-quote",
-        source_text="â€™",
-        replacement_text="’",
-        description="Broken UTF-8 right single quote sequence.",
+        rule_id="mojibake-latin1-e-acute",
+        source_text="Ã©",
+        replacement_text="é",
+        description="UTF-8 'é' decoded as Latin-1 (resumÃ©, clichÃ©).",
     ),
     RepairRule(
-        rule_id="mojibake-left-double-quote",
-        source_text="â€œ",
-        replacement_text="“",
-        description="Broken UTF-8 left double quote sequence.",
+        rule_id="mojibake-latin1-e-diaeresis",
+        source_text="Ã«",
+        replacement_text="ë",
+        description="UTF-8 'ë' decoded as Latin-1 (aÃ«rial).",
     ),
     RepairRule(
-        rule_id="mojibake-right-double-quote",
-        source_text="â€\u009d",
-        replacement_text="”",
-        description="Broken UTF-8 right double quote sequence.",
+        rule_id="mojibake-latin1-e-circumflex",
+        source_text="Ãª",
+        replacement_text="ê",
+        description="UTF-8 'ê' decoded as Latin-1 (vÃªtements).",
     ),
     RepairRule(
-        rule_id="mojibake-en-dash",
-        source_text="â€“",
-        replacement_text="–",
-        description="Broken UTF-8 en dash sequence.",
+        rule_id="mojibake-latin1-o-diaeresis",
+        source_text="Ã¶",
+        replacement_text="ö",
+        description="UTF-8 'ö' decoded as Latin-1 (uncoÃ¶rdinated).",
     ),
     RepairRule(
-        rule_id="mojibake-em-dash",
-        source_text="â€”",
-        replacement_text="—",
-        description="Broken UTF-8 em dash sequence.",
+        rule_id="mojibake-latin1-i-diaeresis",
+        source_text="Ã¯",
+        replacement_text="ï",
+        description="UTF-8 'ï' decoded as Latin-1 (naÃ¯vely).",
     ),
     RepairRule(
-        rule_id="mojibake-ellipsis",
-        source_text="â€¦",
-        replacement_text="…",
-        description="Broken UTF-8 ellipsis sequence.",
+        rule_id="mojibake-latin1-a-grave",
+        source_text="Ã ",
+        replacement_text="à",
+        description="UTF-8 'à' decoded as Latin-1 (Ã la; second byte is NBSP).",
+    ),
+    RepairRule(
+        rule_id="mojibake-latin1-degree-sign",
+        source_text="Â°",
+        replacement_text="°",
+        description="UTF-8 '°' decoded as Latin-1 (60Â° below).",
+    ),
+    RepairRule(
+        rule_id="mojibake-latin1-cent-sign",
+        source_text="Â¢",
+        replacement_text="¢",
+        description="UTF-8 '¢' decoded as Latin-1 (90Â¢).",
+    ),
+    # UTF-8 bytes decoded as Mac-Roman upstream (é stored as C3 A9 -> "√©").
+    RepairRule(
+        rule_id="mojibake-macroman-e-acute",
+        source_text="√©",
+        replacement_text="é",
+        description="UTF-8 'é' decoded as Mac-Roman (blas√©, Merop√©).",
+    ),
+    RepairRule(
+        rule_id="mojibake-macroman-e-grave",
+        source_text="√®",
+        replacement_text="è",
+        description="UTF-8 'è' decoded as Mac-Roman (fin de si√®cle).",
+    ),
+    RepairRule(
+        rule_id="mojibake-macroman-n-tilde",
+        source_text="√±",
+        replacement_text="ñ",
+        description="UTF-8 'ñ' decoded as Mac-Roman (se√±orita).",
+    ),
+    RepairRule(
+        rule_id="mojibake-macroman-u-diaeresis",
+        source_text="√º",
+        replacement_text="ü",
+        description="UTF-8 'ü' decoded as Mac-Roman (Tha√ºle).",
+    ),
+    RepairRule(
+        rule_id="mojibake-macroman-o-diaeresis",
+        source_text="√∂",
+        replacement_text="ö",
+        description="UTF-8 'ö' decoded as Mac-Roman (Ragnar√∂k).",
+    ),
+    RepairRule(
+        rule_id="mojibake-macroman-o-grave",
+        source_text="√≤",
+        replacement_text="ò",
+        description="UTF-8 'ò' decoded as Mac-Roman (Niccol√≤).",
     ),
 )
 
@@ -109,9 +161,14 @@ def _rule_map(rules: Sequence[RepairRule]) -> dict[str, RepairRule]:
 
 
 def _extract_evidence_fragment(evidence: str) -> str:
-    """Return fragment value from semicolon-delimited evidence string."""
+    """Return fragment value from semicolon-delimited evidence string.
+
+    Only leading whitespace is removed: fragments may legitimately end in
+    Unicode whitespace (e.g. "Ã" + NBSP for mojibake 'à'), which .strip()
+    would silently delete.
+    """
     for part in evidence.split(";"):
-        segment = part.strip()
+        segment = part.lstrip()
         if segment.startswith("fragment="):
             return segment.split("=", 1)[1]
     return ""

--- a/lcats/lcats/analysis/corpus/repairs_cli.py
+++ b/lcats/lcats/analysis/corpus/repairs_cli.py
@@ -1,10 +1,30 @@
 """CLI wrapper for conservative Unicode/special-character repair proposals."""
 
 import argparse
+import json
 import pathlib
 import sys
 
 from lcats.analysis.corpus import repairs
+
+
+def load_input_text(file_path: pathlib.Path) -> str:
+    """Return the decoded story body for story JSON files, else raw text.
+
+    Story JSON is written with ASCII-escaped non-ASCII characters, so raw
+    file text hides mojibake as \\uXXXX escapes; scanning it would report
+    nothing. Offsets in proposals for JSON inputs refer to the decoded body.
+    """
+    raw = file_path.read_text(encoding="utf-8")
+    if file_path.suffix.lower() != ".json":
+        return raw
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    if isinstance(payload, dict) and isinstance(payload.get("body"), str):
+        return payload["body"]
+    return raw
 
 
 def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
@@ -13,7 +33,8 @@ def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
         description=(
             "Generate conservative dry-run repair proposals for known "
             "Unicode/mojibake findings. This command is non-destructive and "
-            "never modifies files."
+            "never modifies files. Story JSON inputs are scanned on the "
+            "decoded body field; offsets refer to the decoded body text."
         ),
         add_help=add_help,
     )
@@ -38,7 +59,7 @@ def run(argv=None, parsed_args=None) -> int:
 
     for file_name in args.files:
         file_path = pathlib.Path(file_name)
-        text = file_path.read_text(encoding="utf-8")
+        text = load_input_text(file_path)
         suggestions = repairs.suggest_repairs_for_text(text)
         if args.format == "jsonl":
             report = repairs.build_dry_run_jsonl_report(

--- a/lcats/lcats/analysis/corpus/specials.py
+++ b/lcats/lcats/analysis/corpus/specials.py
@@ -39,6 +39,7 @@ MOJIBAKE_SEQUENCES = (
     "√º",
     "√∂",
     "√≤",
+    "√¶",
 )
 MOJIBAKE_NEIGHBOR_MARKERS = {"Ã", "Â", "â", "ð", "�"}
 

--- a/lcats/lcats/analysis/corpus/specials.py
+++ b/lcats/lcats/analysis/corpus/specials.py
@@ -31,6 +31,14 @@ MOJIBAKE_SEQUENCES = (
     "â€“",
     "â€”",
     "â€¦",
+    # UTF-8 bytes decoded as Mac-Roman upstream; exact sequences only, so a
+    # bare mathematical "√" still classifies as review_needed.
+    "√©",
+    "√®",
+    "√±",
+    "√º",
+    "√∂",
+    "√≤",
 )
 MOJIBAKE_NEIGHBOR_MARKERS = {"Ã", "Â", "â", "ð", "�"}
 

--- a/lcats/project/executions/AD_HOC/2026_07_13_17_32_51_WI_RULES_0016_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_13_17_32_51_WI_RULES_0016_REVIEW.md
@@ -1,0 +1,53 @@
+---
+execution_id: 2026_07_13_17_32_51_WI_RULES_0016_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_RULES_0016_REVIEW)[2026-07-13T17:25:18-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_13_15_17_26_WI_RULES_0016
+pr: https://github.com/xenotaur/LCATS/pull/120
+commit: 2a6bed5
+created_at: 2026-07-13T17:32:51-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/120
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Address the open review comment on PR #120 (WI-RULES-0016) via
+`lrh request review_response`. One P2 comment from chatgpt-codex-connector
+(r3573505208): the WI Problem/Context enumerated `æ as √¶` as a measured
+Mac-Roman defect, but the rule table and MOJIBAKE_SEQUENCES omitted it.
+
+# Result
+
+Verified and fixed in commit 2a6bed5. Measurement: `√¶` occurs **zero**
+times in the live data/ tree but **once** in the stale corpora/ snapshot
+(massQuantities/lost_in_translation.json — "hypnop√¶dic"). The WI
+Problem/Context inherited `√¶` from the earlier corpora/ scan; the rule
+table was correctly built from the data/ scan, hence the gap. `√¶` decodes
+unambiguously to æ under Mac-Roman, so adding the rule is conservative and
+forward-useful (it matters when corpora/ is regenerated or another user's
+data surfaces it).
+
+- `lcats/analysis/corpus/repairs.py` — added rule `mojibake-macroman-ae`
+  (√¶ -> æ).
+- `lcats/analysis/corpus/specials.py` — added `√¶` to MOJIBAKE_SEQUENCES.
+- Tests — added the √¶ case to the repairs mapping test and the specials
+  Mac-Roman classification test, using the real corpora/ context.
+
+No comments skipped.
+
+# Validation
+
+- `scripts/format --check --diff` — 141 files clean
+- `scripts/lint` — ruff and black passed
+- `scripts/test` — 1264 tests OK
+- `lrh validate` — 0 errors, 24 pre-existing owner-role warnings
+- Dry run over live data/ still yields 34 proposals (√¶ absent from data/,
+  as expected — the rule is exercised against the corpora/ context in tests)
+
+# Follow-up
+
+- On merge: set this record and the primary WI-RULES-0016 record to landed,
+  and resolve WI-RULES-0016.

--- a/lcats/project/executions/WI-RULES-0016/2026_07_13_15_17_26_WI_RULES_0016.md
+++ b/lcats/project/executions/WI-RULES-0016/2026_07_13_15_17_26_WI_RULES_0016.md
@@ -1,0 +1,61 @@
+---
+execution_id: 2026_07_13_15_17_26_WI_RULES_0016
+prompt_id: PROMPT(WI-RULES-0016:WI_RULES_0016)[2026-07-13T13:56:02-04:00]
+work_item: WI-RULES-0016
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/120
+commit: af564de
+created_at: 2026-07-13T15:17:26-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-RULES-0016.md
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Implement WI-RULES-0016: replace the dead cp1252-form DEFAULT_REPAIR_RULES
+with rules for the three mojibake encoding families measured in the live
+data/ tree, extend mojibake classification to the Mac-Roman family, and
+make `lcats repair-specials` scan decoded story-JSON bodies.
+
+# Result
+
+Implemented on branch xenotaur/feat/wi-rules-0016 (PR #120, commit af564de):
+
+- `lcats/analysis/corpus/repairs.py` — 14 measured rules (8 Latin-1-form,
+  6 Mac-Roman-form), every source_text verified byte-for-byte against the
+  live corpus before authoring; the six zero-match cp1252 rules removed.
+- `lcats/analysis/corpus/specials.py` — six measured Mac-Roman pairs added
+  to MOJIBAKE_SEQUENCES (exact sequences only; bare mathematical √ still
+  classifies review_needed).
+- `lcats/analysis/corpus/repairs_cli.py` — story-JSON inputs scanned on the
+  decoded body field (raw files hold ASCII escapes; raw-text scans were
+  silent false negatives).
+- Bug discovered by real-byte testing: `_extract_evidence_fragment` used
+  str.strip(), which deletes trailing NBSP, so the a-grave fragment
+  ("Ã"+NBSP) never matched its rule. Fixed to strip leading whitespace
+  only; regression test added.
+- Tests rewritten with byte-exact real story contexts; one stale
+  corpus_survey_test expectation updated (measured Mac-Roman sequence now
+  correctly classifies likely_repairable).
+
+Acceptance: dry run over the full decoded data/ tree yields 34 proposals
+across all 14 rules (previously 0). The 35th measured defect (Ângstrom)
+is deliberately excluded — judgment call assigned to WI-OVERRIDES-0018.
+
+# Validation
+
+- `scripts/format --check --diff` — 141 files clean (ran `scripts/develop`
+  first to align local Black with the pinned 25.11.0)
+- `scripts/lint` — ruff and black passed
+- `scripts/test` — 1263 tests OK
+- `lrh validate` — 0 errors, 24 pre-existing owner-role warnings
+- Item-specific: JSONL dry run over data/ = 34 proposals
+  (20 latin1-family, 14 macroman-family)
+
+# Follow-up
+
+- WI-NORMALIZE-0017 wires these rules into the gather pipeline.
+- WI-OVERRIDES-0018 handles the Ângstrom judgment call.
+- On merge: set this record to landed and resolve WI-RULES-0016.

--- a/lcats/tests/analysis_tests/corpus_survey_test.py
+++ b/lcats/tests/analysis_tests/corpus_survey_test.py
@@ -139,7 +139,9 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
         first_row = output.splitlines()[0].split("\t")
         self.assertEqual("U+221A", first_row[0])
         self.assertEqual("2", first_row[4])
-        self.assertEqual("review_needed", first_row[6])
+        # "√©" is a measured Mac-Roman mojibake sequence (WI-RULES-0016), so
+        # this classifies repairable rather than review_needed.
+        self.assertEqual("likely_repairable", first_row[6])
 
     def test_run_special_characters_check_uses_nocontext_flag(self):
         output = corpus_survey.run_special_characters_check(

--- a/lcats/tests/analysis_tests/repairs_cli_test.py
+++ b/lcats/tests/analysis_tests/repairs_cli_test.py
@@ -17,7 +17,7 @@ class RepairsCliTest(unittest.TestCase):
     def test_dry_run_does_not_modify_source_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = pathlib.Path(tmpdir) / "sample.txt"
-            original_text = "A broken token: â€™\n"
+            original_text = "A broken token: resumÃ©\n"
             file_path.write_text(original_text, encoding="utf-8")
 
             output = io.StringIO()
@@ -30,16 +30,57 @@ class RepairsCliTest(unittest.TestCase):
     def test_dry_run_output_includes_before_after_and_rule(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = pathlib.Path(tmpdir) / "sample.txt"
-            file_path.write_text("Example â€¦ token", encoding="utf-8")
+            file_path.write_text("trumpets of Ragnar√∂k.", encoding="utf-8")
 
             output = io.StringIO()
             with unittest.mock.patch("sys.stdout", output):
                 repairs_cli.run([str(file_path)])
 
             report = output.getvalue().strip()
-            self.assertIn("mojibake-ellipsis", report)
-            self.assertIn("â€¦", report)
-            self.assertIn("…", report)
+            self.assertIn("mojibake-macroman-o-diaeresis", report)
+            self.assertIn("√∂", report)
+            self.assertIn("ö", report)
+
+    def test_story_json_input_scans_decoded_body(self):
+        """Story JSON stores non-ASCII as ASCII escapes (json.dump default);
+        the CLI must scan the decoded body field or every defect is an
+        invisible false negative (WI-RULES-0016)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = pathlib.Path(tmpdir) / "story.json"
+            story = {
+                "name": "The Marrying Man",
+                "body": "unnerving even to the blas√© eyes of Marilyn.",
+                "metadata": {"author": "Test"},
+            }
+            with open(file_path, "w", encoding="utf-8") as handle:
+                json.dump(story, handle, indent=4)
+
+            raw = file_path.read_text(encoding="utf-8")
+            self.assertNotIn("√", raw)  # escaped on disk — raw scan sees nothing
+
+            output = io.StringIO()
+            with unittest.mock.patch("sys.stdout", output):
+                exit_code = repairs_cli.run(["--format", "jsonl", str(file_path)])
+
+            self.assertEqual(0, exit_code)
+            lines = output.getvalue().strip().splitlines()
+            self.assertEqual(1, len(lines))
+            payload = json.loads(lines[0])
+            self.assertEqual("mojibake-macroman-e-acute", payload["rule_id"])
+            self.assertEqual("√©", payload["original_text"])
+            self.assertEqual("é", payload["replacement_text"])
+
+    def test_non_story_json_input_falls_back_to_raw_text(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = pathlib.Path(tmpdir) / "notes.json"
+            file_path.write_text('["se√±orita fixture"]', encoding="utf-8")
+
+            output = io.StringIO()
+            with unittest.mock.patch("sys.stdout", output):
+                repairs_cli.run([str(file_path)])
+
+            report = output.getvalue().strip()
+            self.assertIn("mojibake-macroman-n-tilde", report)
 
     def test_build_dry_run_report_is_deterministic_and_auditable(self):
         suggestion = repairs.RepairSuggestion(
@@ -64,7 +105,7 @@ class RepairsCliTest(unittest.TestCase):
     def test_jsonl_output_is_machine_parseable(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             file_path = pathlib.Path(tmpdir) / "sample.txt"
-            file_path.write_text("Example â€¦ token", encoding="utf-8")
+            file_path.write_text("she pay 90Â¢ for", encoding="utf-8")
 
             output = io.StringIO()
             with unittest.mock.patch("sys.stdout", output):
@@ -74,8 +115,8 @@ class RepairsCliTest(unittest.TestCase):
             self.assertEqual(1, len(lines))
             payload = json.loads(lines[0])
             self.assertEqual(str(file_path), payload["path"])
-            self.assertEqual("â€¦", payload["original_text"])
-            self.assertEqual("…", payload["replacement_text"])
+            self.assertEqual("Â¢", payload["original_text"])
+            self.assertEqual("¢", payload["replacement_text"])
 
 
 if __name__ == "__main__":

--- a/lcats/tests/analysis_tests/repairs_test.py
+++ b/lcats/tests/analysis_tests/repairs_test.py
@@ -32,6 +32,7 @@ class RepairsTest(unittest.TestCase):
             ("them, Tha√ºle?", "√º", "ü", "mojibake-macroman-u-diaeresis"),
             ("trumpets of Ragnar√∂k.", "√∂", "ö", "mojibake-macroman-o-diaeresis"),
             ("work on Niccol√≤ Tartaglia", "√≤", "ò", "mojibake-macroman-o-grave"),
+            ("adapting a hypnop√¶dic language", "√¶", "æ", "mojibake-macroman-ae"),
         ]
     )
     def test_suggest_repairs_maps_known_fragments(

--- a/lcats/tests/analysis_tests/repairs_test.py
+++ b/lcats/tests/analysis_tests/repairs_test.py
@@ -13,18 +13,30 @@ from lcats.analysis.corpus import specials
 class RepairsTest(unittest.TestCase):
     """Tests for repair suggestions built from classified findings."""
 
+    # Each context below is sampled byte-for-byte from a real story in the
+    # live data/ tree (WI-RULES-0016 measurement, 2026-07-13); do not replace
+    # with synthetic text — rule bytes must match real corpus bytes.
     @parameterized.expand(
         [
-            ("â€™", "’", "mojibake-right-single-quote"),
-            ("â€œ", "“", "mojibake-left-double-quote"),
-            ("â€\u009d", "”", "mojibake-right-double-quote"),
-            ("â€“", "–", "mojibake-en-dash"),
-            ("â€”", "—", "mojibake-em-dash"),
-            ("â€¦", "…", "mojibake-ellipsis"),
+            ("them a resumÃ©.", "Ã©", "é", "mojibake-latin1-e-acute"),
+            ("An aÃ«rial toehold", "Ã«", "ë", "mojibake-latin1-e-diaeresis"),
+            ("Regardez des vÃªtements!", "Ãª", "ê", "mojibake-latin1-e-circumflex"),
+            ("His uncoÃ¶rdinated hands", "Ã¶", "ö", "mojibake-latin1-o-diaeresis"),
+            ("she said naÃ¯vely.", "Ã¯", "ï", "mojibake-latin1-i-diaeresis"),
+            ("naturally or _Ã la lobster_", "Ã ", "à", "mojibake-latin1-a-grave"),
+            ("stay off the 60Â° below", "Â°", "°", "mojibake-latin1-degree-sign"),
+            ("she pay 90Â¢ for", "Â¢", "¢", "mojibake-latin1-cent-sign"),
+            ('swear by it on Merop√©."', "√©", "é", "mojibake-macroman-e-acute"),
+            ("Its _fin de si√®cle_ beauty", "√®", "è", "mojibake-macroman-e-grave"),
+            ("The little se√±orita,", "√±", "ñ", "mojibake-macroman-n-tilde"),
+            ("them, Tha√ºle?", "√º", "ü", "mojibake-macroman-u-diaeresis"),
+            ("trumpets of Ragnar√∂k.", "√∂", "ö", "mojibake-macroman-o-diaeresis"),
+            ("work on Niccol√≤ Tartaglia", "√≤", "ò", "mojibake-macroman-o-grave"),
         ]
     )
-    def test_suggest_repairs_maps_known_fragments(self, fragment, replacement, rule_id):
-        text = f"A {fragment} B"
+    def test_suggest_repairs_maps_known_fragments(
+        self, text, fragment, replacement, rule_id
+    ):
         findings = list(
             specials.iter_special_characters(
                 text=text,
@@ -44,8 +56,35 @@ class RepairsTest(unittest.TestCase):
         self.assertEqual(fragment, suggestion.original_text)
         self.assertEqual(replacement, suggestion.replacement_text)
 
+    @parameterized.expand(
+        [
+            ("legacy_cp1252_quote", "A broken â€™ token"),
+            ("legacy_cp1252_ellipsis", "Example â€¦ token"),
+            ("french_circumflex_words", "The bête noire ate the pâte."),
+        ]
+    )
+    def test_suggest_repairs_has_no_rules_for_unmeasured_fragments(self, _name, text):
+        """cp1252-form sequences occur zero times in the measured corpus and
+        circumflex letters in French words are legitimate text; neither may
+        produce a proposal (WI-RULES-0016 acceptance)."""
+        suggestions = repairs.suggest_repairs_for_text(text)
+
+        self.assertEqual([], suggestions)
+
+    def test_evidence_fragment_round_trip_preserves_trailing_whitespace(self):
+        """Regression: 'Ã' + NBSP ('à' mojibake) must survive the evidence
+        string round trip — str.strip() would silently delete the NBSP and
+        the a-grave rule would never fire on real corpus text."""
+        text = "naturally or _Ã la lobster_"
+
+        suggestions = repairs.suggest_repairs_for_text(text)
+
+        self.assertEqual(1, len(suggestions))
+        self.assertEqual("mojibake-latin1-a-grave", suggestions[0].rule_id)
+        self.assertEqual("Ã ", suggestions[0].original_text)
+
     def test_suggest_repairs_preserves_audit_fields(self):
-        text = "Broken â€™ punctuation"
+        text = "so he could give them a resumÃ©."
         findings = list(
             specials.iter_special_characters(
                 text=text,
@@ -61,8 +100,8 @@ class RepairsTest(unittest.TestCase):
 
         self.assertEqual(1, len(suggestions))
         suggestion = suggestions[0]
-        self.assertEqual("â€™", suggestion.original_text)
-        self.assertEqual("’", suggestion.replacement_text)
+        self.assertEqual("Ã©", suggestion.original_text)
+        self.assertEqual("é", suggestion.replacement_text)
         self.assertEqual(
             text[suggestion.start : suggestion.end], suggestion.original_text
         )
@@ -118,43 +157,43 @@ class RepairsTest(unittest.TestCase):
         self.assertEqual([], suggestions)
 
     def test_apply_repair_suggestions_applies_only_matching_spans(self):
-        text = "Broken â€™ and â€¦"
+        text = "Broken Ã© and √∂"
         suggestions = [
             repairs.RepairSuggestion(
                 rule_id="first",
                 start=7,
-                end=10,
-                original_text="â€™",
-                replacement_text="’",
+                end=9,
+                original_text="Ã©",
+                replacement_text="é",
                 finding_offset=7,
-                evidence="rule=mojibake-pattern; fragment=â€™",
+                evidence="rule=mojibake-pattern; fragment=Ã©",
             ),
             repairs.RepairSuggestion(
                 rule_id="mismatch",
-                start=15,
-                end=18,
+                start=14,
+                end=16,
                 original_text="BAD",
                 replacement_text="X",
-                finding_offset=15,
-                evidence="rule=mojibake-pattern; fragment=â€¦",
+                finding_offset=14,
+                evidence="rule=mojibake-pattern; fragment=√∂",
             ),
         ]
 
         updated = repairs.apply_repair_suggestions(text, suggestions)
 
-        self.assertEqual("Broken ’ and â€¦", updated)
+        self.assertEqual("Broken é and √∂", updated)
 
     def test_suggestions_to_span_operations_exposes_explicit_fields(self):
         suggestion = repairs.RepairSuggestion(
-            rule_id="mojibake-right-single-quote",
+            rule_id="mojibake-latin1-e-acute",
             start=2,
-            end=5,
-            original_text="â€™",
-            replacement_text="’",
+            end=4,
+            original_text="Ã©",
+            replacement_text="é",
             finding_offset=2,
-            evidence="rule=mojibake-pattern; fragment=â€™",
+            evidence="rule=mojibake-pattern; fragment=Ã©",
             confidence="high",
-            rationale="Broken UTF-8 right single quote sequence.",
+            rationale="UTF-8 'é' decoded as Latin-1.",
         )
 
         operations = repairs.suggestions_to_span_operations([suggestion])
@@ -163,39 +202,39 @@ class RepairsTest(unittest.TestCase):
         operation = operations[0]
         self.assertEqual("replace", operation.operation)
         self.assertEqual(2, operation.start)
-        self.assertEqual(5, operation.end)
-        self.assertEqual("â€™", operation.original_text)
-        self.assertEqual("’", operation.replacement_text)
-        self.assertEqual("mojibake-right-single-quote", operation.rule_id)
-        self.assertIn("fragment=â€™", operation.evidence)
+        self.assertEqual(4, operation.end)
+        self.assertEqual("Ã©", operation.original_text)
+        self.assertEqual("é", operation.replacement_text)
+        self.assertEqual("mojibake-latin1-e-acute", operation.rule_id)
+        self.assertIn("fragment=Ã©", operation.evidence)
         self.assertEqual("high", operation.confidence)
 
     def test_apply_span_operations_applies_in_deterministic_order(self):
-        text = "â€™-â€¦"
+        text = "Ã©-√∂"
         operations = [
             repairs.SpanRepairOperation(
                 operation="replace",
-                start=4,
-                end=7,
-                original_text="â€¦",
-                replacement_text="…",
-                rule_id="mojibake-ellipsis",
-                evidence="rule=mojibake-pattern; fragment=â€¦",
+                start=3,
+                end=5,
+                original_text="√∂",
+                replacement_text="ö",
+                rule_id="mojibake-macroman-o-diaeresis",
+                evidence="rule=mojibake-pattern; fragment=√∂",
             ),
             repairs.SpanRepairOperation(
                 operation="replace",
                 start=0,
-                end=3,
-                original_text="â€™",
-                replacement_text="’",
-                rule_id="mojibake-right-single-quote",
-                evidence="rule=mojibake-pattern; fragment=â€™",
+                end=2,
+                original_text="Ã©",
+                replacement_text="é",
+                rule_id="mojibake-latin1-e-acute",
+                evidence="rule=mojibake-pattern; fragment=Ã©",
             ),
         ]
 
         updated = repairs.apply_span_operations(text, operations)
 
-        self.assertEqual("’-…", updated)
+        self.assertEqual("é-ö", updated)
 
     def test_apply_span_operations_returns_original_for_overlap(self):
         text = "abcdef"
@@ -225,13 +264,13 @@ class RepairsTest(unittest.TestCase):
         self.assertEqual(text, updated)
 
     def test_apply_span_operations_ignores_non_replace_in_overlap_precheck(self):
-        text = "â€™"
+        text = "Ã©"
         operations = [
             repairs.SpanRepairOperation(
                 operation="delete",
                 start=0,
-                end=2,
-                original_text="â€",
+                end=1,
+                original_text="Ã",
                 replacement_text="",
                 rule_id="unsupported-delete",
                 evidence="unsupported-op",
@@ -239,34 +278,36 @@ class RepairsTest(unittest.TestCase):
             repairs.SpanRepairOperation(
                 operation="replace",
                 start=0,
-                end=3,
-                original_text="â€™",
-                replacement_text="’",
-                rule_id="mojibake-right-single-quote",
-                evidence="rule=mojibake-pattern; fragment=â€™",
+                end=2,
+                original_text="Ã©",
+                replacement_text="é",
+                rule_id="mojibake-latin1-e-acute",
+                evidence="rule=mojibake-pattern; fragment=Ã©",
             ),
         ]
 
         updated = repairs.apply_span_operations(text, operations)
 
-        self.assertEqual("’", updated)
+        self.assertEqual("é", updated)
 
     def test_suggest_repairs_for_text_uses_classifier_and_rules(self):
-        suggestions = repairs.suggest_repairs_for_text("Text â€” sample")
+        suggestions = repairs.suggest_repairs_for_text(
+            "the screaming trumpets of Ragnar√∂k."
+        )
 
         self.assertEqual(1, len(suggestions))
         suggestion = suggestions[0]
-        self.assertEqual("â€”", suggestion.original_text)
-        self.assertEqual("—", suggestion.replacement_text)
+        self.assertEqual("√∂", suggestion.original_text)
+        self.assertEqual("ö", suggestion.replacement_text)
         self.assertEqual("high", suggestion.confidence)
 
     def test_suggest_repairs_for_text_applies_allowed_special_review_rules(self):
-        text = "Text â€” sample"
+        text = "the screaming trumpets of Ragnar√∂k."
         decision_store = review.ReviewDecisionStore(
             allowed_special_cases=(
                 review.AllowedSpecialCase(
                     classification="likely_repairable",
-                    evidence_contains="fragment=â€”",
+                    evidence_contains="fragment=√∂",
                 ),
             )
         )
@@ -281,15 +322,15 @@ class RepairsTest(unittest.TestCase):
     def test_build_dry_run_plan_entries_preserves_rationale_and_location(self):
         suggestions = [
             repairs.RepairSuggestion(
-                rule_id="mojibake-ellipsis",
+                rule_id="mojibake-macroman-o-diaeresis",
                 start=12,
-                end=15,
-                original_text="â€¦",
-                replacement_text="…",
+                end=14,
+                original_text="√∂",
+                replacement_text="ö",
                 finding_offset=13,
-                evidence="rule=mojibake-pattern; fragment=â€¦",
+                evidence="rule=mojibake-pattern; fragment=√∂",
                 confidence="high",
-                rationale="Broken UTF-8 ellipsis sequence.",
+                rationale="UTF-8 'ö' decoded as Mac-Roman.",
             )
         ]
 
@@ -298,26 +339,26 @@ class RepairsTest(unittest.TestCase):
         self.assertEqual(1, len(entries))
         entry = entries[0]
         self.assertEqual(12, entry.start)
-        self.assertEqual(15, entry.end)
-        self.assertEqual("â€¦", entry.original_text)
-        self.assertEqual("…", entry.replacement_text)
-        self.assertEqual("mojibake-ellipsis", entry.rule_id)
-        self.assertIn("fragment=â€¦", entry.evidence)
-        self.assertEqual("Broken UTF-8 ellipsis sequence.", entry.rationale)
+        self.assertEqual(14, entry.end)
+        self.assertEqual("√∂", entry.original_text)
+        self.assertEqual("ö", entry.replacement_text)
+        self.assertEqual("mojibake-macroman-o-diaeresis", entry.rule_id)
+        self.assertIn("fragment=√∂", entry.evidence)
+        self.assertEqual("UTF-8 'ö' decoded as Mac-Roman.", entry.rationale)
         self.assertEqual(13, entry.finding_offset)
 
     def test_build_dry_run_jsonl_report_is_machine_parseable(self):
         suggestions = [
             repairs.RepairSuggestion(
-                rule_id="mojibake-em-dash",
+                rule_id="mojibake-latin1-e-acute",
                 start=5,
-                end=8,
-                original_text="â€”",
-                replacement_text="—",
+                end=7,
+                original_text="Ã©",
+                replacement_text="é",
                 finding_offset=6,
-                evidence="rule=mojibake-pattern; fragment=â€”",
+                evidence="rule=mojibake-pattern; fragment=Ã©",
                 confidence="high",
-                rationale="Broken UTF-8 em dash sequence.",
+                rationale="UTF-8 'é' decoded as Latin-1.",
             )
         ]
 
@@ -327,24 +368,24 @@ class RepairsTest(unittest.TestCase):
         self.assertEqual(1, len(lines))
         payload = json.loads(lines[0])
         self.assertEqual("story.txt", payload["path"])
-        self.assertEqual("â€”", payload["original_text"])
-        self.assertEqual("—", payload["replacement_text"])
-        self.assertEqual("mojibake-em-dash", payload["rule_id"])
+        self.assertEqual("Ã©", payload["original_text"])
+        self.assertEqual("é", payload["replacement_text"])
+        self.assertEqual("mojibake-latin1-e-acute", payload["rule_id"])
 
     def test_suggest_reviewed_repairs_for_text_groups_decision_states(self):
-        text = "Text â€” and â€¦ sample"
+        text = "them a resumÃ©. stay off the 60Â° below"
         decision_store = review.ReviewDecisionStore(
             repair_decisions=(
                 review.RepairReviewDecision(
-                    rule_id="mojibake-em-dash",
-                    original_text="â€”",
-                    replacement_text="—",
+                    rule_id="mojibake-latin1-e-acute",
+                    original_text="Ã©",
+                    replacement_text="é",
                     decision=review.APPROVED,
                 ),
                 review.RepairReviewDecision(
-                    rule_id="mojibake-ellipsis",
-                    original_text="â€¦",
-                    replacement_text="…",
+                    rule_id="mojibake-latin1-degree-sign",
+                    original_text="Â°",
+                    replacement_text="°",
                     decision=review.REJECTED,
                 ),
             )

--- a/lcats/tests/analysis_tests/specials_test.py
+++ b/lcats/tests/analysis_tests/specials_test.py
@@ -133,6 +133,25 @@ class SpecialsTest(unittest.TestCase):
         self.assertEqual("review_needed", classification)
         self.assertIn("residual-review", evidence)
 
+    def test_classify_character_likely_repairable_for_macroman_sequences(self):
+        """Measured Mac-Roman mojibake pairs (√ + specific second char) must
+        classify repairable, while bare mathematical √ stays review_needed
+        (previous test)."""
+        cases = [
+            ("blas√© eyes", "√©"),
+            ("fin de si√®cle", "√®"),
+            ("se√±orita", "√±"),
+            ("Tha√ºle?", "√º"),
+            ("Ragnar√∂k.", "√∂"),
+            ("Niccol√≤ Tartaglia", "√≤"),
+        ]
+        for text, sequence in cases:
+            with self.subTest(sequence=sequence):
+                index = text.index("√")
+                classification, evidence = specials.classify_character(text, index, "√")
+                self.assertEqual("likely_repairable", classification)
+                self.assertIn(f"fragment={sequence}", evidence)
+
     def test_build_special_character_report_applies_review_allow_rules(self):
         decision_store = review.ReviewDecisionStore(
             allowed_special_cases=(

--- a/lcats/tests/analysis_tests/specials_test.py
+++ b/lcats/tests/analysis_tests/specials_test.py
@@ -144,6 +144,7 @@ class SpecialsTest(unittest.TestCase):
             ("Tha√ºle?", "√º"),
             ("Ragnar√∂k.", "√∂"),
             ("Niccol√≤ Tartaglia", "√≤"),
+            ("hypnop√¶dic language", "√¶"),
         ]
         for text, sequence in cases:
             with self.subTest(sequence=sequence):


### PR DESCRIPTION
## Summary

Implements [WI-RULES-0016](https://github.com/xenotaur/LCATS/blob/main/lcats/project/work_items/proposed/WI-RULES-0016.md) under WS-SPECIALS-CLEANUP.

Prompt ID: `PROMPT(WI-RULES-0016:WI_RULES_0016)[2026-07-13T13:56:02-04:00]`

## Changes

- **`repairs.py`** — replaced the six cp1252-form `DEFAULT_REPAIR_RULES` (which match **zero** occurrences in any corpus tree) with **14 rules verified byte-for-byte against the live `data/` tree**: 8 Latin-1-decoded (`Ã©`→é, `Ã«`→ë, `Ãª`→ê, `Ã¶`→ö, `Ã¯`→ï, `Ã`+NBSP→à, `Â°`→°, `Â¢`→¢) and 6 Mac-Roman-decoded (`√©`→é, `√®`→è, `√±`→ñ, `√º`→ü, `√∂`→ö, `√≤`→ò) UTF-8 sequences.
- **`specials.py`** — added the six measured Mac-Roman pairs to `MOJIBAKE_SEQUENCES` so they classify `likely_repairable`; bare mathematical `√` still classifies `review_needed` (exact-sequence matching, no blanket `√.` regex).
- **`repairs_cli.py`** — story-JSON inputs are now scanned on the decoded `body` field. Raw story files hold `\uXXXX` escapes (`json.dump` without `ensure_ascii=False`), so raw-text scans were silent false negatives (Codex review r3564985701 on PR #118).
- **Bug found by testing real bytes:** `_extract_evidence_fragment` used `str.strip()`, which deletes trailing NBSP (Unicode whitespace) — the `Ã`+NBSP fragment came back as bare `Ã` and the a-grave rule could never fire. Now only leading whitespace is stripped, with a regression test.
- **Tests** — classifier-driven tests rewritten against byte-exact contexts sampled from real stories (`resumÃ©`, `blas√©`, `60Â°`, `Ragnar√∂k`, `se√±orita`…); added no-rules assertions for the unmeasured cp1252 forms and legitimate French circumflex words; one `corpus_survey_test` expectation updated (`pi√©ce` is a measured defect, so `likely_repairable` is now correct).

## Acceptance evidence

Dry run over the full decoded `data/` tree: **34 proposals, all 14 rules firing** (previously 0). The 35th measured defect (`Ângstrom`) is deliberately excluded — it's the judgment call assigned to WI-OVERRIDES-0018.

## Validation

- `scripts/format --check --diff` — 141 files clean (after `scripts/develop` aligned Black to the pinned 25.11.0)
- `scripts/lint` — passed
- `scripts/test` — **1,263 tests OK**
- `lrh validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)