### PR TITLE
Add work item WI-RELEASE-0021: manual corpora-release runbook

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_17_02_07_30_WI_RELEASE_0021_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_17_02_07_30_WI_RELEASE_0021_REVIEW.md
@@ -1,0 +1,75 @@
+---
+execution_id: 2026_07_17_02_07_30_WI_RELEASE_0021_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0021_REVIEW)[2026-07-17T02:04:59-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/126
+commit: 1a9284d
+created_at: 2026-07-17T02:07:30-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/126
+session_transcript: claude-app:ff20b6b0-c572-4847-9c89-034d6aa827cd
+---
+
+# Summary
+
+Address eight review comments on PR #126 (WI-RELEASE-0021) via
+`lrh request review_response`. Six from copilot-pull-request-reviewer, two
+(P2) from chatgpt-codex-connector, reducing to five distinct issues. No
+`rerun_of`: WI-RELEASE-0021 was created via the /lrh-work-item-style flow
+(no /lrh-implement primary record exists), matching the WS-SPECIALS-CLEANUP
+workstream's own precedent.
+
+# Result
+
+All five fixed in commit 1a9284d, each confirmed against code before fixing:
+
+- Path corrections (5 duplicate comments) -- the WI's `related_design`,
+  `artifacts_expected`, and body-prose paths read `docs/reference/...`,
+  correct only relative to `lcats/`; the established repo-root-relative
+  convention (confirmed against WI-OVERRIDES-0018's
+  `lcats/lcats/gatherers/...`) requires `lcats/docs/reference/...`
+  everywhere. All 5 occurrences fixed.
+- Undefined reference -- `project_lcats_python_environment` is one of my
+  own persistent-memory file names, not an LCATS repo doc (confirmed:
+  zero repo hits before the fix). Replaced with `lcats/scripts/README.md`,
+  which actually documents `scripts/develop`.
+- Wrong CLI description -- confirmed at
+  `lcats/gatherers/main.py:31-33`: `lcats gather` takes optional
+  *gatherer* names (defaulting to every gatherer), not a required
+  `<collection>`. Replaced with the real, underscore-separated gatherer
+  names from the `GATHERERS` dict.
+- Missing clear/force step (P2) -- confirmed:
+  `DataGatherer.download()` (`downloaders.py:230,260-261`) and the
+  resource cache (`downloaders.py:98-102`) both skip existing files, and
+  no `--force` flag exists anywhere in the CLI. Added an explicit
+  clear-stale-`data/`-state step before the regenerate step, so the
+  runbook can't silently survey stale files while claiming a fresh run.
+- Working-directory ambiguity (P2) -- confirmed: `git rm -r corpora/...`
+  requires repo root (`corpora/` does not exist under `lcats/`), while
+  `lcats gather`/`lcats promote`'s defaults (`env.py:21-36`) require
+  running from `lcats/`. Every step in the Required Changes now states
+  its working directory explicitly.
+
+No comments skipped. This is a doc-plane-only change to
+`project/work_items/proposed/WI-RELEASE-0021.md` -- the actual runbook
+doc (`lcats/docs/reference/prepare-corpora-release.md`) does not exist
+yet; these fixes correct the plan before it's drafted.
+
+# Validation
+
+- `scripts/lint` -- ruff and black passed (no Python files touched)
+- `scripts/test` -- 1314 tests OK (no test changes; unaffected suite)
+- `lrh validate` -- 0 errors, 25 pre-existing owner-role warnings
+- `lrh work-items readiness WI-RELEASE-0021` -- still `prompt_ready: yes`
+
+# Follow-up
+
+- On merge: set this record to landed and resolve WI-RELEASE-0021... no --
+  WI-RELEASE-0021 itself is not resolved by this PR; only the planning
+  artifact is landing. The WI stays `proposed` until `/lrh-implement
+  WI-RELEASE-0021` produces the actual runbook doc.
+- Minor: the commit message for the fix commit (1a9284d) has a malformed
+  timestamp suffix (typo, not functional) -- noted here rather than
+  amending, per this session's no-amend git discipline.

--- a/lcats/project/work_items/proposed/WI-RELEASE-0021.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0021.md
@@ -1,0 +1,104 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-RELEASE-0021
+title: Document a manual corpora-release runbook for independent verification
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_workstreams:
+  - WS-SPECIALS-CLEANUP
+related_design:
+  - docs/reference/corpus-promotion.md
+  - project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+depends_on:
+  - WI-PROMOTE-0020
+forbidden_actions:
+  - execute_release_checklist
+  - modify_data_or_corpora_contents
+  - force_push
+acceptance:
+  - The runbook covers regenerate -> survey -> inspect -> promote as discrete, copy-pasteable CLI steps requiring no agent or Claude involvement
+  - Each step states what a clean result looks like and what a problem result looks like, so a human with no LCATS-internals knowledge can tell pass from fail
+  - The runbook is a superset of docs/reference/corpus-promotion.md, linking to it rather than duplicating its content
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+artifacts_expected:
+  - docs/reference/prepare-corpora-release.md
+---
+
+# Work Item: WI-RELEASE-0021
+
+## Summary
+Write a plain-language runbook a human can execute independently, with no
+agent involvement, to regenerate `data/`, verify it's clean, and promote it
+to `corpora/` — the first real (not simulated) end-to-end test of the
+WS-SPECIALS-CLEANUP pipeline.
+
+## Problem / Context
+Every verification of this pipeline so far has been either automated-agent-run
+or, per EV-0002's own stated method, a *simulated* regeneration (the real
+pipeline applied in-memory, not a literal `lcats gather`). That's real
+evidence, but it's evidence produced by the same agent that wrote the code —
+a known-incomplete verification pattern. An independently-executed, documented
+runbook is a different and stronger kind of check, and it's also the actual
+onboarding doc for any human maintaining this package without Claude.
+
+## Scope
+- Cover the full sequence: environment check, regenerate, survey, inspect
+  findings, dry-run promote, real promote (clearly marked as the
+  release-committing step).
+- Every command must be copy-pasteable as written, with no placeholders
+  requiring LCATS-internals knowledge to fill in.
+- State expected output for both the clean and dirty cases at each step.
+
+## Required Changes
+1. Create `docs/reference/prepare-corpora-release.md` with these sections:
+   - Pre-flight (conda env / `scripts/develop`, per
+     `project_lcats_python_environment` conventions).
+   - Regenerate: `lcats gather <collection>` per collection (or full corpus),
+     noting this re-downloads from Project Gutenberg and is network-dependent.
+   - Verify: `lcats survey --mode specials data/ --no-progress`, with the
+     expected-clean output shown and a troubleshooting pointer if findings
+     remain (link to WI-RESIDUAL-0019's rule/override/allowlist disposition
+     method).
+   - Inspect (diagnostic): `lcats repair-specials <file> --format jsonl` for
+     any flagged file, to see what a residual finding looks like.
+   - Preview: `lcats promote --dry-run`, reading its report.
+   - Promote (the actual release step): the one-time
+     `git rm -r corpora/ohenry corpora/wilde` historical cleanup from
+     `docs/reference/corpus-promotion.md`, then `lcats promote` for real,
+     called out as the step that changes tracked files.
+2. Link to `docs/reference/corpus-promotion.md` for the promote command's
+   full reference rather than repeating it.
+
+## Non-Goals
+- Do not execute the release checklist as part of this work item — that is
+  the maintainer's own independent, manual verification step (the entire
+  point of this WI).
+- Do not perform the actual real gather/promote during implementation.
+- Do not create the follow-up evidence record for the manual run's
+  outcome — that happens after the maintainer reports results, as its own
+  activity.
+
+## Acceptance Criteria
+- A human unfamiliar with the codebase's internals could follow the doc
+  top-to-bottom using only a terminal.
+- Every command is copy-pasteable; no step requires guessing a path or flag.
+- `lrh validate` reports 0 errors.
+
+## Validation
+- `lrh validate`
+
+## Risk Notes
+- The regenerate step is network-dependent (Project Gutenberg) and may be
+  slow; the doc should say so up front rather than let it be a surprise.
+- The real-promote step mutates tracked files in `corpora/`; the doc must
+  make unmistakably clear which steps are read-only/dry-run and which one
+  isn't.

--- a/lcats/project/work_items/proposed/WI-RELEASE-0021.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0021.md
@@ -13,7 +13,7 @@ related_focus:
 related_workstreams:
   - WS-SPECIALS-CLEANUP
 related_design:
-  - docs/reference/corpus-promotion.md
+  - lcats/docs/reference/corpus-promotion.md
   - project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
 depends_on:
   - WI-PROMOTE-0020
@@ -22,15 +22,16 @@ forbidden_actions:
   - modify_data_or_corpora_contents
   - force_push
 acceptance:
-  - The runbook covers regenerate -> survey -> inspect -> promote as discrete, copy-pasteable CLI steps requiring no agent or Claude involvement
+  - The runbook covers clear/regenerate -> survey -> inspect -> promote as discrete, copy-pasteable CLI steps requiring no agent or Claude involvement
   - Each step states what a clean result looks like and what a problem result looks like, so a human with no LCATS-internals knowledge can tell pass from fail
-  - The runbook is a superset of docs/reference/corpus-promotion.md, linking to it rather than duplicating its content
+  - Each step is unambiguous about which working directory it runs from, so no step requires the reader to infer a cd
+  - The runbook is a superset of lcats/docs/reference/corpus-promotion.md, linking to it rather than duplicating its content
   - lrh validate reports 0 errors
 required_evidence:
   - manual_review
   - lrh_validate
 artifacts_expected:
-  - docs/reference/prepare-corpora-release.md
+  - lcats/docs/reference/prepare-corpora-release.md
 ---
 
 # Work Item: WI-RELEASE-0021
@@ -51,32 +52,55 @@ runbook is a different and stronger kind of check, and it's also the actual
 onboarding doc for any human maintaining this package without Claude.
 
 ## Scope
-- Cover the full sequence: environment check, regenerate, survey, inspect
-  findings, dry-run promote, real promote (clearly marked as the
-  release-committing step).
+- Cover the full sequence: environment check, clear stale local state,
+  regenerate, survey, inspect findings, dry-run promote, real promote
+  (clearly marked as the release-committing step).
 - Every command must be copy-pasteable as written, with no placeholders
   requiring LCATS-internals knowledge to fill in.
+- Every step must be unambiguous about which working directory it runs
+  from (repo root vs. the `lcats/` package directory) — no step should
+  require the reader to infer a `cd`.
 - State expected output for both the clean and dirty cases at each step.
 
 ## Required Changes
-1. Create `docs/reference/prepare-corpora-release.md` with these sections:
-   - Pre-flight (conda env / `scripts/develop`, per
-     `project_lcats_python_environment` conventions).
-   - Regenerate: `lcats gather <collection>` per collection (or full corpus),
-     noting this re-downloads from Project Gutenberg and is network-dependent.
-   - Verify: `lcats survey --mode specials data/ --no-progress`, with the
-     expected-clean output shown and a troubleshooting pointer if findings
-     remain (link to WI-RESIDUAL-0019's rule/override/allowlist disposition
-     method).
-   - Inspect (diagnostic): `lcats repair-specials <file> --format jsonl` for
-     any flagged file, to see what a residual finding looks like.
-   - Preview: `lcats promote --dry-run`, reading its report.
+1. Create `lcats/docs/reference/prepare-corpora-release.md` with these
+   sections, each explicit about its working directory (repo root vs.
+   `lcats/`):
+   - Pre-flight (conda env / `scripts/develop`, per `lcats/scripts/README.md`).
+   - Clear stale state (from `lcats/`): `lcats gather` skips any file that
+     already exists (`DataGatherer.download` returns early —
+     `lcats/gatherers/downloaders.py:230,260-261`; the resource cache does
+     the same — `lcats/gatherers/downloaders.py:98-102`) and there is no
+     `--force` flag on the CLI, so a stale `data/` makes the "regenerate"
+     step a no-op that surveys old files while claiming a fresh run. The
+     runbook must have the reader remove the relevant `data/<gatherer>`
+     directories (and note `data/` is a regenerable cache, unlike
+     `corpora/`) before gathering.
+   - Regenerate (from `lcats/`): `lcats gather [gatherer ...]` — the
+     command takes optional *gatherer* names (defaulting to every
+     gatherer when none are given), not a `<collection>` placeholder; list
+     the real names (`sherlock`, `lovecraft`, `ohenry_four_million`,
+     `ohenry_whirligigs`, `hemingway`, `wilde_happy_prince`, `wodehouse`,
+     `grimm`, `anderson`, `chesterton`, `london`, `mass_quantities`), and
+     note this re-downloads from Project Gutenberg and is network-dependent.
+   - Verify (from `lcats/`): `lcats survey --mode specials data/
+     --no-progress`, with the expected-clean output shown and a
+     troubleshooting pointer if findings remain (link to WI-RESIDUAL-0019's
+     rule/override/allowlist disposition method).
+   - Inspect (diagnostic, from `lcats/`): `lcats repair-specials <file>
+     --format jsonl` for any flagged file, to see what a residual finding
+     looks like.
+   - Preview (from `lcats/`): `lcats promote --dry-run`, reading its
+     report; note its `--source`/`--dest` defaults (`data/`, `../corpora`)
+     are only correct when run from `lcats/`
+     (`lcats/utils/env.py:21-36`).
    - Promote (the actual release step): the one-time
-     `git rm -r corpora/ohenry corpora/wilde` historical cleanup from
-     `docs/reference/corpus-promotion.md`, then `lcats promote` for real,
-     called out as the step that changes tracked files.
-2. Link to `docs/reference/corpus-promotion.md` for the promote command's
-   full reference rather than repeating it.
+     `git rm -r corpora/ohenry corpora/wilde` historical cleanup **from the
+     repo root** (`corpora/` does not exist under `lcats/`), then `cd
+     lcats/` and `lcats promote` for real, called out as the step that
+     changes tracked files.
+2. Link to `lcats/docs/reference/corpus-promotion.md` for the promote
+   command's full reference rather than repeating it.
 
 ## Non-Goals
 - Do not execute the release checklist as part of this work item — that is
@@ -90,7 +114,8 @@ onboarding doc for any human maintaining this package without Claude.
 ## Acceptance Criteria
 - A human unfamiliar with the codebase's internals could follow the doc
   top-to-bottom using only a terminal.
-- Every command is copy-pasteable; no step requires guessing a path or flag.
+- Every command is copy-pasteable; no step requires guessing a path, flag,
+  or working directory.
 - `lrh validate` reports 0 errors.
 
 ## Validation
@@ -99,6 +124,13 @@ onboarding doc for any human maintaining this package without Claude.
 ## Risk Notes
 - The regenerate step is network-dependent (Project Gutenberg) and may be
   slow; the doc should say so up front rather than let it be a surprise.
+- `lcats gather` silently skips files that already exist and has no
+  `--force` flag (`lcats/gatherers/downloaders.py:98-102,230,260-261`), so
+  a stale `data/` can make the "regenerate" step look successful while
+  surveying old files; the clear-stale-state step must precede it.
+- `git rm -r corpora/...` and `lcats gather`/`lcats promote` run from
+  different working directories (repo root vs. `lcats/`); the doc must make
+  each step's directory explicit rather than assuming continuity.
 - The real-promote step mutates tracked files in `corpora/`; the doc must
   make unmistakably clear which steps are read-only/dry-run and which one
   isn't.

--- a/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+++ b/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
@@ -21,6 +21,7 @@ work_items:
   - WI-OVERRIDES-0018
   - WI-RESIDUAL-0019
   - WI-PROMOTE-0020
+  - WI-RELEASE-0021
 exit_criteria:
   - lcats survey --mode specials over freshly regenerated data/ reports zero unaddressed mojibake findings — every measured residual occurrence is repaired by rule, covered by a per-story override, or explicitly allowlisted
   - Repair rules and per-story overrides are versioned repo inputs applied during gathering, so clearing the cache and regenerating data/ reproduces the same repaired output deterministically


### PR DESCRIPTION
## Summary

Adds a planning artifact for an independently-executable "preparing a corpora release" runbook — regenerate -> survey -> inspect -> promote, documented for a human to run with zero Claude/agent involvement.

## Why

Every verification of the WS-SPECIALS-CLEANUP pipeline so far has been agent-run and, per [EV-0002](https://github.com/xenotaur/LCATS/blob/main/lcats/project/evidence/EV-0002.md)'s own stated method, a *simulated* regeneration rather than a literal `lcats gather`. An independently-executed, documented checklist is a stronger form of verification (the same reasoning behind independent verification & validation as a standard release-engineering practice), and it doubles as onboarding documentation for any human maintaining `lcats` directly.

## Contents

- `project/work_items/proposed/WI-RELEASE-0021.md` — deliverable: `docs/reference/prepare-corpora-release.md`, a superset of the existing `docs/reference/corpus-promotion.md` covering the full release sequence with copy-pasteable commands and clean/dirty output examples at each step.

## Non-Goals (by design)

- Does not execute the release checklist — that's the maintainer's own manual verification step, which is the entire point.
- Does not perform the actual gather/promote during implementation.

## Validation

- `lrh validate`: 0 errors (25 warnings, all pre-existing `owner: unassigned` class)
- `lrh work-items readiness`: `prompt_ready: yes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)