### PR TITLE
Add prepare-corpora-release runbook (WI-RELEASE-0021)

### DIFF
--- a/lcats/docs/index.md
+++ b/lcats/docs/index.md
@@ -20,10 +20,12 @@ Tutorials are not scaffolded in this phase.
 
 - [Set up API keys](secrets-setup.md)
 - [Run `lcats assess`](../lcats/analysis/corpus/README.md#9-story-assessment-lcats-assess) — usage, manual prompt validation, and dry-run guidance (interim location; pending extraction into `docs/how-to/` in a future phase)
+- [Prepare a corpora release](reference/prepare-corpora-release.md) — manual, agent-free runbook: clear, regenerate, verify, and promote `data/` into `corpora/`
 
 ### Reference
 
 - [CLI status matrix](reference/cli-status.md)
+- [Corpus promotion (`lcats promote`)](reference/corpus-promotion.md) — command reference and collection-name mapping
 
 ### Explanation
 

--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -41,18 +41,28 @@ re-activate the conda environment and re-run `scripts/develop`.
 
 **Directory:** `lcats/`.
 
-`lcats gather` skips any story file that already exists on disk and has no
-`--force` flag — if you skip this step, "regenerate" below will silently do
-nothing and you will end up surveying old files while believing you tested
-a fresh run. `data/` is a regenerable cache (unlike `corpora/`, nothing here
-is precious):
+Most gatherers skip any story file that already exists on disk (no
+`--force` flag exists to override this), so without this step "regenerate"
+below can silently leave old files in place. `mass_quantities` is the one
+exception — it always overwrites its story files — but the real risk this
+step guards against applies to every collection either way: `lcats gather`
+never *deletes* outputs it no longer produces, so a story dropped from the
+source list (or renamed) leaves a stale file behind that `lcats survey` and
+`lcats promote` will still scan. `data/` is a regenerable cache (unlike
+`corpora/`, nothing here is precious):
 
 ```bash
-rm -rf data/*
+rm -rf data && mkdir -p data
 ```
 
 To re-check a single collection instead of the whole corpus, clear only
-that one directory, e.g. `rm -rf data/mass_quantities`.
+that one directory, e.g. `rm -rf data/mass_quantities && mkdir -p data/mass_quantities`.
+This is a diagnostic shortcut, not a release step: scope every command in
+the rest of this runbook to that same collection name (`lcats survey
+--mode specials data/mass_quantities --no-progress`, `lcats promote
+mass_quantities --dry-run`, `lcats promote mass_quantities`) rather than
+running the unscoped forms — those consider every collection under
+`data/`, including ones you did not just regenerate.
 
 (Optional, for a fully from-network run: `rm -rf cache/resources` also
 clears the cached raw Project Gutenberg pages, so extraction re-runs against
@@ -80,9 +90,12 @@ whole corpus. The full list of gatherer names, if you want to target one:
 lcats gather mass_quantities
 ```
 
-This re-downloads source text from Project Gutenberg and is
-network-dependent; expect it to take a while for the full corpus,
-`mass_quantities` in particular (it's by far the largest collection).
+This reads from the `cache/resources` cache when a source page is already
+cached there, and only hits Project Gutenberg over the network for pages
+that aren't. Expect it to take a while for the full corpus either way,
+`mass_quantities` in particular (it's by far the largest collection). To
+force a genuinely fresh, fully-networked run, clear the cache too (see the
+optional note above).
 
 ## 4. Verify
 
@@ -140,13 +153,15 @@ from `lcats/`.
 This step changes tracked files in `corpora/`. Everything above this line is
 read-only.
 
-You should still be in `lcats/` from the previous steps.
+The `cd` commands below use `git rev-parse --show-toplevel` rather than a
+relative `cd ..`/`cd lcats`, so they work regardless of whether you run 7a,
+skip it, or run these steps out of order.
 
 **7a. One-time historical cleanup — directory: repo root** (`corpora/` does
 not exist under `lcats/`, so this fails if run from there):
 
 ```bash
-cd ..
+cd "$(git rev-parse --show-toplevel)"
 git rm -r corpora/ohenry corpora/wilde
 ```
 
@@ -158,7 +173,7 @@ Skip this step if it's already been done (i.e. `corpora/ohenry` and
 **7b. Promote — directory:** `lcats/`:
 
 ```bash
-cd lcats
+cd "$(git rev-parse --show-toplevel)/lcats"
 lcats promote
 ```
 

--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -1,0 +1,183 @@
+# Preparing a corpora release
+
+This is a manual runbook. Every command below is meant to be copy-pasted into
+a plain terminal — it does not assume Claude, an agent, or any tool beyond a
+shell and this repository checked out locally. If a step doesn't produce the
+output shown, stop and report it rather than continuing to the next step.
+
+`corpora/` is LCATS's periodic release snapshot; `data/` is the live working
+corpus, rebuilt from upstream sources as needed. This runbook clears the
+local working corpus, regenerates it from scratch, verifies it's free of
+encoding damage, and promotes it into `corpora/` — the actual release step.
+
+Each step below states which directory to run it from. LCATS is laid out as:
+
+```
+<repo root>/
+├── corpora/        # the release snapshot (this runbook's destination)
+└── lcats/           # the Python package and all tooling (this runbook's
+                      # working directory for most steps)
+```
+
+## 1. Pre-flight
+
+**Directory:** `lcats/` (the package directory, not the repo root).
+
+Set up the environment once per machine, per `lcats/README.md`'s own
+"Building" section:
+
+```bash
+cd LCATS/lcats
+scripts/clean && scripts/build && scripts/develop
+lcats info
+```
+
+`lcats info` should print a one-line description of LCATS. If it errors
+with a missing-package message, you are likely using a system/Homebrew
+Python rather than the conda environment `scripts/develop` installed into —
+re-activate the conda environment and re-run `scripts/develop`.
+
+## 2. Clear stale local state
+
+**Directory:** `lcats/`.
+
+`lcats gather` skips any story file that already exists on disk and has no
+`--force` flag — if you skip this step, "regenerate" below will silently do
+nothing and you will end up surveying old files while believing you tested
+a fresh run. `data/` is a regenerable cache (unlike `corpora/`, nothing here
+is precious):
+
+```bash
+rm -rf data/*
+```
+
+To re-check a single collection instead of the whole corpus, clear only
+that one directory, e.g. `rm -rf data/mass_quantities`.
+
+(Optional, for a fully from-network run: `rm -rf cache/resources` also
+clears the cached raw Project Gutenberg pages, so extraction re-runs against
+freshly downloaded source text rather than a locally cached copy. This
+isn't required to verify the repair pipeline — the JSON write step above is
+what actually re-triggers the repair logic — but it's the strictest form of
+"fresh.")
+
+## 3. Regenerate
+
+**Directory:** `lcats/`.
+
+```bash
+lcats gather
+```
+
+`lcats gather` takes optional gatherer names and defaults to running every
+gatherer when none are given, so the bare command above regenerates the
+whole corpus. The full list of gatherer names, if you want to target one:
+`sherlock`, `lovecraft`, `ohenry_four_million`, `ohenry_whirligigs`,
+`hemingway`, `wilde_happy_prince`, `wodehouse`, `grimm`, `anderson`,
+`chesterton`, `london`, `mass_quantities` — for example:
+
+```bash
+lcats gather mass_quantities
+```
+
+This re-downloads source text from Project Gutenberg and is
+network-dependent; expect it to take a while for the full corpus,
+`mass_quantities` in particular (it's by far the largest collection).
+
+## 4. Verify
+
+**Directory:** `lcats/`.
+
+```bash
+lcats survey --mode specials data/ --no-progress
+```
+
+**Clean result:** no output, exit code `0`.
+
+**Problem result:** one block per flagged file, e.g.:
+
+```
+data/mass_quantities/deny_the_slake__wilson.json
+  [spchar] error: Special character finding. (U+00C3, 'Ã')
+    context: em a resumÃ©.\n\n"As I s
+```
+
+and a non-zero exit code. If you see findings after a genuine fresh
+regeneration (step 2 done first), that's real information, not a false
+positive — see "If verification finds problems" below.
+
+## 5. Inspect (optional diagnostic)
+
+**Directory:** `lcats/`.
+
+For any flagged file, this shows exactly what the repair pipeline would
+propose, without changing anything:
+
+```bash
+lcats repair-specials data/mass_quantities/deny_the_slake__wilson.json --format jsonl
+```
+
+Each line is one proposed fix (`rule_id`, `original_text`, `replacement_text`,
+`rationale`). This is read-only — it never modifies the file.
+
+## 6. Preview promotion
+
+**Directory:** `lcats/`.
+
+```bash
+lcats promote --dry-run
+```
+
+Reports, per collection, either `would promote: <name> -> <name>` or
+`blocked: <name> (N finding(s) across M stories)` with the specific findings
+listed. This makes no changes regardless of what it finds — see
+[`corpus-promotion.md`](corpus-promotion.md) for the full command reference,
+including `--source`/`--dest` and why they default correctly only when run
+from `lcats/`.
+
+## 7. Promote (the actual release step)
+
+This step changes tracked files in `corpora/`. Everything above this line is
+read-only.
+
+You should still be in `lcats/` from the previous steps.
+
+**7a. One-time historical cleanup — directory: repo root** (`corpora/` does
+not exist under `lcats/`, so this fails if run from there):
+
+```bash
+cd ..
+git rm -r corpora/ohenry corpora/wilde
+```
+
+This is a one-time correction for two legacy collection names, documented in
+full in [`corpus-promotion.md`](corpus-promotion.md#collection-name-mapping).
+Skip this step if it's already been done (i.e. `corpora/ohenry` and
+`corpora/wilde` no longer exist).
+
+**7b. Promote — directory:** `lcats/`:
+
+```bash
+cd lcats
+lcats promote
+```
+
+If this exits `0`, every collection promoted and `corpora/` now reflects the
+regenerated `data/`. Commit the result as its own PR.
+
+## If verification finds problems
+
+A finding after a genuine fresh regeneration (step 2 → 3 → 4, in order) means
+a defect exists that the current rule table, override files, or allowlist
+don't yet cover. Do not edit the story JSON directly — every fix is a
+versioned pipeline input:
+
+- A clean, general encoding-family fix → a new rule in
+  `lcats/analysis/corpus/repairs.py`'s `DEFAULT_REPAIR_RULES`.
+- A one-off, story-specific judgment call → a new entry in
+  `lcats/gatherers/overrides/<collection>.json`.
+- A legitimate character that shouldn't be flagged at all → a new entry in
+  `lcats/analysis/corpus/allowlists/corpus_specials.json`.
+
+This is the same disposition method used to reach the current clean state;
+see the `WI-RESIDUAL-0019` execution record for worked examples of each.

--- a/lcats/project/executions/AD_HOC/2026_07_17_03_05_31_WI_RELEASE_0021_RUNBOOK_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_17_03_05_31_WI_RELEASE_0021_RUNBOOK_REVIEW.md
@@ -1,0 +1,86 @@
+---
+execution_id: 2026_07_17_03_05_31_WI_RELEASE_0021_RUNBOOK_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0021_RUNBOOK_REVIEW)[2026-07-17T02:58:05-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_17_02_47_54_WI_RELEASE_0021
+pr: https://github.com/xenotaur/LCATS/pull/127
+commit: 
+created_at: 2026-07-17T03:05:31-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/127
+session_transcript: pending
+---
+
+# Summary
+
+Address five review comments on PR #127 (WI-RELEASE-0021's runbook
+implementation) via `lrh request review_response`: two P2 from
+chatgpt-codex-connector, three from copilot-pull-request-reviewer.
+
+# Result
+
+All five fixed in commit eb40979, each confirmed against source before
+fixing:
+
+- Fragile `cd` in step 7b (P2) -- confirmed the bug live: if step 7a
+  (one-time `corpora/ohenry`/`corpora/wilde` cleanup) is skipped because
+  it was already done, the reader never leaves `lcats/`, so 7b's
+  `cd lcats` would descend into `lcats/lcats` instead. Replaced both
+  7a's and 7b's `cd` with a `git rev-parse --show-toplevel`-based
+  absolute path, which is correct regardless of the reader's current
+  directory or
+  whether 7a ran.
+- Unscoped verify/promote after a single-collection recheck (P2) --
+  confirmed: `lcats promote` with no collection arguments considers
+  every collection under `data/` (`promote_cli.py:22-26`), so following
+  step 2's single-collection shortcut with the unscoped commands in
+  steps 4/6/7 would survey/promote collections that were never
+  regenerated in this run. Labeled the shortcut as diagnostic-only and
+  added matching scoped survey/promote examples.
+- Inaccurate "skips existing files" claim (copilot) -- confirmed this is
+  only true for 11 of 12 gatherers. `mass_quantities` uses
+  `parser.gather_story()` (`lcats/gatherers/parser.py:1474-1477`), which
+  unconditionally overwrites via `open(file_path, "w")` with no
+  existence check -- unlike the other gatherers, which route through
+  `DataGatherer.download()` (`downloaders.py:226-230`, via
+  `gatherlib.gather()`) and do skip existing files. Rewrote the
+  rationale to lead with the risk that's true for every gatherer either
+  way -- `lcats gather` never deletes stale outputs it no longer
+  produces -- rather than a blanket "skips existing files" claim.
+- Inaccurate "re-downloads... network-dependent" wording (copilot) --
+  confirmed `DataGatherer.download()` routes through
+  `ResourceCache.get()`/`.cache()` (`downloaders.py:93-101`), which skips
+  the network entirely when `cache/resources` already holds the page.
+  Reworded to state the cache-first behavior and point to the existing
+  optional `cache/resources`-clearing note for a genuinely fresh run.
+- Non-portable `rm -rf data/*` (copilot) -- confirmed the glob-failure
+  risk (bash errors, zsh has `nomatch` on for an empty/missing `data/`).
+  Replaced with `rm -rf data && mkdir -p data` (and the equivalent
+  single-collection form), which has no glob to fail.
+
+No comments skipped.
+
+Self-caught during this same review pass (not from a reviewer comment):
+`lrh prompt record-execution` was run one directory too deep -- cwd had
+persisted at `lcats/` from a prior command, so `cd lcats` landed in
+`lcats/lcats` (the Python package dir) and wrote this very file to a
+stray `lcats/lcats/project/executions/AD_HOC/` tree. Caught immediately
+via `pwd`, moved the file to the correct `lcats/project/executions/AD_HOC/`
+path, and removed the stray directories before they could be staged.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 149 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1314 tests OK
+- `lrh validate` -- 0 errors, 25 pre-existing owner-role/orphan warnings
+
+# Follow-up
+
+- On merge: set this record and the primary WI-RELEASE-0021 record to
+  `landed` via `/lrh-closeout`.
+- Unchanged from the primary record: the user will manually run the
+  merged runbook end-to-end as independent verification of the repair
+  pipeline; clean run resolves the three legacy WIs, issues found get
+  fixed and re-verified first.

--- a/lcats/project/executions/WI-RELEASE-0021/2026_07_17_02_47_54_WI_RELEASE_0021.md
+++ b/lcats/project/executions/WI-RELEASE-0021/2026_07_17_02_47_54_WI_RELEASE_0021.md
@@ -1,0 +1,86 @@
+---
+execution_id: 2026_07_17_02_47_54_WI_RELEASE_0021
+prompt_id: PROMPT(WI-RELEASE-0021:WI_RELEASE_0021)[2026-07-17T02:33:04-04:00]
+work_item: WI-RELEASE-0021
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/127
+commit: 
+created_at: 2026-07-17T02:47:54-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-RELEASE-0021.md
+session_transcript: pending
+---
+
+# Summary
+
+Implement WI-RELEASE-0021's Required Changes: draft the actual
+`prepare-corpora-release.md` runbook (the planning artifact, PR #126,
+only fixed the WI's own content -- this PR produces the doc itself), and
+link it from `docs/index.md`.
+
+# Result
+
+New `lcats/docs/reference/prepare-corpora-release.md`: a manual,
+copy-pasteable, agent-free runbook covering pre-flight, clearing stale
+`data/` state, regenerating, verifying (`lcats survey --mode specials`),
+an optional per-file inspect step (`lcats repair-specials`), a dry-run
+promotion preview, and the actual promotion. Every section states its
+required working directory (`lcats/` vs. repo root), addressing the P2
+review finding from PR #126. Links to (does not duplicate)
+`corpus-promotion.md` for the full `lcats promote` reference and the
+one-time `corpora/ohenry`/`corpora/wilde` rename.
+
+`lcats/docs/index.md` gained two links: the new runbook (How-to guides)
+and the previously-unlinked `corpus-promotion.md` (Reference) -- a small
+in-scope addition beyond the WI's literal text, for discoverability.
+
+Every command/example was grounded against live output and source before
+being written, not assumed:
+- `lcats gather`'s no-op-on-existing-file behavior:
+  `lcats/lcats/gatherers/downloaders.py:98-102,230,260-261`.
+- `lcats gather`'s optional-gatherer-names signature and the full
+  `GATHERERS` key list: `lcats/lcats/gatherers/main.py:31-33`.
+- `data_root()`/`corpora_root()` defaults requiring `lcats/` as cwd:
+  `lcats/lcats/utils/env.py:21-36`.
+- The runbook's illustrative "problem result" example
+  (`deny_the_slake__wilson.json`) was verified live to actually appear in
+  both `lcats survey --mode specials` and `lcats promote --dry-run`
+  output before being written in -- an earlier candidate file
+  (`dawningsburgh__west.json`) was dropped after live testing showed it
+  is silently excluded by `lcats survey`'s legacy
+  `unicode.DEFAULT_EXCLUDED_CHARS` list despite containing real,
+  unrepaired mojibake (a real `lcats survey` vs. `lcats promote`
+  exclusion-mechanism inconsistency, noted here for the later
+  architecture-revisit discussion rather than documented in the
+  human-facing runbook, since `lcats promote`'s own independent survey
+  is the actual release gate and remains correct regardless).
+
+Self-caught and fixed before commit: step 7a originally read `cd LCATS`,
+which only resolves correctly from a starting point *outside* the repo
+-- but by step 7 the reader has been continuously inside `lcats/` since
+step 1, so `cd LCATS` would look for a nonexistent `lcats/LCATS/`.
+Corrected to `cd ..` (relative to wherever the reader currently is),
+which is both correct and independent of the clone directory's name.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 149 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1314 tests, OK (doc-only change, unaffected suite)
+- `lrh validate` -- 0 errors, 25 pre-existing owner-role/orphan warnings
+- `lrh work-items readiness WI-RELEASE-0021 --format md` -- still
+  `prompt_ready: yes`
+
+# Follow-up
+
+- On merge: update this record to `landed` with the merge commit and
+  session transcript, per `/lrh-closeout`.
+- The user will manually execute this runbook end-to-end as independent
+  verification of the repair pipeline (the whole reason this is a
+  human-run doc, not an agent-run check). Clean run -> resolve
+  WI-SPANOPS-0002/WI-REVIEW-0003/WI-APPLY-0005 + a decision-log entry.
+  Issues found -> report back, fix, re-run before revisiting status.
+- The `lcats survey` vs. `lcats promote` exclusion-mechanism
+  inconsistency discovered while drafting this doc (see Result) should
+  be raised in that same architecture-revisit discussion.


### PR DESCRIPTION
## Summary

Implements WI-RELEASE-0021: a manual, agent-free runbook for preparing a
corpora release, so anyone with a terminal (not just users working through
Claude) can regenerate, verify, and promote the corpus themselves.

- New `lcats/docs/reference/prepare-corpora-release.md`: 7 sections
  (pre-flight, clear stale state, regenerate, verify, inspect, preview
  promotion, promote), each stating its required working directory. Links to
  the existing `corpus-promotion.md` rather than duplicating its content.
- `lcats/docs/index.md`: adds discoverability links to the new runbook and to
  the previously-unlinked `corpus-promotion.md`.

Every command and example in the runbook was grounded against current source
(`downloaders.py`, `gatherers/main.py`, `utils/env.py`) and live command
output, not assumption — following up on review feedback from WI-RELEASE-0021's
planning PR (#126), where an uncited/incorrect convention reference and a
wrong CLI description were caught.

Next: the user will run this runbook manually as independent verification of
the repair pipeline, ahead of resolving the three legacy WIs still open under
WS-SPECIALS-CLEANUP.

PROMPT(WI-RELEASE-0021:WI_RELEASE_0021)[2026-07-17T02:33:04-04:00]

## Test plan

- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — ruff + black pass
- [x] `scripts/test` — 1314 tests OK
- [x] `lrh validate` — 0 errors, 25 pre-existing warnings
- [x] `lrh work-items readiness WI-RELEASE-0021` — prompt_ready: yes
- [ ] User to manually execute the runbook end-to-end
