### PR TITLE
WI-OVERRIDES-0018: Versioned per-story overrides consumed at gather time

### DIFF
--- a/lcats/MANIFEST.in
+++ b/lcats/MANIFEST.in
@@ -1,0 +1,4 @@
+# Versioned gather-time override tables (see lcats/gatherers/overrides.py).
+# Ensures the JSON files ship in sdists and, with include_package_data=True,
+# in wheels built via setup.py.
+recursive-include lcats/gatherers/overrides *.json

--- a/lcats/docs/reference/gather-overrides.md
+++ b/lcats/docs/reference/gather-overrides.md
@@ -1,0 +1,66 @@
+# Per-story gather-time overrides
+
+Some corpus defects are judgment calls that the measured repair rules in
+`lcats/analysis/corpus/repairs.py` cannot safely cover. For example
+`Ângstrom` — a stray `Â` (U+00C2) a human reads as `Ångstrom` — is not a clean
+encoding-family decode, so it is deliberately *not* a repair rule. Per-story
+overrides let such fixes live as versioned repo inputs that the gather-time
+normalization hook applies **after** the rule pass.
+
+Like the rule table, overrides are replayable inputs to regeneration, not edits
+to stored files: because `data/` is cleared and regenerated after major changes,
+a one-off edit to a story JSON would be wiped on the next run. Overrides live
+under the package (`lcats/gatherers/overrides/`), never under `data/`, so
+regeneration and story discovery never touch or wipe them.
+
+## File layout
+
+One JSON file per collection:
+
+```
+lcats/gatherers/overrides/<collection>.json
+```
+
+where `<collection>` is the collection / target-directory name, e.g.
+`mass_quantities`. A collection with no overrides simply has no file.
+
+## Schema
+
+```json
+{
+  "<story_id>": [
+    {
+      "find": "<exact substring, with enough context to be unique>",
+      "replace": "<replacement text>",
+      "rationale": "<why this is a judgment call, not a rule>",
+      "reviewer": "<who decided>"
+    }
+  ]
+}
+```
+
+- `story_id` is the story's filename stem (e.g. `f_o_b_venus__bond`).
+- `find` is a literal substring match, not a regex. Include enough surrounding
+  context that it is unique within the story — a bare single character will
+  misfire.
+- Each applied entry is recorded in the story's
+  `metadata.normalization.overrides_applied`, alongside `rules_applied`, for
+  provenance.
+
+## Behavior
+
+- Overrides are applied by `lcats.gatherers.normalization.normalize_story_dict`
+  when it is called with both `collection` and `story_id` (the two gather write
+  paths pass these). They run after rule-based repairs, so an override sees
+  already-rule-normalized text.
+- A `find` that is absent from the body is **skipped with a warning**, not a
+  silent no-op — a stale override usually means the story text changed and the
+  entry needs re-review.
+- Application is deterministic and idempotent in the sense that regenerating
+  from the same cached source produces identical output.
+
+## Populating overrides
+
+This mechanism (WI-OVERRIDES-0018) ships with one canonical seed entry
+(`Ângstrom` in `f_o_b_venus__bond`). Systematic population from human review of
+residual defects is handled by WI-RESIDUAL-0019.

--- a/lcats/docs/reference/gather-overrides.md
+++ b/lcats/docs/reference/gather-overrides.md
@@ -53,9 +53,12 @@ where `<collection>` is the collection / target-directory name, e.g.
   when it is called with both `collection` and `story_id` (the two gather write
   paths pass these). They run after rule-based repairs, so an override sees
   already-rule-normalized text.
-- A `find` that is absent from the body is **skipped with a warning**, not a
-  silent no-op — a stale override usually means the story text changed and the
-  entry needs re-review.
+- An entry is **skipped with a warning** — never silently — when its `find` is
+  empty, equals its `replace` (a no-op that would otherwise stamp provenance
+  onto an unchanged body), or is absent from the body. A stale override usually
+  means the story text changed and the entry needs re-review.
+- Per-collection override files are parsed once and cached for the process
+  lifetime (they are versioned, effectively immutable during a run).
 - Application is deterministic and idempotent in the sense that regenerating
   from the same cached source produces identical output.
 

--- a/lcats/lcats/gatherers/downloaders.py
+++ b/lcats/lcats/gatherers/downloaders.py
@@ -243,9 +243,14 @@ class DataGatherer:
                 "metadata": additional_data,
             }
 
-            # Apply replayable gather-time repairs before the first write so the
-            # fix is reproduced on every regeneration, not stored as a one-off.
-            normalization.normalize_story_dict(data_to_save)
+            # Apply replayable gather-time repairs (rules + per-story overrides)
+            # before the first write so the fix is reproduced on every
+            # regeneration, not stored as a one-off.
+            normalization.normalize_story_dict(
+                data_to_save,
+                collection=self.name,
+                story_id=os.path.splitext(filename)[0],
+            )
 
             # Write data to JSON file
             with open(file_path, "w", encoding="utf-8") as json_file:

--- a/lcats/lcats/gatherers/normalization.py
+++ b/lcats/lcats/gatherers/normalization.py
@@ -15,6 +15,7 @@ suggestions and is returned unchanged.
 import collections
 
 from lcats.analysis.corpus import repairs
+from lcats.gatherers import overrides
 
 # Identifies which rule set produced a story's normalization provenance, so a
 # regenerated corpus can be traced back to the rules that shaped it. Derived
@@ -65,31 +66,48 @@ def normalize_body(body):
     return normalized, applied
 
 
-def normalize_story_dict(data_to_save):
+def normalize_story_dict(data_to_save, collection=None, story_id=None):
     """Normalize the ``body`` field of a story dict in place, recording provenance.
 
-    The story ``body`` is replaced with its normalized form. When one or more
-    rules fire and ``metadata`` is a dict, a ``normalization`` provenance block
-    is added under ``metadata``. Stories with no findings are left untouched,
-    including their metadata, so clean output stays byte-identical.
+    The story ``body`` is first repaired by the measured rule table, then, when
+    ``collection`` and ``story_id`` are given, by any versioned per-story
+    overrides for that story (applied after the rules). When either step changes
+    the body and ``metadata`` is a dict, a ``normalization`` provenance block is
+    added under ``metadata`` recording what fired. Stories that neither a rule
+    nor an override touches are left untouched, including their metadata, so
+    clean output stays byte-identical.
 
     Args:
         data_to_save: The story dict (``name``/``body``/``metadata``) about to
             be written to JSON.
+        collection: The collection (target directory) name, used to look up
+            per-story overrides. When ``None``, overrides are skipped.
+        story_id: The story's filename stem, used to look up per-story
+            overrides. When ``None``, overrides are skipped.
 
     Returns:
         The same ``data_to_save`` dict, mutated in place.
     """
     body = data_to_save.get("body")
-    normalized, applied = normalize_body(body)
-    if not applied:
+    normalized, rules_applied = normalize_body(body)
+
+    overrides_applied = []
+    if collection is not None and story_id is not None:
+        entries = overrides.load_overrides(collection).get(story_id, [])
+        normalized, overrides_applied = overrides.apply_overrides(normalized, entries)
+
+    if not rules_applied and not overrides_applied:
         return data_to_save
 
     data_to_save["body"] = normalized
     metadata = data_to_save.get("metadata")
     if isinstance(metadata, dict):
-        metadata["normalization"] = {
-            "rule_source": RULE_SOURCE,
-            "rules_applied": applied,
-        }
+        provenance = {}
+        if rules_applied:
+            provenance["rule_source"] = RULE_SOURCE
+            provenance["rules_applied"] = rules_applied
+        if overrides_applied:
+            provenance["override_source"] = overrides.OVERRIDE_SOURCE
+            provenance["overrides_applied"] = overrides_applied
+        metadata["normalization"] = provenance
     return data_to_save

--- a/lcats/lcats/gatherers/overrides.py
+++ b/lcats/lcats/gatherers/overrides.py
@@ -31,6 +31,7 @@ RESIDUAL-0019 populates these files during human review; this module provides
 the mechanism and one canonical seed entry.
 """
 
+import functools
 import json
 import pathlib
 import warnings
@@ -48,10 +49,17 @@ def overrides_path(collection: str) -> pathlib.Path:
     return OVERRIDES_DIR / f"{collection}.json"
 
 
+@functools.lru_cache(maxsize=None)
 def load_overrides(collection: str) -> dict:
     """Return the ``{story_id: [entry, ...]}`` overrides map for a collection.
 
     Returns an empty dict when the collection has no overrides file.
+
+    The result is cached per collection for the lifetime of the process: the
+    files are versioned inputs and effectively immutable during a gather run,
+    and ``normalize_story_dict`` is called once per story. Callers must treat
+    the returned dict as read-only; use ``load_overrides.cache_clear()`` if a
+    file changes on disk within a process (e.g. in a test).
 
     Args:
         collection: The collection (target directory) name, e.g.
@@ -70,11 +78,14 @@ def load_overrides(collection: str) -> dict:
 def apply_overrides(body, entries):
     """Apply override entries to a story body, returning ``(body, applied)``.
 
-    Each entry is a literal ``find`` -> ``replace`` substitution. An entry whose
-    ``find`` text is absent from the body is skipped with a visible warning
-    rather than a silent no-op, since a stale override usually signals a
-    story-text change that needs re-review. When no entry matches, the original
-    ``body`` object is returned unchanged and ``applied`` is empty.
+    Each entry is a literal ``find`` -> ``replace`` substitution. An entry is
+    skipped with a visible warning rather than silently, since a stale override
+    usually signals a story-text change that needs re-review, when its ``find``
+    is empty, equals its ``replace`` (a no-op that would otherwise stamp
+    provenance without changing the body), or is absent from the body. Only
+    entries that actually change the body are recorded in ``applied``; when none
+    do, the original ``body`` object is returned unchanged and ``applied`` is
+    empty.
 
     Args:
         body: The story body text (already rule-normalized).
@@ -93,8 +104,14 @@ def apply_overrides(body, entries):
     for entry in entries:
         find = entry.get("find", "")
         replace = entry.get("replace", "")
-        count = updated.count(find) if find else 0
-        if not find or count == 0:
+        if not find or find == replace:
+            warnings.warn(
+                f"override is empty or a no-op (find == replace), skipping: {find!r}",
+                stacklevel=2,
+            )
+            continue
+        count = updated.count(find)
+        if count == 0:
             warnings.warn(
                 f"override find text not present, skipping: {find!r}",
                 stacklevel=2,

--- a/lcats/lcats/gatherers/overrides.py
+++ b/lcats/lcats/gatherers/overrides.py
@@ -1,0 +1,113 @@
+"""Versioned per-story text overrides applied at gather time.
+
+Some corpus defects are judgment calls that the measured repair rules in
+``lcats.analysis.corpus.repairs`` cannot safely cover -- for example
+``Ângstrom`` (a stray ``Â`` that a human reads as ``Ångstrom``) is not a clean
+encoding-family decode, so it is not a rule. This module lets such fixes live
+as versioned repo inputs, keyed by collection and story id, applied by the
+normalization hook *after* the rule pass.
+
+Because ``data/`` is cleared and regenerated after major changes, these
+overrides -- like the rule table -- are replayable inputs to regeneration, not
+edits to stored files. They deliberately live under the package
+(``lcats/gatherers/overrides/``), never under ``data/``, so regeneration and
+story discovery never touch or wipe them.
+
+Schema (``overrides/<collection>.json``)::
+
+    {
+      "<story_id>": [
+        {
+          "find": "<exact substring, with enough context to be unique>",
+          "replace": "<replacement text>",
+          "rationale": "<why this is a judgment call, not a rule>",
+          "reviewer": "<who decided>"
+        }
+      ]
+    }
+
+``story_id`` is the story's filename stem (e.g. ``f_o_b_venus__bond``). WI-
+RESIDUAL-0019 populates these files during human review; this module provides
+the mechanism and one canonical seed entry.
+"""
+
+import json
+import pathlib
+import warnings
+
+# Overrides live beside this module, never under data/, so they survive
+# cache-clear + regeneration and are never discovered as story JSON.
+OVERRIDES_DIR = pathlib.Path(__file__).parent / "overrides"
+
+# Recorded in provenance so a regenerated corpus can be traced to its overrides.
+OVERRIDE_SOURCE = "lcats.gatherers.overrides"
+
+
+def overrides_path(collection: str) -> pathlib.Path:
+    """Return the overrides file path for a collection (may not exist)."""
+    return OVERRIDES_DIR / f"{collection}.json"
+
+
+def load_overrides(collection: str) -> dict:
+    """Return the ``{story_id: [entry, ...]}`` overrides map for a collection.
+
+    Returns an empty dict when the collection has no overrides file.
+
+    Args:
+        collection: The collection (target directory) name, e.g.
+            ``mass_quantities``.
+
+    Returns:
+        A mapping of story id to a list of override entry dicts.
+    """
+    path = overrides_path(collection)
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def apply_overrides(body, entries):
+    """Apply override entries to a story body, returning ``(body, applied)``.
+
+    Each entry is a literal ``find`` -> ``replace`` substitution. An entry whose
+    ``find`` text is absent from the body is skipped with a visible warning
+    rather than a silent no-op, since a stale override usually signals a
+    story-text change that needs re-review. When no entry matches, the original
+    ``body`` object is returned unchanged and ``applied`` is empty.
+
+    Args:
+        body: The story body text (already rule-normalized).
+        entries: A list of override entry dicts for this story.
+
+    Returns:
+        A tuple of the updated body and a deterministic list of applied-entry
+        provenance dicts (``find``/``replace``/``rationale``/``reviewer``/
+        ``count``), in entry order.
+    """
+    if not isinstance(body, str) or not entries:
+        return body, []
+
+    updated = body
+    applied = []
+    for entry in entries:
+        find = entry.get("find", "")
+        replace = entry.get("replace", "")
+        count = updated.count(find) if find else 0
+        if not find or count == 0:
+            warnings.warn(
+                f"override find text not present, skipping: {find!r}",
+                stacklevel=2,
+            )
+            continue
+        updated = updated.replace(find, replace)
+        applied.append(
+            {
+                "find": find,
+                "replace": replace,
+                "rationale": entry.get("rationale", ""),
+                "reviewer": entry.get("reviewer", ""),
+                "count": count,
+            }
+        )
+    return updated, applied

--- a/lcats/lcats/gatherers/overrides/mass_quantities.json
+++ b/lcats/lcats/gatherers/overrides/mass_quantities.json
@@ -1,0 +1,10 @@
+{
+    "f_o_b_venus__bond": [
+        {
+            "find": "Ângstrom",
+            "replace": "Ångstrom",
+            "rationale": "Stray 'Â' (U+00C2) before 'ngstrom' is not a clean encoding-family decode, so it is a judgment call rather than a repair rule; a human reads the intended unit as 'Ångstrom'.",
+            "reviewer": "WI-OVERRIDES-0018 seed"
+        }
+    ]
+}

--- a/lcats/lcats/gatherers/parser.py
+++ b/lcats/lcats/gatherers/parser.py
@@ -1454,9 +1454,14 @@ def gather_story(gatherer, story):
         },
     }
 
-    # Apply replayable gather-time repairs before the first write so the fix is
-    # reproduced on every regeneration, not stored as a one-off.
-    normalization.normalize_story_dict(data_to_save)
+    # Apply replayable gather-time repairs (rules + per-story overrides) before
+    # the first write so the fix is reproduced on every regeneration, not stored
+    # as a one-off.
+    normalization.normalize_story_dict(
+        data_to_save,
+        collection=storymap.TARGET_DIRECTORY,
+        story_id=os.path.splitext(file_name)[0],
+    )
 
     # Move all of this code up into the API so it is done consistently.
     # Ensure the data directory exists

--- a/lcats/project/executions/AD_HOC/2026_07_15_19_39_02_WI_OVERRIDES_0018_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_15_19_39_02_WI_OVERRIDES_0018_REVIEW.md
@@ -1,0 +1,57 @@
+---
+execution_id: 2026_07_15_19_39_02_WI_OVERRIDES_0018_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_OVERRIDES_0018_REVIEW)[2026-07-15T19:15:43-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_15_17_05_07_WI_OVERRIDES_0018
+pr: https://github.com/xenotaur/LCATS/pull/123
+commit: 287bc53
+created_at: 2026-07-15T19:39:02-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/123
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Address the open review comments on PR #123 (WI-OVERRIDES-0018) via
+`lrh request review_response`. Four comments from chatgpt-codex-connector and
+copilot-pull-request-reviewer, reducing to three distinct issues (the two
+packaging comments are duplicates).
+
+# Result
+
+All three fixed in commit 287bc53:
+
+- Packaging (r3590755993, r3591298980) — override JSON files were not declared
+  as package data, so wheels/sdists omitted them and `load_overrides()`
+  returned `{}` in packaged installs. Added `[tool.setuptools.package-data]`
+  ("lcats.gatherers" = ["overrides/*.json"]) to pyproject.toml and a
+  MANIFEST.in. Verified: both `python -m build` sdist and wheel now contain
+  `lcats/gatherers/overrides/mass_quantities.json`.
+- Caching (r3591298960) — `load_overrides()` re-read/re-parsed JSON once per
+  story. Added `functools.lru_cache`; files are versioned and immutable during
+  a run. Documented that the returned dict is read-only and
+  `cache_clear()` is available for tests.
+- find == replace no-op (r3591298973) — a stale no-op entry recorded as
+  applied and stamped metadata onto an unchanged body, breaking the
+  byte-identical-clean-output guarantee. Now skipped with a warning alongside
+  empty and absent finds.
+
+No comments skipped. Docs (docs/reference/gather-overrides.md) updated. Tests
+added: no-op/empty skip + warning, caching identity, and a temp-dir
+collection fixture (no-op leaves story byte-identical; real override applies).
+
+# Validation
+
+- `black --check` — clean after formatting
+- `scripts/lint` — ruff and black passed
+- `scripts/test` — 1287 tests OK (5 new)
+- `lrh validate` — 0 errors, 24 pre-existing owner-role warnings
+- Packaging verified: `python -m build` sdist + wheel both include
+  `lcats/gatherers/overrides/mass_quantities.json`
+
+# Follow-up
+
+- On merge: set this record and the primary WI-OVERRIDES-0018 record to
+  landed, and resolve WI-OVERRIDES-0018.

--- a/lcats/project/executions/WI-OVERRIDES-0018/2026_07_15_17_05_07_WI_OVERRIDES_0018.md
+++ b/lcats/project/executions/WI-OVERRIDES-0018/2026_07_15_17_05_07_WI_OVERRIDES_0018.md
@@ -1,0 +1,72 @@
+---
+execution_id: 2026_07_15_17_05_07_WI_OVERRIDES_0018
+prompt_id: PROMPT(WI-OVERRIDES-0018:WI_OVERRIDES_0018)[2026-07-15T16:56:17-04:00]
+work_item: WI-OVERRIDES-0018
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/123
+commit: c35cd28
+created_at: 2026-07-15T17:05:07-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-OVERRIDES-0018.md
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Implement WI-OVERRIDES-0018: a versioned per-story override mechanism for
+judgment-call defects that the measured repair rules cannot safely cover,
+applied by the gather-time normalization hook after the rule pass and
+recorded in story metadata.
+
+# Result
+
+Implemented on branch xenotaur/feat/wi-overrides-0018 (PR #123, commit
+c35cd28):
+
+- `lcats/lcats/gatherers/overrides.py` — new module: `load_overrides`,
+  `apply_overrides`. Literal find->replace with rationale/reviewer
+  provenance; a non-matching `find` warns (`warnings.warn`) rather than
+  failing silently. Overrides live at `lcats/gatherers/overrides/`, never
+  under `data/`.
+- `lcats/lcats/gatherers/overrides/mass_quantities.json` — per-collection
+  overrides keyed by story id, seeded with the canonical Ângstrom ->
+  Ångstrom entry for `f_o_b_venus__bond` (Â = U+00C2 is not a clean
+  encoding-family decode, so it is a judgment call, not a rule).
+- `lcats/lcats/gatherers/normalization.py` — `normalize_story_dict` now takes
+  optional `collection`/`story_id` and applies overrides after rules,
+  recording override provenance separately under
+  `metadata['normalization']['overrides_applied']`. Backward-compatible.
+- `lcats/lcats/gatherers/downloaders.py`, `parser.py` — both write paths pass
+  `collection` + filename-stem `story_id`.
+- `lcats/docs/reference/gather-overrides.md` — schema and behavior documented.
+
+Acceptance criteria all met (covered by tests):
+- Real judgment-call override applied during normalization with provenance.
+- Overrides live outside data/ (survive cache-clear + regeneration).
+- Non-matching override surfaces a visible warning.
+- Rules and overrides compose with separate provenance; deterministic.
+
+# Validation
+
+- `scripts/lint` — ruff and black passed
+- `scripts/test` — 1282 tests OK (11 new in
+  tests/gatherers_tests/overrides_test.py)
+- `lrh validate` — 0 errors, 24 pre-existing owner-role warnings
+- Note: `scripts/format` (no-arg) trips a `set -u` unbound-variable bash bug
+  in this environment; formatting verified with `black` directly (pinned
+  25.11.0) and the pre-commit black hook passed on commit.
+
+# Follow-up
+
+- WI-RESIDUAL-0019 runs the pipeline over a fresh regeneration and populates
+  the override files from human review of residual defects.
+- WI-PROMOTE-0020 gates data/ -> corpora/ promotion on a passing survey.
+- On merge: set this record to landed and resolve WI-OVERRIDES-0018.
+
+# Recovery note
+
+At session resume the working tree had drifted to the stale local branch
+`claude/lcats-special-char-strategy-c18aa7` (957fdae, pre-workstream). The
+tree was clean and all prior work was safe on origin/main; recovered by
+branching xenotaur/feat/wi-overrides-0018 from origin/main.

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -36,6 +36,11 @@ classifiers = [
 [project.scripts]
 lcats = "lcats.cli:main"
 
+[tool.setuptools.package-data]
+# Ship the versioned gather-time override tables so they are present in
+# wheel/sdist installs, not only in source checkouts.
+"lcats.gatherers" = ["overrides/*.json"]
+
 [project.optional-dependencies]
 test = [
     "ruff",

--- a/lcats/tests/gatherers_tests/overrides_test.py
+++ b/lcats/tests/gatherers_tests/overrides_test.py
@@ -1,0 +1,159 @@
+"""Unit tests for lcats.gatherers.overrides and its normalization integration."""
+
+import json
+import unittest
+import warnings
+
+from lcats.gatherers import normalization
+from lcats.gatherers import overrides
+
+
+class ApplyOverridesTest(unittest.TestCase):
+    """Tests for the override application helper."""
+
+    def test_applies_entry_and_reports_provenance(self):
+        entries = [
+            {
+                "find": "Ângstrom",
+                "replace": "Ångstrom",
+                "rationale": "judgment call",
+                "reviewer": "tester",
+            }
+        ]
+
+        updated, applied = overrides.apply_overrides("1/100,000 Ângstrom unit", entries)
+
+        self.assertEqual("1/100,000 Ångstrom unit", updated)
+        self.assertEqual(1, len(applied))
+        self.assertEqual("Ângstrom", applied[0]["find"])
+        self.assertEqual("Ångstrom", applied[0]["replace"])
+        self.assertEqual("judgment call", applied[0]["rationale"])
+        self.assertEqual("tester", applied[0]["reviewer"])
+        self.assertEqual(1, applied[0]["count"])
+
+    def test_non_matching_entry_warns_and_is_skipped(self):
+        entries = [{"find": "not present", "replace": "X"}]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            updated, applied = overrides.apply_overrides("clean body", entries)
+
+        self.assertEqual("clean body", updated)
+        self.assertEqual([], applied)
+        self.assertEqual(1, len(caught))
+        self.assertIn("not present", str(caught[0].message))
+
+    def test_no_entries_returns_body_unchanged(self):
+        body = "unchanged body"
+
+        updated, applied = overrides.apply_overrides(body, [])
+
+        self.assertIs(body, updated)
+        self.assertEqual([], applied)
+
+    def test_multiple_occurrences_are_counted(self):
+        entries = [{"find": "foo", "replace": "bar"}]
+
+        updated, applied = overrides.apply_overrides("foo and foo again", entries)
+
+        self.assertEqual("bar and bar again", updated)
+        self.assertEqual(2, applied[0]["count"])
+
+
+class LoadOverridesTest(unittest.TestCase):
+    """Tests for loading the versioned per-collection override files."""
+
+    def test_missing_collection_returns_empty(self):
+        self.assertEqual({}, overrides.load_overrides("no_such_collection"))
+
+    def test_seed_angstrom_override_is_present(self):
+        loaded = overrides.load_overrides("mass_quantities")
+
+        self.assertIn("f_o_b_venus__bond", loaded)
+        entry = loaded["f_o_b_venus__bond"][0]
+        self.assertEqual("Ângstrom", entry["find"])
+        self.assertEqual("Ångstrom", entry["replace"])
+        self.assertTrue(entry["rationale"])
+
+    def test_override_files_are_valid_json_keyed_by_story(self):
+        for path in overrides.OVERRIDES_DIR.glob("*.json"):
+            with self.subTest(path=path.name):
+                data = json.loads(path.read_text(encoding="utf-8"))
+                self.assertIsInstance(data, dict)
+                for entries in data.values():
+                    self.assertIsInstance(entries, list)
+                    for entry in entries:
+                        self.assertIn("find", entry)
+                        self.assertIn("replace", entry)
+
+
+class NormalizeStoryDictOverridesTest(unittest.TestCase):
+    """Tests for override integration in the normalization hook."""
+
+    def test_seed_override_applied_during_normalization(self):
+        data = {
+            "name": "F.O.B. Venus",
+            "body": "rays go down to 1/100,000\nÂngstrom units",
+            "metadata": {"author": "Bond"},
+        }
+
+        result = normalization.normalize_story_dict(
+            data, collection="mass_quantities", story_id="f_o_b_venus__bond"
+        )
+
+        self.assertIn("Ångstrom", result["body"])
+        self.assertNotIn("Ângstrom", result["body"])
+        provenance = result["metadata"]["normalization"]
+        self.assertEqual(overrides.OVERRIDE_SOURCE, provenance["override_source"])
+        self.assertEqual("Ângstrom", provenance["overrides_applied"][0]["find"])
+
+    def test_rules_and_overrides_compose_with_separate_provenance(self):
+        data = {
+            "name": "Mixed",
+            "body": "blas√© eyes near 1/100,000\nÂngstrom",
+            "metadata": {"author": "X"},
+        }
+
+        result = normalization.normalize_story_dict(
+            data, collection="mass_quantities", story_id="f_o_b_venus__bond"
+        )
+
+        self.assertEqual("blasé eyes near 1/100,000\nÅngstrom", result["body"])
+        provenance = result["metadata"]["normalization"]
+        self.assertIn("rules_applied", provenance)
+        self.assertIn("overrides_applied", provenance)
+
+    def test_without_collection_and_story_id_overrides_are_skipped(self):
+        data = {
+            "name": "F.O.B. Venus",
+            "body": "1/100,000\nÂngstrom units",
+            "metadata": {"author": "Bond"},
+        }
+
+        result = normalization.normalize_story_dict(data)
+
+        # No rule matches bare "Ân", and overrides are not consulted, so the
+        # body and metadata pass through untouched.
+        self.assertEqual("1/100,000\nÂngstrom units", result["body"])
+        self.assertNotIn("normalization", result["metadata"])
+
+    def test_override_normalization_is_deterministic(self):
+        def fresh():
+            return {
+                "name": "F.O.B. Venus",
+                "body": "1/100,000\nÂngstrom units",
+                "metadata": {"author": "Bond"},
+            }
+
+        first = normalization.normalize_story_dict(
+            fresh(), collection="mass_quantities", story_id="f_o_b_venus__bond"
+        )
+        second = normalization.normalize_story_dict(
+            fresh(), collection="mass_quantities", story_id="f_o_b_venus__bond"
+        )
+
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/gatherers_tests/overrides_test.py
+++ b/lcats/tests/gatherers_tests/overrides_test.py
@@ -1,7 +1,10 @@
 """Unit tests for lcats.gatherers.overrides and its normalization integration."""
 
 import json
+import pathlib
+import tempfile
 import unittest
+import unittest.mock
 import warnings
 
 from lcats.gatherers import normalization
@@ -59,6 +62,31 @@ class ApplyOverridesTest(unittest.TestCase):
         self.assertEqual("bar and bar again", updated)
         self.assertEqual(2, applied[0]["count"])
 
+    def test_find_equal_replace_is_skipped_as_noop_with_warning(self):
+        # A stale no-op entry must not be recorded as applied, or callers would
+        # stamp provenance metadata onto an otherwise byte-identical body.
+        entries = [{"find": "same", "replace": "same"}]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            updated, applied = overrides.apply_overrides("this has same word", entries)
+
+        self.assertEqual("this has same word", updated)
+        self.assertEqual([], applied)
+        self.assertEqual(1, len(caught))
+        self.assertIn("no-op", str(caught[0].message))
+
+    def test_empty_find_is_skipped_with_warning(self):
+        entries = [{"find": "", "replace": "x"}]
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            updated, applied = overrides.apply_overrides("body", entries)
+
+        self.assertEqual("body", updated)
+        self.assertEqual([], applied)
+        self.assertEqual(1, len(caught))
+
 
 class LoadOverridesTest(unittest.TestCase):
     """Tests for loading the versioned per-collection override files."""
@@ -85,6 +113,73 @@ class LoadOverridesTest(unittest.TestCase):
                     for entry in entries:
                         self.assertIn("find", entry)
                         self.assertIn("replace", entry)
+
+    def test_repeated_loads_are_cached(self):
+        # load_overrides is called once per story during a gather; the parsed
+        # result is cached per collection for the process lifetime.
+        first = overrides.load_overrides("mass_quantities")
+        second = overrides.load_overrides("mass_quantities")
+
+        self.assertIs(first, second)
+
+
+class OverridesTempDirTest(unittest.TestCase):
+    """Tests that point OVERRIDES_DIR at a temp dir for isolated fixtures."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_dir = pathlib.Path(self._tmp.name)
+        self._patch = unittest.mock.patch.object(
+            overrides, "OVERRIDES_DIR", self.tmp_dir
+        )
+        self._patch.start()
+        overrides.load_overrides.cache_clear()
+
+    def tearDown(self):
+        self._patch.stop()
+        overrides.load_overrides.cache_clear()
+        self._tmp.cleanup()
+
+    def _write_collection(self, collection, payload):
+        (self.tmp_dir / f"{collection}.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    def test_noop_override_leaves_story_byte_identical(self):
+        # A collection whose only override is a no-op must not stamp metadata,
+        # so an otherwise-clean story stays byte-identical.
+        self._write_collection("demo", {"story": [{"find": "x", "replace": "x"}]})
+        data = {
+            "name": "S",
+            "body": "clean body with x present",
+            "metadata": {"author": "A"},
+        }
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = normalization.normalize_story_dict(
+                data, collection="demo", story_id="story"
+            )
+
+        self.assertEqual("clean body with x present", result["body"])
+        self.assertNotIn("normalization", result["metadata"])
+
+    def test_real_override_from_temp_collection_applies(self):
+        self._write_collection(
+            "demo",
+            {"story": [{"find": "teh", "replace": "the", "reviewer": "t"}]},
+        )
+        data = {"name": "S", "body": "teh cat", "metadata": {}}
+
+        result = normalization.normalize_story_dict(
+            data, collection="demo", story_id="story"
+        )
+
+        self.assertEqual("the cat", result["body"])
+        self.assertEqual(
+            "the",
+            result["metadata"]["normalization"]["overrides_applied"][0]["replace"],
+        )
 
 
 class NormalizeStoryDictOverridesTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements [WI-OVERRIDES-0018](https://github.com/xenotaur/LCATS/blob/main/lcats/project/work_items/proposed/WI-OVERRIDES-0018.md) under WS-SPECIALS-CLEANUP — a versioned per-story override mechanism for judgment-call defects the measured repair rules cannot safely cover.

Prompt ID: `PROMPT(WI-OVERRIDES-0018:WI_OVERRIDES_0018)[2026-07-15T16:56:17-04:00]`

## Motivating case

`Ângstrom` in `f_o_b_venus__bond`: the stray `Â` (U+00C2) before `ngstrom` is **not** a clean encoding-family decode (unlike `Â°`→° or `√©`→é), so it can't be a repair rule — a human reads the intended unit as `Ångstrom`. That's exactly what an override is for.

## Changes

- **New `lcats/lcats/gatherers/overrides.py`** — `load_overrides(collection)` + `apply_overrides(body, entries)`. Literal `find`→`replace` with `rationale`/`reviewer` provenance; a `find` absent from the body is **skipped with a `warnings.warn`**, not a silent no-op.
- **New `lcats/lcats/gatherers/overrides/mass_quantities.json`** — per-collection overrides keyed by story id, seeded with the canonical `Ângstrom` entry. Lives under the package, **never under `data/`**, so it survives cache-clear + regeneration and is never discovered as story JSON.
- **`normalization.py`** — `normalize_story_dict(data, collection=None, story_id=None)` applies overrides **after** the rule pass; override provenance recorded separately under `metadata.normalization.overrides_applied`. Backward-compatible: no-arg callers behave exactly as before.
- **`downloaders.py` / `parser.py`** — pass `collection` + filename-stem `story_id` at both write paths.
- **`docs/reference/gather-overrides.md`** — schema + behavior documented for contributors.

## Acceptance evidence (all met)

- **Real judgment-call override applied with provenance:** `Ângstrom`→`Ångstrom` fires for `f_o_b_venus__bond`, recorded in metadata.
- **Overrides live outside `data/`:** under `lcats/gatherers/overrides/`.
- **Non-matching override warns:** verified via `assertWarns`-style test.
- Rules + overrides compose with separate provenance; deterministic across regenerations.

## Non-Goals honored

Bulk population from human review is WI-RESIDUAL-0019; only the one canonical seed entry is included here. No corpus-JSON rewrite (applied in-memory pre-write); no CI changes.

## Validation

- `scripts/lint` — passed
- `scripts/test` — **1,282 tests OK** (11 new)
- `lrh validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)