### PR TITLE
Fix symlink safety and cache/texts gap in the corpora-release runbook

### DIFF
--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -52,23 +52,32 @@ source list (or renamed) leaves a stale file behind that `lcats survey` and
 `corpora/`, nothing here is precious):
 
 ```bash
-sh -c 'rm -rf data/*'
+sh -c 'rm -rf data/* data/.[!.]* data/..?*'
 ```
 
 `data/` and `cache/` are plain directories for most setups, but some
 machines point them at symlinks to a scratch/tempspace location (to keep
 large regenerated data out of a backup system, for instance) — every
-`rm -rf <dir>/*` in this runbook clears the *contents* of the directory
+clear command in this runbook removes the *contents* of the directory
 without touching the directory (or symlink) itself, so a symlinked setup
-survives a clear-and-regenerate cycle intact. Running the glob under
-`sh -c '...'` rather than directly is deliberate, not stylistic: zsh's
-default options abort with `no matches found` if the glob doesn't match
-anything (e.g. the directory is already empty or doesn't exist yet), while
-`/bin/sh` doesn't have that behavior — `sh -c '...'` makes the command
-copy-pasteable regardless of which shell you run it in.
+survives a clear-and-regenerate cycle intact. The three glob patterns
+together (`data/*`, `data/.[!.]*`, `data/..?*`) are the standard portable
+idiom for "every entry, dotfiles included, excluding `.`/`..` themselves"
+— a bare `data/*` misses dotfiles (e.g. a stray `.DS_Store` or a leftover
+`.ipynb_checkpoints/` directory), which `lcats survey`'s recursive
+discovery and `lcats promote`'s directory-level scan would otherwise still
+pick up despite the runbook saying the local corpus was cleared. Running
+the globs under `sh -c '...'` rather than directly is deliberate, not
+stylistic: zsh's default options abort with `no matches found` if *any one*
+of the three globs doesn't match anything (e.g. there are no dotfiles
+present, or the directory is empty or doesn't exist yet), while `/bin/sh`
+doesn't have that behavior — `sh -c '...'` makes the command copy-pasteable
+regardless of which shell you run it in, and regardless of which subset of
+the three patterns happens to match.
 
 To re-check a single collection instead of the whole corpus, clear only
-that one directory, e.g. `sh -c 'rm -rf data/mass_quantities/*'`.
+that one directory, e.g.
+`sh -c 'rm -rf data/mass_quantities/* data/mass_quantities/.[!.]* data/mass_quantities/..?*'`.
 This is a diagnostic shortcut, not a release step: scope every command in
 the rest of this runbook to that same collection name (`lcats survey
 --mode specials data/mass_quantities --no-progress`, `lcats promote
@@ -76,18 +85,18 @@ mass_quantities --dry-run`, `lcats promote mass_quantities`) rather than
 running the unscoped forms — those consider every collection under
 `data/`, including ones you did not just regenerate.
 
-(Optional, for a fully from-network run: `rm -rf cache/resources
-cache/texts` also clears the cached raw Project Gutenberg pages, so
-extraction re-runs against freshly downloaded source text rather than a
-locally cached copy. Both directories are recreated automatically on the
-next `lcats gather`, so removing them outright — no glob, no `sh -c`
-needed — is safe. Most gatherers cache through `cache/resources`, but
-`mass_quantities` caches raw text separately through `cache/texts`
-(`lcats/gettenberg/cache.py:30`, via `lcats/gettenberg/api.py:37`), so a
-from-network run of `mass_quantities` specifically needs both cleared, not
-just `cache/resources`. This isn't required to verify the repair pipeline —
-the JSON write step above is what actually re-triggers the repair logic —
-but it's the strictest form of "fresh.")
+(Optional, for a fully from-network run: `rm -rf cache/resources cache/texts`
+also clears the cached raw Project Gutenberg pages, so extraction re-runs
+against freshly downloaded source text rather than a locally cached copy.
+Both directories are recreated automatically on the next `lcats gather`, so
+removing them outright — no glob, no `sh -c` needed — is safe. Most
+gatherers cache through `cache/resources`, but `mass_quantities` caches raw
+text separately through `cache/texts` (`lcats/gettenberg/cache.py:30`, via
+`lcats/gettenberg/api.py:37`), so a from-network run of `mass_quantities`
+specifically needs both cleared, not just `cache/resources`. This isn't
+required to verify the repair pipeline — the JSON write step above is what
+actually re-triggers the repair logic — but it's the strictest form of
+"fresh.")
 
 ## 3. Regenerate
 

--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -52,11 +52,23 @@ source list (or renamed) leaves a stale file behind that `lcats survey` and
 `corpora/`, nothing here is precious):
 
 ```bash
-rm -rf data && mkdir -p data
+sh -c 'rm -rf data/*'
 ```
 
+`data/` and `cache/` are plain directories for most setups, but some
+machines point them at symlinks to a scratch/tempspace location (to keep
+large regenerated data out of a backup system, for instance) — every
+`rm -rf <dir>/*` in this runbook clears the *contents* of the directory
+without touching the directory (or symlink) itself, so a symlinked setup
+survives a clear-and-regenerate cycle intact. Running the glob under
+`sh -c '...'` rather than directly is deliberate, not stylistic: zsh's
+default options abort with `no matches found` if the glob doesn't match
+anything (e.g. the directory is already empty or doesn't exist yet), while
+`/bin/sh` doesn't have that behavior — `sh -c '...'` makes the command
+copy-pasteable regardless of which shell you run it in.
+
 To re-check a single collection instead of the whole corpus, clear only
-that one directory, e.g. `rm -rf data/mass_quantities && mkdir -p data/mass_quantities`.
+that one directory, e.g. `sh -c 'rm -rf data/mass_quantities/*'`.
 This is a diagnostic shortcut, not a release step: scope every command in
 the rest of this runbook to that same collection name (`lcats survey
 --mode specials data/mass_quantities --no-progress`, `lcats promote
@@ -64,12 +76,18 @@ mass_quantities --dry-run`, `lcats promote mass_quantities`) rather than
 running the unscoped forms — those consider every collection under
 `data/`, including ones you did not just regenerate.
 
-(Optional, for a fully from-network run: `rm -rf cache/resources` also
-clears the cached raw Project Gutenberg pages, so extraction re-runs against
-freshly downloaded source text rather than a locally cached copy. This
-isn't required to verify the repair pipeline — the JSON write step above is
-what actually re-triggers the repair logic — but it's the strictest form of
-"fresh.")
+(Optional, for a fully from-network run: `rm -rf cache/resources
+cache/texts` also clears the cached raw Project Gutenberg pages, so
+extraction re-runs against freshly downloaded source text rather than a
+locally cached copy. Both directories are recreated automatically on the
+next `lcats gather`, so removing them outright — no glob, no `sh -c`
+needed — is safe. Most gatherers cache through `cache/resources`, but
+`mass_quantities` caches raw text separately through `cache/texts`
+(`lcats/gettenberg/cache.py:30`, via `lcats/gettenberg/api.py:37`), so a
+from-network run of `mass_quantities` specifically needs both cleared, not
+just `cache/resources`. This isn't required to verify the repair pipeline —
+the JSON write step above is what actually re-triggers the repair logic —
+but it's the strictest form of "fresh.")
 
 ## 3. Regenerate
 

--- a/lcats/project/executions/AD_HOC/2026_07_17_13_00_45_RUNBOOK_SYMLINK_SAFETY.md
+++ b/lcats/project/executions/AD_HOC/2026_07_17_13_00_45_RUNBOOK_SYMLINK_SAFETY.md
@@ -1,0 +1,82 @@
+---
+execution_id: 2026_07_17_13_00_45_RUNBOOK_SYMLINK_SAFETY
+prompt_id: PROMPT(AD_HOC:RUNBOOK_SYMLINK_SAFETY)[2026-07-17T12:58:41-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/128
+commit: 
+created_at: 2026-07-17T13:00:45-04:00
+agent: claude_app
+instruction_source: user report from manually running lcats/docs/reference/prepare-corpora-release.md
+session_transcript: pending
+---
+
+# Summary
+
+Fix two issues in `prepare-corpora-release.md` (WI-RELEASE-0021, merged
+PR #127) reported by the maintainer while actually running the runbook by
+hand: the clear-state command breaks a symlinked `data/`/`cache/` setup,
+and the "fully from-network run" note misses a second, mass_quantities-only
+cache directory.
+
+# Result
+
+Fixed in commit 47f902b, both confirmed empirically (not just by reading
+source) before writing the fix:
+
+- Symlink-destroying clear command -- the PR #127 review fix
+  (`rm -rf data && mkdir -p data`) was itself the regression: verified in
+  a scratch dir that `rm -rf <symlink>` unlinks the symlink (leaving its
+  target untouched) and the following `mkdir -p` then creates a *new real
+  directory* in its place, silently orphaning the old target. Replaced
+  with `sh -c 'rm -rf data/*'`, verified correct on populated, empty, and
+  missing `data/` alike -- it clears contents without ever touching the
+  directory/symlink entry itself. Also verified the reviewer's original
+  zsh concern is real and specifically what `sh -c` fixes: a bare
+  `zsh -c 'rm -rf data/*'` on an empty/missing dir aborts with
+  `zsh: no matches found` (exit 1); `sh` has no such default option. (A
+  `find -L data -mindepth 1 -delete` alternative was tried and rejected --
+  BSD/macOS find refuses it outright: "`-delete: forbidden when symlinks
+  are followed`".)
+- Missing `cache/texts` (P2-equivalent, from a live dogfood run rather
+  than a PR review): confirmed `mass_quantities` caches raw Gutenberg text
+  through a second, independent cache -- `lcats/gettenberg/cache.py:30`
+  (`GUTENBERG_TEXTS = GUTENBERG_ROOT / "texts"`), used only by
+  `api.py:37`'s `load_etext()`, which only `parser.py:1403`
+  (mass_quantities' own pipeline) calls. The other 11 gatherers use
+  `downloaders.py`'s `ResourceCache` -> `cache/resources` exclusively and
+  never touch `cache/texts`. Added `cache/texts` to the optional
+  from-network-run note alongside `cache/resources`.
+
+Also confirmed while investigating: no `lcats clean` CLI command exists
+(`scripts/clean` only removes Python build artifacts --
+`lcats/scripts/clean:1-6`), but `ResourceCache.clear()` /
+`DataGatherer.clear()` (`downloaders.py:108-122,262-276`) already exist
+and are already symlink-safe (they `os.listdir()` and delete children
+individually, never touching the root). Not wired to any CLI command
+today -- noted as a possible follow-up, not done as part of this fix.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 149 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1314 tests OK
+- `lrh validate` -- 0 errors, 25 pre-existing owner-role/orphan warnings
+- Manually verified (in a scratch directory, not asserted from reading
+  source alone): symlink survives `sh -c 'rm -rf data/*'` on populated,
+  empty, and missing directories; `zsh -c 'rm -rf data/*'` aborts on an
+  empty/missing directory; `find -L ... -delete` is refused by BSD find
+
+# Follow-up
+
+- On merge: update this record to `landed`.
+- Possible future work item: wire `ResourceCache.clear()` /
+  `DataGatherer.clear()` up to a real `lcats clean` command, and extend
+  the same clearing to `gettenberg/cache.py`'s `texts`/`tmp` directories
+  (which have no `clear()` method today) -- would remove the need for any
+  shell-glob reasoning in the runbook at all. Not started; the maintainer
+  deferred this to keep the current dogfood run moving.
+- The maintainer's dogfood run of the runbook (the actual point of
+  WI-RELEASE-0021) is still in progress; this fix unblocks it, not
+  concludes it.

--- a/lcats/project/executions/AD_HOC/2026_07_17_14_12_37_RUNBOOK_SYMLINK_SAFETY_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_17_14_12_37_RUNBOOK_SYMLINK_SAFETY_REVIEW.md
@@ -1,0 +1,65 @@
+---
+execution_id: 2026_07_17_14_12_37_RUNBOOK_SYMLINK_SAFETY_REVIEW
+prompt_id: PROMPT(AD_HOC:RUNBOOK_SYMLINK_SAFETY_REVIEW)[2026-07-17T14:09:53-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_17_13_00_45_RUNBOOK_SYMLINK_SAFETY
+pr: https://github.com/xenotaur/LCATS/pull/128
+commit: 
+created_at: 2026-07-17T14:12:37-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/128
+session_transcript: pending
+---
+
+# Summary
+
+Address four review comments on PR #128 (the runbook symlink-safety fix):
+one P2 from chatgpt-codex-connector, three from
+copilot-pull-request-reviewer, reducing to two distinct issues (dotfile
+gap, code-span formatting).
+
+# Result
+
+Both fixed in commit a6abb11, confirmed against a live test before fixing:
+
+- Dotfile gap (4 comments, 1 distinct issue) -- confirmed live: `data/*`
+  does not match dotfile entries (`.DS_Store`, `.ipynb_checkpoints/`,
+  etc.), so the clear step could leave stale hidden files behind that
+  `lcats survey`'s recursive `path.rglob("*.json")` discovery
+  (`discovery.py:65`) and `lcats promote`'s top-level directory scan
+  (`promote.py:201-203`) would still pick up, despite the runbook claiming
+  a clean slate. Replaced the two-glob commands
+  (`rm -rf data/*` and the single-collection form) with the standard
+  three-glob idiom `data/* data/.[!.]* data/..?*` (dotfiles included,
+  `.`/`..` excluded), still wrapped in `sh -c '...'` since zsh aborts with
+  `no matches found` if *any one* of the three globs has nothing to match
+  (e.g. a directory with only dotfiles, or none at all) -- verified this
+  exact scenario live: a directory containing only a dotfile aborts under
+  bare `zsh -c` but clears correctly under `sh -c`. Also verified the fix
+  preserves a symlinked `data/`, removes nested hidden directories, and is
+  a no-op on empty/missing directories.
+- Code-span formatting (1 comment) -- the `cache/resources`/`cache/texts`
+  clearing note had the command split across two separate inline code
+  spans, making it easy to copy only half. Joined into one
+  `` `rm -rf cache/resources cache/texts` `` span.
+
+No comments skipped.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 149 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1314 tests OK (doc-only change, unaffected suite)
+- `lrh validate` -- 0 errors, 25 pre-existing owner-role/orphan warnings
+- Manually verified in a scratch directory (not asserted from reading
+  source alone): three-glob pattern clears dotfiles, nested hidden dirs,
+  and regular files while preserving the symlink; a bare `zsh -c` with the
+  same globs aborts on a dotfile-only directory while `sh -c` does not
+
+# Follow-up
+
+- On merge: update this record and the primary
+  `2026_07_17_13_00_45_RUNBOOK_SYMLINK_SAFETY` record to `landed`.
+- Unchanged from the primary record: the maintainer's dogfood run of the
+  runbook is still in progress.


### PR DESCRIPTION
## Summary

Fixes two real issues in `prepare-corpora-release.md` (merged in PR #127),
found while the maintainer actually ran the runbook by hand.

- **Symlink safety**: the review fix in PR #127 changed the clear-step to
  `rm -rf data && mkdir -p data`. On a setup where `data/`/`cache/` are
  symlinks to a scratch/tempspace location (to keep large regenerated data
  out of a backup system), this destroys the symlink and silently replaces
  it with a real directory. Switched to `sh -c 'rm -rf data/*'`, which
  clears contents without touching the directory/symlink itself. Verified
  directly: `sh -c 'rm -rf data/*'` is correct on populated, empty, and
  missing `data/` alike, while a bare `zsh -c 'rm -rf data/*'` on an
  empty/missing dir aborts with `zsh: no matches found` (`sh` doesn't have
  that default option, so it's copy-pasteable regardless of the reader's
  shell).
- **`cache/texts` gap**: the runbook's "fully from-network run" note only
  mentioned clearing `cache/resources`. `mass_quantities` caches raw text
  separately through `cache/texts` (`lcats/gettenberg/cache.py:30`, via
  `api.py:37`), so a from-network run of `mass_quantities` specifically
  needs both cleared. Added `cache/texts` to that note.

PROMPT(AD_HOC:RUNBOOK_SYMLINK_SAFETY)[2026-07-17T12:58:41-04:00]

## Test plan

- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — ruff + black pass
- [x] `scripts/test` — 1314 tests OK
- [x] `lrh validate` — 0 errors, 25 pre-existing warnings
- [x] Manually verified symlink-preservation and zsh-glob-abort claims in a scratch directory before writing the fix
