### PR TITLE
Add mass_quantities overrides for dogfood-run residuals; add lcats assess pointer

### DIFF
--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -196,3 +196,31 @@ versioned pipeline input:
 
 This is the same disposition method used to reach the current clean state;
 see the `WI-RESIDUAL-0019` execution record for worked examples of each.
+
+## Optional next step: quality/genre assessment
+
+**Directory:** `lcats/`.
+
+Once `corpora/` is promoted, `lcats assess` can score the release for
+quality and genre fit using the Claude API. This is a separate, optional
+step from the promotion above — not part of the release itself — and,
+unlike everything above, it is **not free**: it calls a real model on every
+story you point it at. Always preview first:
+
+```bash
+lcats assess corpora/ --genre "science fiction" --dry-run
+```
+
+`--dry-run` runs the same pre-flight checks (file discovery, body-length
+limits) without calling the API, so it's safe to run anytime. `--genre` is
+one of `science fiction`, `horror`, `western`, `romance`; omit it to run
+detect mode instead of genre-lens mode. A real run needs an API key and
+your explicit go-ahead:
+
+```bash
+ANTHROPIC_API_KEY=sk-... lcats assess corpora/ --genre "science fiction" --format tsv --output sf_assessment.tsv
+```
+
+See [`lcats assess`'s how-to guide](../lcats/analysis/corpus/README.md#9-story-assessment-lcats-assess)
+for the full option reference, output formats, and manual prompt-validation
+guidance.

--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -205,10 +205,12 @@ Once `corpora/` is promoted, `lcats assess` can score the release for
 quality and genre fit using the Claude API. This is a separate, optional
 step from the promotion above — not part of the release itself — and,
 unlike everything above, it is **not free**: it calls a real model on every
-story you point it at. Always preview first:
+story you point it at. Always preview first. `corpora/` is a sibling of
+`lcats/`, not under it, so from this section's `lcats/` working directory
+the path is `../corpora/`:
 
 ```bash
-lcats assess corpora/ --genre "science fiction" --dry-run
+lcats assess ../corpora/ --genre "science fiction" --dry-run
 ```
 
 `--dry-run` runs the same pre-flight checks (file discovery, body-length
@@ -218,9 +220,9 @@ detect mode instead of genre-lens mode. A real run needs an API key and
 your explicit go-ahead:
 
 ```bash
-ANTHROPIC_API_KEY=sk-... lcats assess corpora/ --genre "science fiction" --format tsv --output sf_assessment.tsv
+ANTHROPIC_API_KEY=sk-... lcats assess ../corpora/ --genre "science fiction" --format tsv --output sf_assessment.tsv
 ```
 
-See [`lcats assess`'s how-to guide](../lcats/analysis/corpus/README.md#9-story-assessment-lcats-assess)
+See [`lcats assess`'s how-to guide](../../lcats/analysis/corpus/README.md#9-story-assessment-lcats-assess)
 for the full option reference, output formats, and manual prompt-validation
 guidance.

--- a/lcats/lcats/gatherers/overrides/mass_quantities.json
+++ b/lcats/lcats/gatherers/overrides/mass_quantities.json
@@ -14,5 +14,21 @@
             "rationale": "U+C9F8 (Hangul 'JJAE') is a corrupted degree sign; all occurrences are temperatures (102째F, 135째, 140째, 145째). Not a clean encoding-family decode, so dispositioned as a per-story override rather than a rule.",
             "reviewer": "WI-RESIDUAL-0019 residual review"
         }
+    ],
+    "has_anyone_here_seen_kelly__walton": [
+        {
+            "find": "иии",
+            "replace": "* * * * *",
+            "rationale": "Cyrillic 'и' (U+0438) x3 used as the story's final scene-break marker, immediately before 'THE END'. Confirmed against the Project Gutenberg source (ebook #30086) that this is present verbatim upstream, not LCATS-introduced corruption -- almost certainly a transcription artifact, since the rest of the story renders its other scene breaks as '* * * * *'. Trusting the author's original structural intent (a scene break belongs there) over the transcriber's choice of glyph, normalized to match the story's own established convention rather than allowlisted as-is or treated as a repair-rule mojibake decode.",
+            "reviewer": "dogfood run of prepare-corpora-release.md, 2026-07-17"
+        }
+    ],
+    "rough_beast__aycock": [
+        {
+            "find": "■",
+            "replace": "* * * * *",
+            "rationale": "U+25A0 black square used as the story's opening scene-break marker, appearing exactly once, before the story's very first sentence. Confirmed against the Project Gutenberg source (ebook #48880) that this is present verbatim upstream; the same story renders its other, mid-story scene breaks as '* * * * *'. Previously flagged in WI-RESIDUAL-0019 as a deferred boundary artifact ('candidate for a boundary-cleanup WI'); normalized here to the story's own convention rather than allowlisted as-is.",
+            "reviewer": "dogfood run of prepare-corpora-release.md, 2026-07-17"
+        }
     ]
 }

--- a/lcats/project/executions/AD_HOC/2026_07_17_14_07_32_MASS_QUANTITIES_RESIDUAL_OVERRIDES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_17_14_07_32_MASS_QUANTITIES_RESIDUAL_OVERRIDES.md
@@ -1,0 +1,101 @@
+---
+execution_id: 2026_07_17_14_07_32_MASS_QUANTITIES_RESIDUAL_OVERRIDES
+prompt_id: PROMPT(AD_HOC:MASS_QUANTITIES_RESIDUAL_OVERRIDES)[2026-07-17T14:03:05-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/129
+commit: 
+created_at: 2026-07-17T14:07:32-04:00
+agent: claude_app
+instruction_source: user report from step 5 (inspect) of a manual run of lcats/docs/reference/prepare-corpora-release.md
+session_transcript: pending
+---
+
+# Summary
+
+Disposition two residual specials findings the maintainer hit at step 5
+(inspect) of their first real, non-simulated run of
+`prepare-corpora-release.md` (WI-RELEASE-0021), where `lcats survey`
+flagged two characters but `lcats repair-specials` proposed nothing for
+either. Also add an `lcats assess` pointer to the same runbook, requested
+separately in the same conversation.
+
+# Result
+
+Diagnosed first, before writing any fix: `repair-specials` only proposes a
+fix when a finding's classification is `likely_repairable`
+(`repairs.py:232-233`), which only fires for the exact continuation-byte
+mojibake patterns in `DEFAULT_REPAIR_RULES` (`repairs.py:69-162`, all
+two-character UTF-8-decoded-as-Latin-1/Mac-Roman sequences). Neither
+finding matches: Cyrillic `и` (U+0438) and `■` (U+25A0) are both classified
+`review_needed` (`specials.py:264-292`), so silence was the designed
+behavior, not a bug.
+
+Fetched the actual Project Gutenberg source for both stories to determine
+whether the characters are LCATS-introduced corruption or genuine upstream
+content:
+- "Has Anyone Here Seen Kelly?" (ebook #30086): raw text contains `иии THE
+  END` verbatim; the rest of the story renders scene breaks as
+  `* * * * *`.
+- "Rough Beast" (ebook #48880): raw text opens with `■ The field of the
+  experimental Telethink station...`; the same story renders its other,
+  mid-story scene breaks as `* * * * *` too, and `■` appears exactly once.
+
+Both are genuine upstream artifacts (almost certainly Gutenberg
+transcription quirks rendering a printer's scene-break ornament), not
+something `lcats gather` corrupted. `■` was already known: WI-RESIDUAL-0019's
+own execution record explicitly flagged "a lone U+25A0 black square" as a
+deferred "boundary/typographic artifact... candidate for a boundary-cleanup
+WI." The Cyrillic finding wasn't previously catalogued anywhere (allowlist,
+overrides, or prior execution records) -- likely because WI-RESIDUAL-0019's
+scan was simulated over an earlier `data/` snapshot, not this literal
+regeneration.
+
+Per the maintainer's explicit direction -- trust the story authors'
+structural intent (a scene break belongs there), not the transcribers'
+choice of glyph -- added two per-story overrides to
+`lcats/gatherers/overrides/mass_quantities.json`:
+- `has_anyone_here_seen_kelly__walton`: `"иии"` -> `"* * * * *"`
+- `rough_beast__aycock`: `"■"` -> `"* * * * *"`
+
+Both normalize to the same convention each story already uses for its own
+other scene breaks, rather than allowlisting the odd glyphs as-is. Added 4
+tests to `tests/gatherers_tests/overrides_test.py` (presence + apply, one
+pair per override), matching the existing seed-override test pattern.
+
+Also added a new "Optional next step: quality/genre assessment" section to
+`prepare-corpora-release.md`, pointing to `lcats assess` for after
+promotion -- `--dry-run` first (free), the real, API-cost-incurring form
+clearly marked as needing `ANTHROPIC_API_KEY` and explicit authorization,
+linking to the existing assess how-to guide rather than duplicating it.
+
+Secondary observation, not yet investigated: the maintainer's `find data/
+-iname *json | wc` showed 1868 story files, but WI-RESIDUAL-0019's record
+cites 1971 stories in its simulated scan -- a ~100-story gap worth a
+sanity check before treating the corpus as a fully clean baseline, flagged
+to the maintainer but not pursued as part of this fix.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 149 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1318 tests OK (4 new)
+- `lrh validate` -- 0 errors, 25 pre-existing owner-role/orphan warnings
+- New tests (`test_cyrillic_scene_break_override_is_present`,
+  `test_cyrillic_scene_break_override_applies`,
+  `test_black_square_scene_break_override_is_present`,
+  `test_black_square_scene_break_override_applies`) run individually and
+  pass
+
+# Follow-up
+
+- On merge: update this record to `landed`.
+- The maintainer's dogfood run of the runbook is still in progress; this
+  unblocks step 5 (inspect), not the whole run.
+- The 1868-vs-1971 story-count discrepancy noted above is unresolved and
+  worth a follow-up check.
+- This PR (#129) and PR #128 (symlink-safety fix) both branch from
+  pre-#128 `main` and touch disjoint parts of `prepare-corpora-release.md`
+  (step 2 vs. the new final section) -- no conflict expected, but not
+  verified by an actual merge yet since neither has landed.

--- a/lcats/project/executions/AD_HOC/2026_07_17_15_55_52_MASS_QUANTITIES_RESIDUAL_OVERRIDES_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_17_15_55_52_MASS_QUANTITIES_RESIDUAL_OVERRIDES_REVIEW.md
@@ -1,0 +1,71 @@
+---
+execution_id: 2026_07_17_15_55_52_MASS_QUANTITIES_RESIDUAL_OVERRIDES_REVIEW
+prompt_id: PROMPT(AD_HOC:MASS_QUANTITIES_RESIDUAL_OVERRIDES_REVIEW)[2026-07-17T15:55:16-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_17_14_07_32_MASS_QUANTITIES_RESIDUAL_OVERRIDES
+pr: https://github.com/xenotaur/LCATS/pull/129
+commit: 
+created_at: 2026-07-17T15:55:52-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/129
+session_transcript: pending
+---
+
+# Summary
+
+Address four review comments on PR #129 (the mass_quantities residual
+overrides + `lcats assess` pointer), all from the new "Optional next step"
+section: one P2 from chatgpt-codex-connector, three from
+copilot-pull-request-reviewer, reducing to two distinct issues (wrong
+`corpora/` path, wrong relative link depth).
+
+# Result
+
+Both fixed in commit ed2368a, both reproduced live before fixing (not just
+reasoned about):
+
+- Wrong `corpora/` path (3 comments, 1 distinct issue) -- the new section
+  states its working directory as `lcats/`, but `corpora/` is a sibling of
+  `lcats/` at the repo root, not under it. Reproduced exactly as the
+  reviewer described: `lcats assess corpora/ --genre "science fiction"
+  --dry-run` run from `lcats/` prints `warning: directory does not exist:
+  corpora/` then exits 0 with "No JSON files found" -- a silent no-op that
+  looks successful. `lcats assess ../corpora/ ...` from the same directory
+  correctly discovers real files. Fixed both example commands (dry-run and
+  real-run) to use `../corpora/`, with a sentence explaining why (sibling
+  of `lcats/`, not under it).
+- Wrong link depth (1 comment) -- the how-to link
+  `../lcats/analysis/corpus/README.md` was copy-pasted from
+  `docs/index.md`'s own working link without adjusting for
+  `prepare-corpora-release.md` living one directory deeper
+  (`docs/reference/`, not `docs/`). From `docs/reference/`, `../` only
+  reaches `docs/`, so the link resolved to the nonexistent
+  `docs/lcats/analysis/...`. Verified the correct target
+  (`lcats/lcats/analysis/corpus/README.md`) exists on disk, and confirmed
+  `../../lcats/analysis/corpus/README.md` resolves to it via a normpath
+  check.
+
+No comments skipped.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 149 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1318 tests OK (doc-only change, unaffected suite)
+- `lrh validate` -- 0 errors, 25 pre-existing owner-role/orphan warnings
+- Reproduced the `corpora/` bug live (silent "No JSON files found") and
+  confirmed the `../corpora/` fix actually discovers files, before and
+  after the edit
+- Confirmed the link-depth fix resolves to a real file via a Python
+  `os.path.normpath`/`os.path.exists` check, not just by reasoning about
+  directory levels
+
+# Follow-up
+
+- On merge: update this record and the primary
+  `2026_07_17_14_07_32_MASS_QUANTITIES_RESIDUAL_OVERRIDES` record to
+  `landed`.
+- Unchanged from the primary record: the maintainer's dogfood run of the
+  runbook is still in progress; the 1868-vs-1971 story-count discrepancy
+  noted there remains unresolved.

--- a/lcats/tests/gatherers_tests/overrides_test.py
+++ b/lcats/tests/gatherers_tests/overrides_test.py
@@ -123,6 +123,53 @@ class LoadOverridesTest(unittest.TestCase):
         self.assertEqual("meter stood at 102°F, then 135°", updated)
         self.assertEqual(2, applied[0]["count"])
 
+    def test_cyrillic_scene_break_override_is_present(self):
+        # Dogfood run of prepare-corpora-release.md: 'и' (U+0438) x3 used as
+        # the story's final scene-break marker, confirmed against the
+        # Project Gutenberg source (ebook #30086) as verbatim upstream text.
+        loaded = overrides.load_overrides("mass_quantities")
+
+        self.assertIn("has_anyone_here_seen_kelly__walton", loaded)
+        entry = loaded["has_anyone_here_seen_kelly__walton"][0]
+        self.assertEqual("иии", entry["find"])
+        self.assertEqual("* * * * *", entry["replace"])
+        self.assertTrue(entry["rationale"])
+
+    def test_cyrillic_scene_break_override_applies(self):
+        updated, applied = overrides.apply_overrides(
+            "...and so it ended.\n\n          иии THE END",
+            overrides.load_overrides("mass_quantities")[
+                "has_anyone_here_seen_kelly__walton"
+            ],
+        )
+
+        self.assertEqual("...and so it ended.\n\n          * * * * * THE END", updated)
+        self.assertEqual(1, applied[0]["count"])
+
+    def test_black_square_scene_break_override_is_present(self):
+        # Dogfood run of prepare-corpora-release.md: U+25A0 was previously
+        # flagged in WI-RESIDUAL-0019 as a deferred boundary artifact,
+        # confirmed against the Project Gutenberg source (ebook #48880) as
+        # verbatim upstream text (the story's opening scene-break marker).
+        loaded = overrides.load_overrides("mass_quantities")
+
+        self.assertIn("rough_beast__aycock", loaded)
+        entry = loaded["rough_beast__aycock"][0]
+        self.assertEqual("■", entry["find"])
+        self.assertEqual("* * * * *", entry["replace"])
+        self.assertTrue(entry["rationale"])
+
+    def test_black_square_scene_break_override_applies(self):
+        updated, applied = overrides.apply_overrides(
+            "■ The field of the experimental Telethink station",
+            overrides.load_overrides("mass_quantities")["rough_beast__aycock"],
+        )
+
+        self.assertEqual(
+            "* * * * * The field of the experimental Telethink station", updated
+        )
+        self.assertEqual(1, applied[0]["count"])
+
     def test_override_files_are_valid_json_keyed_by_story(self):
         for path in overrides.OVERRIDES_DIR.glob("*.json"):
             with self.subTest(path=path.name):


### PR DESCRIPTION
## Summary

Two changes from the maintainer's first real (non-simulated) run of
`prepare-corpora-release.md`, per WI-RELEASE-0021.

**Two new per-story overrides in `lcats/gatherers/overrides/mass_quantities.json`:**

- `has_anyone_here_seen_kelly__walton`: Cyrillic `и` (U+0438) x3 used as the
  story's final scene-break marker, right before "THE END".
- `rough_beast__aycock`: a lone `■` (U+25A0) used as the story's opening
  scene-break marker.

Both were confirmed against the actual Project Gutenberg source
([#30086](https://www.gutenberg.org/ebooks/30086),
[#48880](https://www.gutenberg.org/ebooks/48880)) to be present verbatim
upstream — not corruption introduced anywhere in LCATS's pipeline — almost
certainly artifacts of how Gutenberg's own volunteer transcribers rendered
a printer's scene-break ornament. Both stories render their *other* scene
breaks as `* * * * *`, so per the maintainer's direction (trust the
authors' structural intent, not the transcribers' choice of glyph), both
overrides normalize to that same convention rather than allowlisting the
odd glyphs as-is. `■` was already flagged as a deferred "boundary artifact"
in `WI-RESIDUAL-0019`'s execution record; this resolves it. The Cyrillic
finding wasn't previously catalogued anywhere.

Added 4 tests to `tests/gatherers_tests/overrides_test.py` matching the
existing seed-override test pattern (presence + apply, one pair per
override).

**New "Optional next step: quality/genre assessment" section in
`lcats/docs/reference/prepare-corpora-release.md`:** a pointer to
`lcats assess` for after promotion, requested by the maintainer while
working through the runbook. Previewed via `--dry-run` (free); the real,
API-cost-incurring form is clearly marked as needing an API key and
explicit go-ahead, and links to the existing assess how-to guide rather
than duplicating its reference.

## Test plan

- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — ruff + black pass
- [x] `scripts/test` — 1318 tests OK (4 new)
- [x] `lrh validate` — 0 errors, 25 pre-existing warnings
- [x] New override tests run individually and pass
