### PR TITLE
WI-PROMOTE-0020: Survey-gated promotion from data/ to corpora/

### DIFF
--- a/lcats/docs/reference/corpus-promotion.md
+++ b/lcats/docs/reference/corpus-promotion.md
@@ -16,15 +16,23 @@ lcats promote [collection ...] [--source data/] [--dest ../corpora] [--dry-run]
 
 - With no `collection` arguments, every subdirectory under `--source` is
   considered.
-- Each collection is surveyed and promoted **independently**: a collection
-  with any mojibake (`likely_repairable`) finding is skipped and its findings
-  are printed to stderr; every other requested collection still promotes.
+- Every requested collection is surveyed first, as one complete phase; only
+  once all surveys finish does copying begin. Each collection is still gated
+  **independently** (a deliberate, documented mode — not an all-or-nothing
+  whole-corpus gate): a collection with any mojibake (`likely_repairable`)
+  finding is skipped and its findings are printed to stderr, while every
+  other clean collection is still promoted, so an unrelated collection that
+  still needs regeneration doesn't hold the rest hostage.
 - A clean collection **wholesale-replaces** its `corpora/` counterpart (the
   destination directory is removed, then the source directory is copied), so
   files removed from `data/` since the last promotion don't linger in
   `corpora/`.
-- Exit code is `0` only when every considered collection promoted; `1` if any
-  collection was blocked.
+- Refuses to run (exit `2`) if `--source` and `--dest` resolve to the same
+  directory or are nested inside one another — this would otherwise delete
+  the source before the copy could run.
+- Exit code is `0` when every considered collection promoted, `1` if any
+  collection was blocked, `2` on a usage/environment error (missing source
+  directory, unknown collection name, unsafe source/dest paths).
 - `--dry-run` surveys and reports without copying any files.
 
 This tool builds and gates promotion; it does not decide *when* to promote —

--- a/lcats/docs/reference/corpus-promotion.md
+++ b/lcats/docs/reference/corpus-promotion.md
@@ -1,0 +1,65 @@
+# Corpus promotion: data/ to corpora/
+
+`corpora/` is a periodic release snapshot; `data/` is the live working corpus,
+cleared and regenerated after major changes (see `project/design/design.md`'s
+State and Persistence Boundary). Promotion copies collections from `data/`
+into `corpora/`, gated on a passing special-character survey, so stale
+encoding damage cannot silently re-enter the release snapshot the way the
+pre-2026-07 `corpora/` snapshot did (148 stories of stale mojibake, from a
+promotion that happened without a quality gate).
+
+## Command
+
+```bash
+lcats promote [collection ...] [--source data/] [--dest ../corpora] [--dry-run]
+```
+
+- With no `collection` arguments, every subdirectory under `--source` is
+  considered.
+- Each collection is surveyed and promoted **independently**: a collection
+  with any mojibake (`likely_repairable`) finding is skipped and its findings
+  are printed to stderr; every other requested collection still promotes.
+- A clean collection **wholesale-replaces** its `corpora/` counterpart (the
+  destination directory is removed, then the source directory is copied), so
+  files removed from `data/` since the last promotion don't linger in
+  `corpora/`.
+- Exit code is `0` only when every considered collection promoted; `1` if any
+  collection was blocked.
+- `--dry-run` surveys and reports without copying any files.
+
+This tool builds and gates promotion; it does not decide *when* to promote —
+running it (for real, not `--dry-run`) is a release-time human action.
+
+## Collection-name mapping
+
+The mapping is **identity**: a `data/` collection promotes to `corpora/` under
+the same name. There is no rename or merge table.
+
+This was resolved 2026-07-16, before any external LCATS release, by adopting
+`data/`'s current names as canonical everywhere. Two `corpora/` collections
+previously used older, divergent names:
+
+| `data/` collection (canonical) | Legacy `corpora/` name | Relationship |
+|---|---|---|
+| `ohenry-four_million` (25 stories) | `ohenry` (25 stories) | Same 25 stories, identical filenames — a straight rename. |
+| `ohenry-whirligigs` (24 stories) | *(none)* | A second O. Henry collection ("Whirligigs"), never previously promoted — not a merge target. |
+| `wilde_happy_prince` (5 stories) | `wilde` (5 stories) | Same 5 stories, identical filenames — a straight rename. |
+
+All other collections (`anderson`, `chesterton`, `grimm`, `hemingway`,
+`london`, `lovecraft`, `mass_quantities`, `sherlock`, `wodehouse`) already use
+identical names in both trees.
+
+### One-time manual cleanup
+
+`lcats promote` only ever touches the destination directory matching a source
+collection's own name — it does not know that `corpora/ohenry` and
+`corpora/wilde` are the old identities of `ohenry-four_million` and
+`wilde_happy_prince`, and it will not delete them automatically. The first
+real promotion under this scheme should include, as part of that same change:
+
+```bash
+git rm -r corpora/ohenry corpora/wilde
+lcats promote  # populates ohenry-four_million, ohenry-whirligigs, wilde_happy_prince, ...
+```
+
+This is a one-time historical correction, not a recurring promotion step.

--- a/lcats/lcats/analysis/corpus/promote.py
+++ b/lcats/lcats/analysis/corpus/promote.py
@@ -125,6 +125,34 @@ class PromotionReport:
         return not self.blocked
 
 
+def _validate_distinct_roots(
+    source_root: pathlib.Path, dest_root: pathlib.Path
+) -> None:
+    """Raise ValueError if source_root and dest_root are equal or nested.
+
+    ``_copy_collection`` removes the destination before copying; if source and
+    destination resolve to the same directory (or one contains the other), a
+    per-collection ``rmtree`` would delete source data before ``copytree`` can
+    run it, destroying the collection with no recovery path.
+    """
+    resolved_source = source_root.resolve()
+    resolved_dest = dest_root.resolve()
+    if resolved_source == resolved_dest:
+        raise ValueError(
+            f"--source and --dest resolve to the same directory "
+            f"({resolved_source}); refusing to promote to avoid deleting "
+            "the source before copying."
+        )
+    if (
+        resolved_dest in resolved_source.parents
+        or resolved_source in resolved_dest.parents
+    ):
+        raise ValueError(
+            f"--source ({resolved_source}) and --dest ({resolved_dest}) are "
+            "nested inside one another; refusing to promote."
+        )
+
+
 def _copy_collection(source_dir: pathlib.Path, dest_dir: pathlib.Path) -> None:
     """Wholesale-replace dest_dir with a copy of source_dir's contents."""
     if dest_dir.exists():
@@ -140,9 +168,15 @@ def promote_collections(
 ) -> PromotionReport:
     """Survey and promote data/ collections into corpora/.
 
-    Each requested collection is surveyed independently; a collection with any
-    blocking (mojibake) finding is skipped and reported, all others are
-    promoted. Promotion wholesale-replaces the destination collection
+    Every requested collection is surveyed first; only once all surveys are
+    complete does copying begin, so a mid-run error cannot leave a collection
+    half-copied. Each collection is still gated **independently**: a
+    collection with any blocking (mojibake) finding is skipped and reported,
+    while every other clean collection is still promoted -- this is a
+    deliberate, documented mode (see docs/reference/corpus-promotion.md), not
+    an all-or-nothing whole-corpus gate, so that already-clean collections
+    are not held hostage by an unrelated collection that still needs
+    regeneration. Promotion wholesale-replaces the destination collection
     directory under its identity-mapped name (see ``destination_name``) so
     stale files from a prior promotion cannot linger.
 
@@ -158,25 +192,33 @@ def promote_collections(
     Returns:
         A PromotionReport listing promoted collection names and blocked
         CollectionSurveyResult entries.
+
+    Raises:
+        ValueError: If source_root and dest_root are the same or nested.
     """
+    _validate_distinct_roots(source_root, dest_root)
+
     if collection_names is None:
         collection_names = sorted(
             entry.name for entry in source_root.iterdir() if entry.is_dir()
         )
 
-    promoted: list[str] = []
-    blocked: list[CollectionSurveyResult] = []
     allowlist = specials.load_allowlist_config(specials.default_allowlist_config_path())
 
-    for name in collection_names:
-        collection_dir = source_root / name
-        result = survey_collection(collection_dir, allowlist=allowlist)
+    results = [
+        survey_collection(source_root / name, allowlist=allowlist)
+        for name in collection_names
+    ]
+
+    promoted: list[str] = []
+    blocked: list[CollectionSurveyResult] = []
+    for name, result in zip(collection_names, results):
         if not result.clean:
             blocked.append(result)
             continue
 
         if not dry_run:
-            _copy_collection(collection_dir, dest_root / destination_name(name))
+            _copy_collection(source_root / name, dest_root / destination_name(name))
         promoted.append(name)
 
     return PromotionReport(promoted=tuple(promoted), blocked=tuple(blocked))

--- a/lcats/lcats/analysis/corpus/promote.py
+++ b/lcats/lcats/analysis/corpus/promote.py
@@ -1,0 +1,182 @@
+"""Survey-gated promotion of data/ collections into corpora/.
+
+``corpora/`` is a periodic release snapshot; ``data/`` is the live working
+corpus, cleared and regenerated after major changes (see
+``project/design/design.md``'s State and Persistence Boundary). Promotion must
+be gated on a passing special-character survey, or drift like the pre-2026-07
+``corpora/`` snapshot (148 stories of stale mojibake) recurs at every release.
+
+Collection-name mapping is identity: the ``data/`` collection name is the
+``corpora/`` collection name. As of 2026-07 (before any external release) two
+legacy ``corpora/`` names diverged from their current ``data/`` counterparts
+(``corpora/ohenry`` for ``data/ohenry-four_million``,
+``corpora/wilde`` for ``data/wilde_happy_prince``), and ``data/ohenry-whirligigs``
+-- a second O. Henry collection, not a merge target -- was never promoted at
+all. See ``docs/reference/corpus-promotion.md`` for the one-time manual cleanup
+this implies at the first gated promotion.
+"""
+
+import dataclasses
+import pathlib
+import shutil
+
+from lcats.analysis.corpus import cli
+from lcats.analysis.corpus import discovery
+from lcats.analysis.corpus import specials
+
+BLOCKING_CLASSIFICATION = "likely_repairable"
+
+
+def destination_name(source_collection_name: str) -> str:
+    """Return the corpora/ directory name for a data/ collection name.
+
+    Identity mapping: every collection promotes under its data/ name.
+    """
+    return source_collection_name
+
+
+@dataclasses.dataclass(frozen=True)
+class BlockingFinding:
+    """One mojibake finding that blocks a collection from promotion."""
+
+    story_path: pathlib.Path
+    codepoint: str
+    character: str
+    context: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CollectionSurveyResult:
+    """Survey outcome for one collection directory."""
+
+    collection: str
+    story_count: int
+    findings: tuple[BlockingFinding, ...]
+
+    @property
+    def clean(self) -> bool:
+        """Return True when the collection has no blocking findings."""
+        return not self.findings
+
+
+def survey_collection(
+    collection_dir: pathlib.Path,
+    allowlist: specials.AllowlistConfig | None = None,
+) -> CollectionSurveyResult:
+    """Survey one collection directory for blocking (mojibake) findings.
+
+    Scoped to ``likely_repairable`` findings only, matching this work item's
+    mojibake-only gate; structural/boundary checks are a separate concern.
+
+    Args:
+        collection_dir: Path to one collection directory under data/.
+        allowlist: Allowlist to apply; defaults to the packaged corpus
+            allowlist (the same default ``lcats survey`` uses).
+
+    Returns:
+        A CollectionSurveyResult with any blocking findings.
+    """
+    effective_allowlist = (
+        allowlist
+        if allowlist is not None
+        else specials.load_allowlist_config(specials.default_allowlist_config_path())
+    )
+    story_paths = discovery.find_corpus_stories(collection_dir)
+    findings: list[BlockingFinding] = []
+    for story_path in story_paths:
+        data = cli.read_story_data(story_path)
+        text = cli.coerce_story_text(data.get("body", ""))
+        for result in specials.iter_special_characters(
+            text=text,
+            allow_smart=True,
+            excluded=set(),
+            allowlist=effective_allowlist,
+            context=10,
+            name_width=0,
+        ):
+            if result.classification != BLOCKING_CLASSIFICATION:
+                continue
+            findings.append(
+                BlockingFinding(
+                    story_path=story_path,
+                    codepoint=result.codepoint,
+                    character=result.character,
+                    context=result.context,
+                )
+            )
+
+    return CollectionSurveyResult(
+        collection=collection_dir.name,
+        story_count=len(story_paths),
+        findings=tuple(findings),
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class PromotionReport:
+    """Outcome of a promotion run across one or more collections."""
+
+    promoted: tuple[str, ...]
+    blocked: tuple[CollectionSurveyResult, ...]
+
+    @property
+    def all_promoted(self) -> bool:
+        """Return True when every considered collection promoted cleanly."""
+        return not self.blocked
+
+
+def _copy_collection(source_dir: pathlib.Path, dest_dir: pathlib.Path) -> None:
+    """Wholesale-replace dest_dir with a copy of source_dir's contents."""
+    if dest_dir.exists():
+        shutil.rmtree(dest_dir)
+    shutil.copytree(source_dir, dest_dir)
+
+
+def promote_collections(
+    source_root: pathlib.Path,
+    dest_root: pathlib.Path,
+    collection_names: list[str] | None = None,
+    dry_run: bool = False,
+) -> PromotionReport:
+    """Survey and promote data/ collections into corpora/.
+
+    Each requested collection is surveyed independently; a collection with any
+    blocking (mojibake) finding is skipped and reported, all others are
+    promoted. Promotion wholesale-replaces the destination collection
+    directory under its identity-mapped name (see ``destination_name``) so
+    stale files from a prior promotion cannot linger.
+
+    Args:
+        source_root: Root directory containing collection subdirectories
+            (typically data/).
+        dest_root: Root directory to promote clean collections into
+            (typically corpora/).
+        collection_names: Collection directory names to consider; defaults to
+            every subdirectory of source_root.
+        dry_run: When True, survey and report but do not copy any files.
+
+    Returns:
+        A PromotionReport listing promoted collection names and blocked
+        CollectionSurveyResult entries.
+    """
+    if collection_names is None:
+        collection_names = sorted(
+            entry.name for entry in source_root.iterdir() if entry.is_dir()
+        )
+
+    promoted: list[str] = []
+    blocked: list[CollectionSurveyResult] = []
+    allowlist = specials.load_allowlist_config(specials.default_allowlist_config_path())
+
+    for name in collection_names:
+        collection_dir = source_root / name
+        result = survey_collection(collection_dir, allowlist=allowlist)
+        if not result.clean:
+            blocked.append(result)
+            continue
+
+        if not dry_run:
+            _copy_collection(collection_dir, dest_root / destination_name(name))
+        promoted.append(name)
+
+    return PromotionReport(promoted=tuple(promoted), blocked=tuple(blocked))

--- a/lcats/lcats/analysis/corpus/promote_cli.py
+++ b/lcats/lcats/analysis/corpus/promote_cli.py
@@ -1,0 +1,81 @@
+"""CLI wrapper for survey-gated data/ -> corpora/ promotion."""
+
+import argparse
+import pathlib
+import sys
+
+from lcats.analysis.corpus import promote
+from lcats.utils import env
+
+
+def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
+    """Build parser for the promote command."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Promote data/ collections into corpora/, gated on a passing "
+            "special-character survey. A collection with any mojibake "
+            "finding is skipped and reported rather than promoted; clean "
+            "collections wholesale-replace their corpora/ counterpart."
+        ),
+        add_help=add_help,
+    )
+    parser.add_argument(
+        "collections",
+        nargs="*",
+        help="Collection names to consider. Defaults to every collection under --source.",
+    )
+    parser.add_argument(
+        "--source",
+        type=pathlib.Path,
+        default=env.data_root(),
+        help="Root directory of source collections (default: data/).",
+    )
+    parser.add_argument(
+        "--dest",
+        type=pathlib.Path,
+        default=env.corpora_root(),
+        help="Root directory to promote clean collections into (default: ../corpora).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Survey and report without copying any files.",
+    )
+    return parser
+
+
+def run(argv=None, parsed_args=None) -> int:
+    """Run survey-gated promotion. Returns 0 if all considered collections promoted."""
+    parser = build_parser()
+    args = parsed_args if parsed_args is not None else parser.parse_args(argv)
+
+    collection_names = args.collections or None
+    report = promote.promote_collections(
+        source_root=args.source,
+        dest_root=args.dest,
+        collection_names=collection_names,
+        dry_run=args.dry_run,
+    )
+
+    for name in report.promoted:
+        verb = "would promote" if args.dry_run else "promoted"
+        print(f"{verb}: {name} -> {promote.destination_name(name)}")
+
+    for result in report.blocked:
+        print(
+            f"blocked: {result.collection} "
+            f"({len(result.findings)} finding(s) across {result.story_count} stories)",
+            file=sys.stderr,
+        )
+        for finding in result.findings:
+            print(
+                f"  {finding.story_path}: {finding.codepoint} {finding.character!r} "
+                f"context={finding.context!r}",
+                file=sys.stderr,
+            )
+
+    return 0 if report.all_promoted else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/lcats/lcats/analysis/corpus/promote_cli.py
+++ b/lcats/lcats/analysis/corpus/promote_cli.py
@@ -49,32 +49,38 @@ def run(argv=None, parsed_args=None) -> int:
     parser = build_parser()
     args = parsed_args if parsed_args is not None else parser.parse_args(argv)
 
-    collection_names = args.collections or None
-    report = promote.promote_collections(
-        source_root=args.source,
-        dest_root=args.dest,
-        collection_names=collection_names,
-        dry_run=args.dry_run,
-    )
-
-    for name in report.promoted:
-        verb = "would promote" if args.dry_run else "promoted"
-        print(f"{verb}: {name} -> {promote.destination_name(name)}")
-
-    for result in report.blocked:
-        print(
-            f"blocked: {result.collection} "
-            f"({len(result.findings)} finding(s) across {result.story_count} stories)",
-            file=sys.stderr,
+    try:
+        collection_names = args.collections or None
+        report = promote.promote_collections(
+            source_root=args.source,
+            dest_root=args.dest,
+            collection_names=collection_names,
+            dry_run=args.dry_run,
         )
-        for finding in result.findings:
+
+        for name in report.promoted:
+            verb = "would promote" if args.dry_run else "promoted"
+            print(f"{verb}: {name} -> {promote.destination_name(name)}")
+
+        for result in report.blocked:
             print(
-                f"  {finding.story_path}: {finding.codepoint} {finding.character!r} "
-                f"context={finding.context!r}",
+                f"blocked: {result.collection} "
+                f"({len(result.findings)} finding(s) across {result.story_count} stories)",
                 file=sys.stderr,
             )
+            for finding in result.findings:
+                print(
+                    f"  {finding.story_path}: {finding.codepoint} {finding.character!r} "
+                    f"context={finding.context!r}",
+                    file=sys.stderr,
+                )
 
-    return 0 if report.all_promoted else 1
+        return 0 if report.all_promoted else 1
+    except BrokenPipeError:
+        return 141
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -6,6 +6,7 @@ import sys
 
 from lcats.analysis.corpus import assess_cli
 from lcats.analysis.corpus import cli as corpus_cli
+from lcats.analysis.corpus import promote_cli
 from lcats.analysis.corpus import repairs_cli
 import lcats.gatherers.main
 import lcats.inspect
@@ -51,6 +52,10 @@ def _handle_assess(args):
 
 def _handle_repair_specials(args):
     return "", repairs_cli.run(parsed_args=args)
+
+
+def _handle_promote(args):
+    return "", promote_cli.run(parsed_args=args)
 
 
 def _handle_meta_register(args):
@@ -225,6 +230,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     repair_specials_parser.set_defaults(handler=_handle_repair_specials)
     command_parsers["repair-specials"] = repair_specials_parser
+
+    promote_parent = promote_cli.build_parser(add_help=False)
+    promote_parser = subparsers.add_parser(
+        "promote",
+        parents=[promote_parent],
+        help="Promote data/ collections into corpora/, gated on a passing specials survey.",
+        description=(
+            "Promote data/ collections into corpora/. A collection with any "
+            "mojibake finding is skipped and reported rather than promoted; "
+            "clean collections wholesale-replace their corpora/ counterpart."
+        ),
+    )
+    promote_parser.set_defaults(handler=_handle_promote)
+    command_parsers["promote"] = promote_parser
 
     meta_parser = subparsers.add_parser(
         "meta",

--- a/lcats/project/executions/AD_HOC/2026_07_16_11_58_28_WI_PROMOTE_0020_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_16_11_58_28_WI_PROMOTE_0020_REVIEW.md
@@ -1,0 +1,65 @@
+---
+execution_id: 2026_07_16_11_58_28_WI_PROMOTE_0020_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_PROMOTE_0020_REVIEW)[2026-07-16T11:53:19-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_16_11_13_20_WI_PROMOTE_0020
+pr: https://github.com/xenotaur/LCATS/pull/125
+commit: 2b02ddc
+created_at: 2026-07-16T11:58:28-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/125
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Address three review comments on PR #125 (WI-PROMOTE-0020) via
+`lrh request review_response`. Two from copilot-pull-request-reviewer, one
+(P2) from chatgpt-codex-connector.
+
+# Result
+
+All three fixed in commit 2b02ddc, each confirmed against code (and, for the
+first, reproduced) before fixing:
+
+- Data-loss guard (r3596690978) -- reproduced: `_copy_collection`'s
+  rmtree-then-copytree deleted a source collection's story data with no
+  recovery when `--source`/`--dest` resolved to the same directory.
+  Added `_validate_distinct_roots()`, raising `ValueError` when source and
+  dest are equal or nested; checked once at the top of
+  `promote_collections()`.
+- CLI exception handling (r3596691018) -- confirmed `promote_cli.run()` had
+  no try/except, producing raw tracebacks for a missing `--source` or a
+  typo'd collection name. Wrapped in the `except BrokenPipeError` /
+  `except Exception -> "error: {exc}"` + exit 2 pattern already used by
+  `assess_cli.py` and `cli.run_survey`.
+- Partial mutation on a failed run (r3596708117, P2) -- a design trade-off,
+  confirmed at the Step 4 gate with the user before fixing. Restructured
+  `promote_collections()` into two phases (survey all requested collections,
+  then copy only the clean ones), so a mid-run exception can no longer leave
+  a half-copied state. Kept per-collection independent gating as the
+  intended, now explicitly documented, mode rather than switching to an
+  all-or-nothing whole-corpus gate -- the user confirmed this preserves the
+  practical value against today's actual data/ state (only mass_quantities
+  still needs regeneration; an all-or-nothing gate would block promoting
+  every other already-clean collection until that lands).
+
+5 new tests added (17 total in promote_test.py): same-directory guard,
+nested-path guard, survey-before-copy ordering, and two CLI
+clean-error-message tests. docs/reference/corpus-promotion.md updated for
+the new exit code 2 and refusal cases.
+
+No comments skipped.
+
+# Validation
+
+- `black --check` -- clean after formatting
+- `scripts/lint` -- ruff and black passed
+- `scripts/test` -- 1314 tests OK (5 new)
+- `lrh validate` -- 0 errors, 24 pre-existing owner-role warnings
+
+# Follow-up
+
+- On merge: set this record and the primary WI-PROMOTE-0020 record to
+  landed, and resolve WI-PROMOTE-0020.

--- a/lcats/project/executions/WI-PROMOTE-0020/2026_07_16_11_13_20_WI_PROMOTE_0020.md
+++ b/lcats/project/executions/WI-PROMOTE-0020/2026_07_16_11_13_20_WI_PROMOTE_0020.md
@@ -1,0 +1,68 @@
+---
+execution_id: 2026_07_16_11_13_20_WI_PROMOTE_0020
+prompt_id: PROMPT(WI-PROMOTE-0020:WI_PROMOTE_0020)[2026-07-16T03:34:26-04:00]
+work_item: WI-PROMOTE-0020
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/125
+commit: 436e1d3
+created_at: 2026-07-16T11:13:20-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-PROMOTE-0020.md
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Implement WI-PROMOTE-0020: the survey-gated data/ -> corpora/ promotion tool,
+the last work item in WS-SPECIALS-CLEANUP's burn-down.
+
+# Result
+
+Implemented on branch xenotaur/feat/wi-promote-0020 (PR #125, commit
+436e1d3). Collection-name mapping resolved per user direction (no external
+release yet, so free to adopt data/'s current names as canonical):
+
+- Verified against the real trees before deciding: `corpora/ohenry` (25
+  stories) is byte-identical in filenames to `data/ohenry-four_million`;
+  `corpora/wilde` (5 stories) likewise matches `data/wilde_happy_prince`.
+  `data/ohenry-whirligigs` (24 stories) has no corpora/ counterpart at all --
+  a second O. Henry collection never promoted, not a merge target.
+- Mapping is identity: `data/`'s current names become canonical everywhere.
+  The two legacy corpora/ directories are documented as a one-time manual
+  cleanup at the first real promotion, not auto-deleted by the tool.
+
+- `lcats/lcats/analysis/corpus/promote.py` (new) --
+  `survey_collection()` (mojibake-only gate, `likely_repairable` findings,
+  packaged allowlist), `promote_collections()` (per-collection independent
+  gating; wholesale-replace on promotion).
+- `lcats/lcats/analysis/corpus/promote_cli.py` (new) -- CLI wrapper.
+- `lcats/lcats/cli.py` -- wires `lcats promote [collection...] [--source]
+  [--dest] [--dry-run]`.
+- `lcats/tests/analysis_tests/promote_test.py` (new, 12 tests) -- including
+  the required seeded-defect gate test.
+- `lcats/docs/reference/corpus-promotion.md` (new) -- procedure, mapping
+  table, one-time cleanup note.
+
+Verified against the real corpus via `--dry-run` (no writes): anderson,
+wodehouse, ohenry-four_million report promotable; mass_quantities is
+correctly blocked (59 real findings -- it hasn't undergone the literal
+regeneration WI-RESIDUAL-0019 documented as a follow-up). Confirmed
+corpora/ was not touched (git status).
+
+# Validation
+
+- `scripts/lint` -- ruff and black passed
+- `scripts/test` -- 1309 tests OK (12 new)
+- `lrh validate` -- 0 errors, 24 pre-existing owner-role warnings
+
+# Follow-up
+
+- The actual first real promotion (git rm corpora/ohenry corpora/wilde +
+  lcats promote) is a release-time human action, out of this WI's scope.
+- mass_quantities needs the literal `lcats gather` regeneration
+  (WI-RESIDUAL-0019 follow-up) before it will pass the promotion gate.
+- On merge: set this record to landed and resolve WI-PROMOTE-0020. This is
+  the last of the five WS-SPECIALS-CLEANUP burn-down items; the workstream
+  itself stays open due to three pre-existing legacy-adopted items
+  (WI-SPANOPS-0002, WI-REVIEW-0003, WI-APPLY-0005).

--- a/lcats/tests/analysis_tests/promote_test.py
+++ b/lcats/tests/analysis_tests/promote_test.py
@@ -1,0 +1,210 @@
+"""Unit tests for lcats.analysis.corpus.promote and promote_cli."""
+
+import io
+import json
+import pathlib
+import tempfile
+import unittest
+import unittest.mock
+
+from lcats.analysis.corpus import promote
+from lcats.analysis.corpus import promote_cli
+
+
+def _write_story(collection_dir: pathlib.Path, name: str, body: str) -> None:
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    story_path = collection_dir / f"{name}.json"
+    story_path.write_text(
+        json.dumps({"name": name, "body": body, "metadata": {}}),
+        encoding="utf-8",
+    )
+
+
+class DestinationNameTest(unittest.TestCase):
+    """Tests for the collection-name mapping."""
+
+    def test_mapping_is_identity_for_every_name(self):
+        # As of 2026-07 (pre-external-release), data/'s current names are
+        # canonical everywhere -- no rename/merge table.
+        for name in [
+            "ohenry-four_million",
+            "ohenry-whirligigs",
+            "wilde_happy_prince",
+            "anderson",
+        ]:
+            with self.subTest(name=name):
+                self.assertEqual(name, promote.destination_name(name))
+
+
+class SurveyCollectionTest(unittest.TestCase):
+    """Tests for the per-collection mojibake survey gate."""
+
+    def test_clean_collection_has_no_findings(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collection_dir = pathlib.Path(tmpdir) / "clean_collection"
+            _write_story(collection_dir, "story_one", "A perfectly clean sentence.")
+
+            result = promote.survey_collection(collection_dir)
+
+            self.assertTrue(result.clean)
+            self.assertEqual((), result.findings)
+            self.assertEqual(1, result.story_count)
+
+    def test_mojibake_collection_reports_blocking_findings(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collection_dir = pathlib.Path(tmpdir) / "damaged_collection"
+            _write_story(collection_dir, "story_one", "them a resumÃ©.")
+
+            result = promote.survey_collection(collection_dir)
+
+            self.assertFalse(result.clean)
+            # The mojibake marker and its continuation byte are each reported
+            # as a separate finding (Ã and © in "resumÃ©").
+            self.assertEqual(2, len(result.findings))
+            self.assertEqual(
+                {"Ã", "©"}, {finding.character for finding in result.findings}
+            )
+
+    def test_legitimate_accented_letters_do_not_block(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collection_dir = pathlib.Path(tmpdir) / "legit_collection"
+            _write_story(collection_dir, "story_one", "café, señorita, façade")
+
+            result = promote.survey_collection(collection_dir)
+
+            self.assertTrue(result.clean)
+
+
+class PromoteCollectionsTest(unittest.TestCase):
+    """Tests for the survey-gated promotion pass (acceptance criteria)."""
+
+    def test_seeded_defect_blocks_promotion(self):
+        # WI-PROMOTE-0020 acceptance: a seeded-defect test proves the gate
+        # blocks promotion of damaged text.
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            _write_story(source_root / "damaged", "story_one", "them a resumÃ©.")
+
+            report = promote.promote_collections(source_root, dest_root)
+
+            self.assertEqual((), report.promoted)
+            self.assertEqual(1, len(report.blocked))
+            self.assertEqual("damaged", report.blocked[0].collection)
+            self.assertFalse((dest_root / "damaged").exists())
+
+    def test_clean_collection_is_promoted(self):
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            _write_story(source_root / "clean", "story_one", "A clean sentence.")
+
+            report = promote.promote_collections(source_root, dest_root)
+
+            self.assertEqual(("clean",), report.promoted)
+            self.assertEqual((), report.blocked)
+            self.assertTrue(report.all_promoted)
+            promoted_story = dest_root / "clean" / "story_one.json"
+            self.assertTrue(promoted_story.exists())
+            self.assertEqual(
+                "A clean sentence.",
+                json.loads(promoted_story.read_text(encoding="utf-8"))["body"],
+            )
+
+    def test_mixed_collections_promote_clean_and_block_damaged_independently(self):
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            _write_story(source_root / "clean", "story_one", "A clean sentence.")
+            _write_story(source_root / "damaged", "story_one", "them a resumÃ©.")
+
+            report = promote.promote_collections(source_root, dest_root)
+
+            self.assertEqual(("clean",), report.promoted)
+            self.assertEqual(1, len(report.blocked))
+            self.assertFalse(report.all_promoted)
+            self.assertTrue((dest_root / "clean").exists())
+            self.assertFalse((dest_root / "damaged").exists())
+
+    def test_dry_run_does_not_copy_clean_collections(self):
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            _write_story(source_root / "clean", "story_one", "A clean sentence.")
+
+            report = promote.promote_collections(source_root, dest_root, dry_run=True)
+
+            self.assertEqual(("clean",), report.promoted)
+            self.assertFalse((dest_root / "clean").exists())
+
+    def test_promotion_wholesale_replaces_stale_destination_files(self):
+        # A file present in a prior promotion but absent from the current
+        # source must not survive re-promotion.
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            stale_dest = dest_root / "clean"
+            stale_dest.mkdir(parents=True)
+            (stale_dest / "removed_story.json").write_text("{}", encoding="utf-8")
+            _write_story(source_root / "clean", "story_one", "A clean sentence.")
+
+            promote.promote_collections(source_root, dest_root)
+
+            self.assertFalse((dest_root / "clean" / "removed_story.json").exists())
+            self.assertTrue((dest_root / "clean" / "story_one.json").exists())
+
+    def test_collection_names_scopes_to_requested_collections(self):
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            _write_story(source_root / "one", "story_one", "A clean sentence.")
+            _write_story(source_root / "two", "story_one", "Another clean sentence.")
+
+            report = promote.promote_collections(
+                source_root, dest_root, collection_names=["one"]
+            )
+
+            self.assertEqual(("one",), report.promoted)
+            self.assertTrue((dest_root / "one").exists())
+            self.assertFalse((dest_root / "two").exists())
+
+
+class PromoteCliTest(unittest.TestCase):
+    """Tests for the promote CLI exit-code and reporting behavior."""
+
+    def test_exit_code_zero_when_all_collections_promote(self):
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            _write_story(source_root / "clean", "story_one", "A clean sentence.")
+
+            output = io.StringIO()
+            with unittest.mock.patch("sys.stdout", output):
+                exit_code = promote_cli.run(
+                    ["--source", str(source_root), "--dest", str(dest_root)]
+                )
+
+            self.assertEqual(0, exit_code)
+            self.assertIn("promoted: clean", output.getvalue())
+
+    def test_exit_code_nonzero_when_a_collection_is_blocked(self):
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            _write_story(source_root / "damaged", "story_one", "them a resumÃ©.")
+
+            output = io.StringIO()
+            error_output = io.StringIO()
+            with unittest.mock.patch("sys.stdout", output), unittest.mock.patch(
+                "sys.stderr", error_output
+            ):
+                exit_code = promote_cli.run(
+                    ["--source", str(source_root), "--dest", str(dest_root)]
+                )
+
+            self.assertEqual(1, exit_code)
+            self.assertIn("blocked: damaged", error_output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/analysis_tests/promote_test.py
+++ b/lcats/tests/analysis_tests/promote_test.py
@@ -168,6 +168,45 @@ class PromoteCollectionsTest(unittest.TestCase):
             self.assertTrue((dest_root / "one").exists())
             self.assertFalse((dest_root / "two").exists())
 
+    def test_refuses_when_source_and_dest_are_the_same_directory(self):
+        # Regression: _copy_collection's rmtree-then-copytree would otherwise
+        # delete the source collection before the copy could run.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            _write_story(root / "clean", "story_one", "A clean sentence.")
+
+            with self.assertRaises(ValueError):
+                promote.promote_collections(root, root)
+
+            self.assertTrue((root / "clean" / "story_one.json").exists())
+
+    def test_refuses_when_dest_is_nested_inside_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            nested_dest = root / "sub" / "nested"
+
+            with self.assertRaises(ValueError):
+                promote.promote_collections(root, nested_dest)
+
+    def test_all_collections_are_surveyed_before_any_copy_begins(self):
+        # A collection sorted after a blocked one must not have been copied
+        # by the time promote_collections raises or returns -- surveying
+        # happens as a distinct phase before any copytree call.
+        with tempfile.TemporaryDirectory() as source_tmp, tempfile.TemporaryDirectory() as dest_tmp:
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            _write_story(source_root / "a_clean", "story_one", "A clean sentence.")
+            _write_story(source_root / "b_damaged", "story_one", "them a resumÃ©.")
+
+            report = promote.promote_collections(source_root, dest_root)
+
+            # Both collections are independently gated (documented mode): the
+            # clean one still promotes even though it sorts before the
+            # blocked one, but this is now the outcome of a completed survey
+            # phase, not an artifact of copying mid-loop.
+            self.assertEqual(("a_clean",), report.promoted)
+            self.assertEqual(1, len(report.blocked))
+
 
 class PromoteCliTest(unittest.TestCase):
     """Tests for the promote CLI exit-code and reporting behavior."""
@@ -204,6 +243,35 @@ class PromoteCliTest(unittest.TestCase):
 
             self.assertEqual(1, exit_code)
             self.assertIn("blocked: damaged", error_output.getvalue())
+
+    def test_missing_source_directory_reports_clean_error_not_traceback(self):
+        with tempfile.TemporaryDirectory() as dest_tmp:
+            missing_source = pathlib.Path(dest_tmp) / "does_not_exist"
+
+            error_output = io.StringIO()
+            with unittest.mock.patch("sys.stderr", error_output):
+                exit_code = promote_cli.run(
+                    [
+                        "--source",
+                        str(missing_source),
+                        "--dest",
+                        dest_tmp,
+                        "some_collection",
+                    ]
+                )
+
+            self.assertEqual(2, exit_code)
+            self.assertIn("error:", error_output.getvalue())
+
+    def test_source_equals_dest_reports_clean_error_not_traceback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            error_output = io.StringIO()
+            with unittest.mock.patch("sys.stderr", error_output):
+                exit_code = promote_cli.run(["--source", tmp, "--dest", tmp])
+
+            self.assertEqual(2, exit_code)
+            self.assertIn("error:", error_output.getvalue())
+            self.assertIn("same directory", error_output.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements [WI-PROMOTE-0020](https://github.com/xenotaur/LCATS/blob/main/lcats/project/work_items/proposed/WI-PROMOTE-0020.md) — the final work item in WS-SPECIALS-CLEANUP's burn-down. Adds `lcats promote`, gating `data/`→`corpora/` promotion on a passing special-character survey.

Prompt ID: `PROMPT(WI-PROMOTE-0020:WI_PROMOTE_0020)[2026-07-16T03:34:26-04:00]`

## Collection-name mapping (resolved)

Verified against the real trees before deciding:

| `data/` collection | `corpora/` collection | Relationship |
|---|---|---|
| `ohenry-four_million` (25 stories) | `ohenry` (25 stories) | Byte-identical filenames — straight rename |
| `ohenry-whirligigs` (24 stories) | *(none)* | A second O. Henry collection, **never promoted at all** — not a merge target |
| `wilde_happy_prince` (5 stories) | `wilde` (5 stories) | Byte-identical filenames — straight rename |

Per maintainer direction (no external release yet, so free to rename): the mapping is **identity** — `data/`'s current names become canonical everywhere. The two legacy `corpora/` directories are documented as a one-time manual cleanup at the first real promotion ([docs/reference/corpus-promotion.md](https://github.com/xenotaur/LCATS/blob/main/lcats/docs/reference/corpus-promotion.md)), not something the tool auto-deletes.

## Changes

- **New `lcats/lcats/analysis/corpus/promote.py`** — `survey_collection()` (mojibake-only gate, `likely_repairable` findings, packaged allowlist), `promote_collections()` (per-collection independent gating; a damaged collection is skipped + reported without blocking clean siblings; wholesale-replace on promotion so stale destination files can't linger).
- **New `lcats/lcats/analysis/corpus/promote_cli.py`** — CLI wrapper, mirrors `repairs_cli.py`'s pattern.
- **`lcats/lcats/cli.py`** — wires `lcats promote [collection...] [--source] [--dest] [--dry-run]`.
- **New `lcats/tests/analysis_tests/promote_test.py`** (12 tests) — including the required **seeded-defect gate test** (damaged collection blocked, destination untouched) plus mixed clean/damaged, wholesale-replace, dry-run, and scoping tests.
- **New `docs/reference/corpus-promotion.md`** — procedure, the mapping table, the one-time cleanup note.

## Verification against the real corpus (`--dry-run`, no writes)

- `anderson`, `wodehouse`, `ohenry-four_million` → report promotable (clean, per WI-RESIDUAL-0019's fixes).
- `mass_quantities` → correctly **blocked** (59 real findings) — it hasn't undergone the literal regeneration WI-RESIDUAL-0019 documented as a follow-up, so a genuine block here is the gate working as intended.
- `corpora/` was not touched (confirmed via `git status`).

## Validation

- `scripts/lint` — passed
- `scripts/test` — **1,309 tests OK** (12 new)
- `lrh validate` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)