### PR TITLE
WI-NORMALIZE-0017: Apply repair rules at gather time with provenance metadata

### DIFF
--- a/lcats/lcats/gatherers/downloaders.py
+++ b/lcats/lcats/gatherers/downloaders.py
@@ -8,6 +8,7 @@ import shutil
 import requests
 
 from lcats import constants
+from lcats.gatherers import normalization
 from lcats.utils import env
 from lcats.utils import names
 
@@ -241,6 +242,10 @@ class DataGatherer:
                 "body": body_text,
                 "metadata": additional_data,
             }
+
+            # Apply replayable gather-time repairs before the first write so the
+            # fix is reproduced on every regeneration, not stored as a one-off.
+            normalization.normalize_story_dict(data_to_save)
 
             # Write data to JSON file
             with open(file_path, "w", encoding="utf-8") as json_file:

--- a/lcats/lcats/gatherers/normalization.py
+++ b/lcats/lcats/gatherers/normalization.py
@@ -1,0 +1,93 @@
+"""Gather-time text normalization for extracted story bodies.
+
+This module applies the conservative, measured repair rules from
+``lcats.analysis.corpus.repairs`` to a story body at gather time, before the
+story JSON is first written. Because ``data/`` is cleared and regenerated
+after major changes, repairs must be replayable inputs to regeneration rather
+than one-off edits to stored files (see WS-SPECIALS-CLEANUP).
+
+The hook reuses the same suggestion/apply code path as ``lcats
+repair-specials``, so the dry-run report and the applied normalization always
+agree. It is idempotent: a body with no mojibake findings yields no
+suggestions and is returned unchanged.
+"""
+
+import collections
+
+from lcats.analysis.corpus import repairs
+
+# Identifies which rule set produced a story's normalization provenance, so a
+# regenerated corpus can be traced back to the rules that shaped it.
+RULE_SOURCE = "lcats.analysis.corpus.repairs.DEFAULT_REPAIR_RULES"
+
+
+def normalize_body(body, rules=repairs.DEFAULT_REPAIR_RULES):
+    """Return ``(normalized_body, applied)`` for one story body.
+
+    ``applied`` is a deterministic list of ``{"rule_id", "replacement",
+    "count"}`` dicts, one per rule that fired, sorted by ``rule_id``. When no
+    rule fires the original ``body`` object is returned unchanged and
+    ``applied`` is empty.
+
+    Args:
+        body: The extracted story body text.
+        rules: Repair rules to apply (defaults to the measured rule table).
+
+    Returns:
+        A tuple of the normalized body and the applied-rule provenance list.
+    """
+    if not isinstance(body, str):
+        return body, []
+
+    suggestions = repairs.suggest_repairs_for_text(body, rules=rules)
+    if not suggestions:
+        return body, []
+
+    normalized = repairs.apply_repair_suggestions(body, suggestions)
+
+    counts = collections.Counter()
+    replacements = {}
+    for suggestion in suggestions:
+        counts[suggestion.rule_id] += 1
+        replacements[suggestion.rule_id] = suggestion.replacement_text
+
+    applied = [
+        {
+            "rule_id": rule_id,
+            "replacement": replacements[rule_id],
+            "count": counts[rule_id],
+        }
+        for rule_id in sorted(counts)
+    ]
+    return normalized, applied
+
+
+def normalize_story_dict(data_to_save, rules=repairs.DEFAULT_REPAIR_RULES):
+    """Normalize the ``body`` field of a story dict in place, recording provenance.
+
+    The story ``body`` is replaced with its normalized form. When one or more
+    rules fire and ``metadata`` is a dict, a ``normalization`` provenance block
+    is added under ``metadata``. Stories with no findings are left untouched,
+    including their metadata, so clean output stays byte-identical.
+
+    Args:
+        data_to_save: The story dict (``name``/``body``/``metadata``) about to
+            be written to JSON.
+        rules: Repair rules to apply (defaults to the measured rule table).
+
+    Returns:
+        The same ``data_to_save`` dict, mutated in place.
+    """
+    body = data_to_save.get("body")
+    normalized, applied = normalize_body(body, rules=rules)
+    if not applied:
+        return data_to_save
+
+    data_to_save["body"] = normalized
+    metadata = data_to_save.get("metadata")
+    if isinstance(metadata, dict):
+        metadata["normalization"] = {
+            "rule_source": RULE_SOURCE,
+            "rules_applied": applied,
+        }
+    return data_to_save

--- a/lcats/lcats/gatherers/normalization.py
+++ b/lcats/lcats/gatherers/normalization.py
@@ -17,12 +17,16 @@ import collections
 from lcats.analysis.corpus import repairs
 
 # Identifies which rule set produced a story's normalization provenance, so a
-# regenerated corpus can be traced back to the rules that shaped it.
-RULE_SOURCE = "lcats.analysis.corpus.repairs.DEFAULT_REPAIR_RULES"
+# regenerated corpus can be traced back to the rules that shaped it. Derived
+# from the imported module so it stays accurate if the module path changes.
+RULE_SOURCE = f"{repairs.__name__}.DEFAULT_REPAIR_RULES"
 
 
-def normalize_body(body, rules=repairs.DEFAULT_REPAIR_RULES):
+def normalize_body(body):
     """Return ``(normalized_body, applied)`` for one story body.
+
+    Repairs use the measured ``repairs.DEFAULT_REPAIR_RULES`` table, applied via
+    the same suggestion/apply path as ``lcats repair-specials``.
 
     ``applied`` is a deterministic list of ``{"rule_id", "replacement",
     "count"}`` dicts, one per rule that fired, sorted by ``rule_id``. When no
@@ -31,7 +35,6 @@ def normalize_body(body, rules=repairs.DEFAULT_REPAIR_RULES):
 
     Args:
         body: The extracted story body text.
-        rules: Repair rules to apply (defaults to the measured rule table).
 
     Returns:
         A tuple of the normalized body and the applied-rule provenance list.
@@ -39,7 +42,7 @@ def normalize_body(body, rules=repairs.DEFAULT_REPAIR_RULES):
     if not isinstance(body, str):
         return body, []
 
-    suggestions = repairs.suggest_repairs_for_text(body, rules=rules)
+    suggestions = repairs.suggest_repairs_for_text(body)
     if not suggestions:
         return body, []
 
@@ -62,7 +65,7 @@ def normalize_body(body, rules=repairs.DEFAULT_REPAIR_RULES):
     return normalized, applied
 
 
-def normalize_story_dict(data_to_save, rules=repairs.DEFAULT_REPAIR_RULES):
+def normalize_story_dict(data_to_save):
     """Normalize the ``body`` field of a story dict in place, recording provenance.
 
     The story ``body`` is replaced with its normalized form. When one or more
@@ -73,13 +76,12 @@ def normalize_story_dict(data_to_save, rules=repairs.DEFAULT_REPAIR_RULES):
     Args:
         data_to_save: The story dict (``name``/``body``/``metadata``) about to
             be written to JSON.
-        rules: Repair rules to apply (defaults to the measured rule table).
 
     Returns:
         The same ``data_to_save`` dict, mutated in place.
     """
     body = data_to_save.get("body")
-    normalized, applied = normalize_body(body, rules=rules)
+    normalized, applied = normalize_body(body)
     if not applied:
         return data_to_save
 

--- a/lcats/lcats/gatherers/parser.py
+++ b/lcats/lcats/gatherers/parser.py
@@ -10,6 +10,7 @@ import csv
 
 from lcats import constants
 from lcats.utils import names
+from lcats.gatherers import normalization
 from lcats.gettenberg import api
 from lcats.gettenberg import headers
 from lcats.gatherers.mass_quantities import storymap
@@ -941,6 +942,10 @@ def gather_story(gatherer, story):
             "name": file_name,
         },
     }
+
+    # Apply replayable gather-time repairs before the first write so the fix is
+    # reproduced on every regeneration, not stored as a one-off.
+    normalization.normalize_story_dict(data_to_save)
 
     # Move all of this code up into the API so it is done consistently.
     # Ensure the data directory exists

--- a/lcats/project/design/design.md
+++ b/lcats/project/design/design.md
@@ -35,3 +35,4 @@ Define the LCATS corpus-quality pipeline design for the current execution horizo
 ## State and Persistence Boundary
 - Current active design emphasizes in-run audit records.
 - Durable persistence model is tracked as planned work (Phase 5) and is intentionally separated from the active repair/review implementation.
+- **Gather-time repairs are the exception (WI-NORMALIZE-0017, 2026-07-13).** Special-character repairs are applied during gathering as a replayable step, not stored as edits to `data/`/`corpora/` JSON: because `data/` regenerates from cache, the durable artifact is the rule table (plus per-story overrides), and provenance is recorded as applied rule ids in story `metadata`, keyed by rule rather than byte offset. Byte offsets remain an ephemeral per-run execution detail. See `project/memory/decision_log.md` (2026-07-13).

--- a/lcats/project/executions/AD_HOC/2026_07_14_01_08_45_WI_NORMALIZE_0017_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_14_01_08_45_WI_NORMALIZE_0017_REVIEW.md
@@ -1,0 +1,48 @@
+---
+execution_id: 2026_07_14_01_08_45_WI_NORMALIZE_0017_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_NORMALIZE_0017_REVIEW)[2026-07-14T01:06:27-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_14_00_38_00_WI_NORMALIZE_0017
+pr: https://github.com/xenotaur/LCATS/pull/121
+commit: f6fd14a
+created_at: 2026-07-14T01:08:45-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/121
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Address the two open review comments on PR #121 (WI-NORMALIZE-0017) via
+`lrh request review_response`. Both from copilot-pull-request-reviewer,
+both targeting `RULE_SOURCE` provenance accuracy in
+`lcats/lcats/gatherers/normalization.py`.
+
+# Result
+
+Both fixed in commit f6fd14a:
+
+- r3576072372 — `RULE_SOURCE` was a hard-coded string literal that could go
+  stale on a module move. Now derived: `f"{repairs.__name__}.DEFAULT_REPAIR_RULES"`.
+- r3576072389 — `normalize_body`/`normalize_story_dict` accepted a `rules`
+  parameter but always recorded provenance as DEFAULT_REPAIR_RULES, so a
+  custom sequence would mislabel provenance. Removed the unused parameter.
+  WI-OVERRIDES-0018 applies per-story overrides as a second pass after the
+  rule pass (not by swapping the rule table), so the parameter was unused
+  speculative surface; removing it eliminates the inaccuracy vector.
+
+No comments skipped. Derived RULE_SOURCE verified byte-equal to the former
+literal.
+
+# Validation
+
+- `black --check lcats/gatherers/normalization.py` — unchanged
+- `scripts/lint` — ruff and black passed
+- `scripts/test` — 1273 tests OK
+- `lrh validate` — 0 errors, 24 pre-existing owner-role warnings
+
+# Follow-up
+
+- On merge: set this record and the primary WI-NORMALIZE-0017 record to
+  landed, and resolve WI-NORMALIZE-0017.

--- a/lcats/project/executions/WI-NORMALIZE-0017/2026_07_14_00_38_00_WI_NORMALIZE_0017.md
+++ b/lcats/project/executions/WI-NORMALIZE-0017/2026_07_14_00_38_00_WI_NORMALIZE_0017.md
@@ -1,0 +1,67 @@
+---
+execution_id: 2026_07_14_00_38_00_WI_NORMALIZE_0017
+prompt_id: PROMPT(WI-NORMALIZE-0017:WI_NORMALIZE_0017)[2026-07-13T22:13:41-04:00]
+work_item: WI-NORMALIZE-0017
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/121
+commit: ede25ec
+created_at: 2026-07-14T00:38:00-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-NORMALIZE-0017.md
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Implement WI-NORMALIZE-0017: a deterministic gather-time normalization step
+that applies the measured repair rules to each extracted story body before
+the first JSON write, stamping applied rule ids into story metadata, so
+repairs replay on every regeneration instead of being one-off edits to data/.
+
+# Result
+
+Implemented on branch xenotaur/feat/wi-normalize-0017 (PR #121, commit
+ede25ec):
+
+- `lcats/lcats/gatherers/normalization.py` — new module with
+  `normalize_body(body)` and `normalize_story_dict(data)`. Reuses the same
+  suggestion/apply path as `lcats repair-specials`
+  (`repairs.suggest_repairs_for_text` + `apply_repair_suggestions`), so the
+  dry-run and the applied normalization always agree. Provenance
+  (`rule_id` + `count`, plus `rule_source`) is written to
+  `metadata["normalization"]` only when a rule fires.
+- `lcats/lcats/gatherers/downloaders.py` and
+  `lcats/lcats/gatherers/parser.py` — call the hook on the story dict
+  immediately before each `json.dump` (both write paths). Applied in memory
+  before the first write; no in-place rewrite of stored corpus JSON.
+- `project/memory/decision_log.md` — decision entry: repairs are gather-time
+  replayable inputs keyed by rule id, not byte offset; supersedes the
+  2026-06-18 "application out of scope" decision.
+- `project/design/design.md` — amended State and Persistence Boundary.
+
+Acceptance criteria all met (covered by tests):
+- Known-defect body is repaired and its applied rule ids recorded in metadata.
+- Clean stories pass through byte-identical (body and metadata), no
+  `normalization` key added.
+- Two regenerations from the same source produce identical output.
+
+# Validation
+
+- `scripts/lint` — ruff and black passed
+- `scripts/test` — 1273 tests OK (9 new in
+  tests/gatherers_tests/normalization_test.py)
+- `lrh validate` — 0 errors, 24 pre-existing owner-role warnings
+- Note: `scripts/format` (no-arg) trips a `set -u` unbound-variable bash bug
+  in this environment; formatting verified with `black` directly (pinned
+  25.11.0) and the pre-commit black hook passed on commit.
+
+# Follow-up
+
+- WI-OVERRIDES-0018 adds the per-story overrides file, consumed by this hook
+  after the rule pass (design left room: normalize_story_dict is the single
+  entry point).
+- WI-RESIDUAL-0019 runs the pipeline over a fresh regeneration and reviews
+  residuals.
+- Possible separate fix: `scripts/format` no-arg `set -u` bug.
+- On merge: set this record to landed and resolve WI-NORMALIZE-0017.

--- a/lcats/project/memory/decision_log.md
+++ b/lcats/project/memory/decision_log.md
@@ -1,5 +1,35 @@
 # Decision Log
 
+## 2026-07-13: Repairs are gather-time replayable inputs, keyed by rule not offset
+
+### Summary
+- Implemented WI-NORMALIZE-0017: a deterministic normalization step in the
+  gather pipeline (`lcats/lcats/gatherers/normalization.py`) that applies the
+  measured repair rules to each extracted story body before its first JSON
+  write, stamping applied rule ids into `metadata["normalization"]`.
+
+### Decisions
+- **Repairs live in the pipeline, not in stored files.** Because `data/` is
+  cleared and regenerated after major changes (and users regenerate with their
+  own customizations), a durable fix must be a replayable input to
+  regeneration. Applying rules at gather time reproduces the fix on every run;
+  editing stored JSON would be wiped by the next regeneration.
+- **The reviewable/durable unit is the rule id, not a byte offset.** Offsets
+  are recomputed each run by the shared suggestion path and are an ephemeral
+  execution detail; provenance is recorded as applied rule ids + counts.
+- **Reuse the dry-run code path.** Normalization calls
+  `repairs.suggest_repairs_for_text` + `apply_repair_suggestions`, so what
+  `lcats repair-specials` reports is exactly what normalization applies.
+- **Non-destructive and idempotent.** Clean bodies pass through byte-identical
+  with no metadata change; re-normalizing an already-clean body is a no-op.
+- This supersedes the 2026-06-18 decision to keep application workflows out of
+  scope, and amends the State and Persistence Boundary in
+  `project/design/design.md`. Span-op review persistence (WI-REVIEW-0003) and
+  per-story overrides (WI-OVERRIDES-0018) build on this replayable model.
+
+### Status
+- Accepted
+
 ## 2026-06-29: Adopt unified LLMBackend Protocol for model-comparison experiments
 
 ### Summary

--- a/lcats/tests/gatherers_tests/normalization_test.py
+++ b/lcats/tests/gatherers_tests/normalization_test.py
@@ -1,0 +1,121 @@
+"""Unit tests for lcats.gatherers.normalization."""
+
+import unittest
+
+from lcats.gatherers import normalization
+
+
+class NormalizeBodyTest(unittest.TestCase):
+    """Tests for the body-level normalization helper."""
+
+    def test_repairs_measured_mojibake_and_reports_provenance(self):
+        # Real sampled contexts (WI-RULES-0016): Mac-Roman é and Latin-1 °.
+        body = "unnerving even to the blas√© eyes; 60Â° below"
+
+        normalized, applied = normalization.normalize_body(body)
+
+        self.assertEqual("unnerving even to the blasé eyes; 60° below", normalized)
+        rule_ids = [entry["rule_id"] for entry in applied]
+        self.assertEqual(
+            ["mojibake-latin1-degree-sign", "mojibake-macroman-e-acute"], rule_ids
+        )
+        for entry in applied:
+            self.assertEqual(1, entry["count"])
+            self.assertIn("replacement", entry)
+
+    def test_counts_multiple_occurrences_of_one_rule(self):
+        body = "resumÃ© and clichÃ© and exptosÃ©"
+
+        _, applied = normalization.normalize_body(body)
+
+        self.assertEqual(1, len(applied))
+        self.assertEqual("mojibake-latin1-e-acute", applied[0]["rule_id"])
+        self.assertEqual(3, applied[0]["count"])
+
+    def test_clean_body_returned_unchanged(self):
+        body = "A perfectly clean sentence with é and ñ already correct."
+
+        normalized, applied = normalization.normalize_body(body)
+
+        self.assertIs(body, normalized)
+        self.assertEqual([], applied)
+
+    def test_non_string_body_is_passed_through(self):
+        normalized, applied = normalization.normalize_body(None)
+
+        self.assertIsNone(normalized)
+        self.assertEqual([], applied)
+
+    def test_normalization_is_idempotent(self):
+        body = "trumpets of Ragnar√∂k and se√±orita"
+
+        once, first_applied = normalization.normalize_body(body)
+        twice, second_applied = normalization.normalize_body(once)
+
+        self.assertEqual(once, twice)
+        self.assertNotEqual([], first_applied)
+        self.assertEqual([], second_applied)
+
+
+class NormalizeStoryDictTest(unittest.TestCase):
+    """Tests for the story-dict normalization helper."""
+
+    def test_repairs_body_and_stamps_metadata(self):
+        data = {
+            "name": "The Marrying Man",
+            "body": "even to the blas√© eyes of Marilyn",
+            "metadata": {"author": "Test", "year": 1950},
+        }
+
+        result = normalization.normalize_story_dict(data)
+
+        self.assertIs(data, result)
+        self.assertEqual("even to the blasé eyes of Marilyn", result["body"])
+        provenance = result["metadata"]["normalization"]
+        self.assertEqual(normalization.RULE_SOURCE, provenance["rule_source"])
+        self.assertEqual(
+            "mojibake-macroman-e-acute",
+            provenance["rules_applied"][0]["rule_id"],
+        )
+        # Pre-existing metadata is preserved alongside the provenance block.
+        self.assertEqual("Test", result["metadata"]["author"])
+
+    def test_clean_story_left_byte_identical(self):
+        data = {
+            "name": "Clean",
+            "body": "No defects here at all.",
+            "metadata": {"author": "Z"},
+        }
+        original_metadata = dict(data["metadata"])
+
+        result = normalization.normalize_story_dict(data)
+
+        self.assertEqual("No defects here at all.", result["body"])
+        self.assertEqual(original_metadata, result["metadata"])
+        self.assertNotIn("normalization", result["metadata"])
+
+    def test_two_regenerations_produce_identical_output(self):
+        def fresh():
+            return {
+                "name": "S",
+                "body": "adapting a hypnop√¶dic language on Ragnar√∂k",
+                "metadata": {"author": "A"},
+            }
+
+        first = normalization.normalize_story_dict(fresh())
+        second = normalization.normalize_story_dict(fresh())
+
+        self.assertEqual(first, second)
+        self.assertEqual("adapting a hypnopædic language on Ragnarök", first["body"])
+
+    def test_missing_metadata_still_repairs_body(self):
+        data = {"name": "S", "body": "se√±orita"}
+
+        result = normalization.normalize_story_dict(data)
+
+        self.assertEqual("señorita", result["body"])
+        self.assertNotIn("metadata", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements [WI-NORMALIZE-0017](https://github.com/xenotaur/LCATS/blob/main/lcats/project/work_items/proposed/WI-NORMALIZE-0017.md) under WS-SPECIALS-CLEANUP — the replayable normalization hook that makes WI-RULES-0016's measured repairs survive `data/` regeneration.

Prompt ID: `PROMPT(WI-NORMALIZE-0017:WI_NORMALIZE_0017)[2026-07-13T22:13:41-04:00]`

## Changes

- **New `lcats/lcats/gatherers/normalization.py`** — `normalize_body(body)` and `normalize_story_dict(data)`. Reuses the *same* code path as `lcats repair-specials` (`repairs.suggest_repairs_for_text` → `apply_repair_suggestions`), so the dry-run report and the applied normalization always agree. Provenance (`rule_id` + `count`) is written to `metadata["normalization"]` **only when a rule fires** — clean stories pass through byte-identical, metadata included.
- **`downloaders.py` / `parser.py`** — call the hook on the story dict immediately before each `json.dump`, so repairs are applied in-memory before the first write (no in-place rewrite of stored corpus JSON).
- **`project/memory/decision_log.md`** — records the decision that repairs are gather-time replayable inputs keyed by rule id, not byte offset; supersedes the 2026-06-18 "application out of scope" decision.
- **`project/design/design.md`** — amends the State and Persistence Boundary section accordingly.

## Acceptance evidence (all met)

- **Repaired story → repaired body + provenance:** `blas√©`/`60Â°` → `blasé`/`60°` with both rule ids in `metadata`.
- **Clean story → byte-identical:** body and metadata untouched, no `normalization` key added.
- **Deterministic across regenerations:** two runs from the same source produce identical output (verified in tests).
- Idempotent: re-normalizing a repaired body is a no-op.

## Validation

- `scripts/lint` — passed
- `scripts/test` — **1,273 tests OK** (9 new)
- `lrh validate` — 0 errors

Note: `scripts/format` (no-arg) trips a `set -u` "unbound variable" bash bug in this environment; formatting was verified with `black` directly (pinned 25.11.0) and the pre-commit black hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)