### PR TITLE
Add work item WI-CLEAN-0022: Harden data/cache dir creation against dangling symlinks; add lcats clean

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_17_19_14_30_WI_CLEAN_0022_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_17_19_14_30_WI_CLEAN_0022_REVIEW.md
@@ -1,0 +1,76 @@
+---
+execution_id: 2026_07_17_19_14_30_WI_CLEAN_0022_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_CLEAN_0022_REVIEW)[2026-07-17T18:49:05-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/130
+commit: 
+created_at: 2026-07-17T19:14:30-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/130
+session_transcript: pending
+---
+
+# Summary
+
+Address six review comments on PR #130 (WI-CLEAN-0022's planning artifact):
+four path-prefix issues from copilot-pull-request-reviewer, two P2 design
+gaps from chatgpt-codex-connector. No `rerun_of`: this WI was created via
+the `/lrh-work-item` flow, no `/lrh-implement` primary record exists yet.
+
+# Result
+
+All six fixed in commit 58f87c1, each confirmed before fixing:
+
+- Path-prefix inconsistency (4 comments) -- the WI's `artifacts_expected`
+  and `related_design` frontmatter already used the correct
+  `lcats/lcats/...` repo-root-relative paths, but the `## Required
+  Changes` body prose used the shorter, incorrect form
+  (`lcats/utils/paths.py` instead of `lcats/lcats/utils/paths.py`, etc.) --
+  confirmed by listing both candidate paths directly rather than assuming.
+  Fixed all four body-prose occurrences to match the frontmatter.
+- Ancestor-dangling-symlink gap (P2) -- confirmed live, not just reasoned
+  about: `os.makedirs("cache/resources")` when `cache` itself (not the
+  leaf) is a dangling symlink raises `FileNotFoundError`, not the
+  `FileExistsError` the WI's original 4-case test matrix was scoped
+  around. This is the realistic failure mode for `cache/resources`,
+  `cache/texts`, `cache/tmp`, since `cache/` itself is what gets
+  symlinked in the documented setup, not these subdirectories. Added an
+  explicit 5th case to the acceptance criteria and Required Changes #1,
+  naming both exception types so the distinction can't be missed during
+  implementation.
+- Self-contradictory `DataGatherer.clear()` fix (P2) -- confirmed the
+  contradiction directly: checking `file_path` instead of `self.path` in
+  the per-entry loop would leave `self.path` in place (now empty) after
+  clearing, but `test_clear_removes_path` asserts `self.path` is gone
+  entirely. Resolved by re-scoping Required Changes #3 from "fix the
+  per-entry check" to "simplify to a direct `shutil.rmtree(self.path)`,
+  no behavior change" -- `self.path` (e.g. `data/sherlock`) is a real
+  subdirectory inside whatever `data/` resolves to, never the `data/`
+  symlink itself, so removing it wholesale was already symlink-safe; the
+  per-entry branching was dead code producing the same result by
+  accident, not a safety bug needing a behavior change.
+
+No comments skipped.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean (doc-only change, no Python
+  files touched)
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1318 tests OK (unaffected suite)
+- `lrh validate` -- 0 errors, 26 pre-existing owner-role/orphan warnings
+- `lrh work-items readiness WI-CLEAN-0022 --format md` -- still
+  `prompt_ready: yes`
+
+# Follow-up
+
+- On merge: resolve WI-CLEAN-0022... no -- WI-CLEAN-0022 itself is not
+  resolved by this PR; only the planning artifact is landing. The WI
+  stays `proposed` until `/lrh-implement WI-CLEAN-0022` produces the
+  actual code.
+- Once PR #130 merges, re-fetch fresh `main` before branching for
+  implementation, per the maintainer's own instruction earlier in this
+  session (double-check against the reviewed PR's revised WI content
+  before starting).

--- a/lcats/project/work_items/proposed/WI-CLEAN-0022.md
+++ b/lcats/project/work_items/proposed/WI-CLEAN-0022.md
@@ -1,0 +1,154 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-CLEAN-0022
+title: Harden data/cache directory creation against dangling symlinks; add lcats clean
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_workstreams:
+  - WS-SPECIALS-CLEANUP
+related_design:
+  - lcats/docs/reference/prepare-corpora-release.md
+  - lcats/lcats/gatherers/downloaders.py
+  - lcats/lcats/gettenberg/cache.py
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - modify_data_or_corpora_contents
+acceptance:
+  - lcats.utils.paths.makedirs() exists and is unit-tested for all four cases -- path missing, path already a valid directory (incl. via a live symlink), path is a dangling symlink, path is blocked by a plain file
+  - All five existing os.makedirs/Path.mkdir call sites for data/cache directories (downloaders.py ResourceCache.ensure(), DataGatherer.ensure() x2, gettenberg/cache.py's two module-level mkdir calls) use the new utility
+  - DataGatherer.clear()'s per-entry check uses the loop variable instead of the constant parent path, with test_clear_removes_path's existing assertion unchanged
+  - gettenberg/cache.py gains a symlink-safe clear function for cache/texts and cache/tmp, unit-tested
+  - lcats clean CLI subcommand exists, clears data/ and cache/ contents while preserving symlinks, and is documented in --help
+  - prepare-corpora-release.md's "Clear stale local state" step is updated to use lcats clean as the primary path
+  - lrh validate reports 0 errors
+  - scripts/test passes with new/updated coverage for all of the above
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/lcats/utils/paths.py
+  - lcats/tests/utils_tests/paths_test.py
+  - lcats/lcats/gatherers/downloaders.py
+  - lcats/lcats/gettenberg/cache.py
+  - lcats/lcats/analysis/corpus/clean_cli.py
+  - lcats/lcats/cli.py
+  - lcats/docs/reference/prepare-corpora-release.md
+---
+
+# Work Item: WI-CLEAN-0022
+
+## Summary
+Add a symlink-aware directory-creation utility (`lcats.utils.paths.makedirs()`)
+to fix a real crash hit during dogfooding, fix a related dead-logic bug in
+`DataGatherer.clear()`, and ship a new `lcats clean` command so users never
+need shell-glob reasoning to safely clear `data/`/`cache/`.
+
+## Problem / Context
+While manually running `prepare-corpora-release.md` (WI-RELEASE-0021),
+`lcats gather` crashed with `FileExistsError: 'data'` after the maintainer's
+`data/` symlink was left dangling (its target directory was deleted, not
+just emptied). Root-caused via live reproduction and by reading the
+installed CPython `os.py` source directly: `os.makedirs`'s `ensure()` call
+sites use `if not os.path.exists(path): os.makedirs(path)`, and
+`os.path.exists()` returns `False` for a broken symlink (per the Python
+docs), so the code proceeds to `mkdir()`, which fails with `EEXIST` because
+a symlink already occupies that name. Critically, `exist_ok=True` — the
+standard reflex fix — does **not** help: both `os.makedirs` and
+`pathlib.Path.mkdir`'s `exist_ok` suppression is gated on
+`path.isdir(name)`/`self.is_dir()`, which is also `False` for a dangling
+symlink (confirmed against `os.py:229` and `pathlib.py:1125` directly).
+While investigating reuse of the existing `ResourceCache.clear()` /
+`DataGatherer.clear()` methods for a proposed `lcats clean` command, found
+that `DataGatherer.clear()`'s per-entry file/symlink/directory check
+(`downloaders.py:279-282`) checks the constant parent path instead of the
+loop variable — dead logic that happens to produce its currently-tested,
+intended result (removing the whole gatherer subdirectory) by accident,
+worth fixing for clarity while touching this file. `gettenberg/cache.py`'s
+`cache/texts`/`cache/tmp` directories (used only by `mass_quantities`) have
+no `clear()` method at all today.
+
+## Scope
+- A new, unit-tested `lcats.utils.paths.makedirs()` utility distinguishing
+  "doesn't exist," "already a valid directory," "dangling symlink," and
+  "blocked by a plain file."
+- Wiring that utility into all five existing unsafe call sites.
+- A correctness (not behavior) fix to `DataGatherer.clear()`.
+- A new clear function for `gettenberg/cache.py`'s two cache directories.
+- A new `lcats clean` CLI subcommand and a runbook update to use it.
+
+## Required Changes
+1. Create `lcats/utils/paths.py` with a `makedirs()` function: no-op if the
+   path already resolves to a real directory (symlink or not); if the path
+   is a dangling symlink, recreate the symlink's target directory (`data/`
+   and `cache/` are both documented, in this same runbook, as disposable
+   regenerable caches, so auto-healing is consistent with their existing
+   contract — the proposed default, per this WI's own Risk Notes); if the
+   path is blocked by a plain file or anything else non-directory, raise a
+   clear `NotADirectoryError`-style message naming the exact conflict,
+   instead of letting a bare `FileExistsError` propagate.
+2. Update `lcats/gatherers/downloaders.py`: `ResourceCache.ensure()`
+   (line ~71) and `DataGatherer.ensure()` (lines ~204, ~208) to call
+   `paths.makedirs()` instead of `os.makedirs()`.
+3. Fix `DataGatherer.clear()` (lines ~272-287): change the per-entry
+   `if os.path.isfile(self.path)...` checks to check `file_path` (the loop
+   variable), not `self.path`. `test_clear_removes_path`'s assertion (the
+   whole gatherer directory is gone afterward) must still pass unchanged.
+4. Update `lcats/gettenberg/cache.py`'s module-level
+   `GUTENBERG_TEXTS.mkdir(...)`/`GUTENBERG_TMP.mkdir(...)` (lines ~31, ~33)
+   to use `paths.makedirs()`, and add a new `clear()`-equivalent function
+   for both directories, symlink-safe by construction.
+5. Create `lcats/analysis/corpus/clean_cli.py` (following the
+   `promote_cli.py`/`assess_cli.py` pattern) and wire a `clean` subcommand
+   into `lcats/cli.py`, clearing `data/` (all gatherers) and `cache/`
+   (both cache mechanisms) via the functions above.
+6. Update `lcats/docs/reference/prepare-corpora-release.md`'s "Clear stale
+   local state" section to recommend `lcats clean` as the primary path,
+   since by that point in the runbook `scripts/develop` has already run
+   (Pre-flight precedes Clear), so `lcats` is guaranteed to be on `PATH`.
+
+## Non-Goals
+- Does not change `ResourceCache.clear()`'s existing, already-correct
+  behavior.
+- Does not retroactively address the maintainer's already-manually-resolved
+  dangling-symlink incident.
+- Does not touch the separate `lcats survey`/`lcats promote` exclusion-list
+  inconsistency (tracked separately).
+- Does not remove the runbook's documented `sh -c 'rm -rf ...'` glob
+  commands entirely -- keep them as a fallback note for readers without
+  `lcats` on `PATH` yet.
+
+## Acceptance Criteria
+- `lcats.utils.paths.makedirs()` is unit-tested for all four cases listed
+  in the frontmatter `acceptance` list.
+- All five call sites use the new utility; no remaining unsafe
+  `os.makedirs`/`Path.mkdir` calls for these two directory trees.
+- `lcats clean` clears `data/`/`cache/` contents while preserving a
+  symlinked setup, verified with a symlink-backed test fixture.
+- `lrh validate` reports 0 errors.
+
+## Validation
+- `scripts/version tools`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `lrh validate`
+
+## Risk Notes
+- Auto-healing a dangling symlink (recreating its target directory) is a
+  real design choice, not a neutral default -- it's the right call for
+  `data/`/`cache/` specifically because both are already documented,
+  elsewhere in this exact runbook, as disposable regenerable caches, but
+  it would be the *wrong* default for a general-purpose utility applied to
+  arbitrary paths. This was flagged to the maintainer before this work item
+  was written and accepted as proposed.
+- `lcats clean` operates on real filesystem state; implementation and
+  tests must exercise it only against temp directories, never the
+  session's real `data/`/`cache/`.

--- a/lcats/project/work_items/proposed/WI-CLEAN-0022.md
+++ b/lcats/project/work_items/proposed/WI-CLEAN-0022.md
@@ -21,9 +21,9 @@ forbidden_actions:
   - delete_branch
   - modify_data_or_corpora_contents
 acceptance:
-  - lcats.utils.paths.makedirs() exists and is unit-tested for all four cases -- path missing, path already a valid directory (incl. via a live symlink), path is a dangling symlink, path is blocked by a plain file
+  - lcats.utils.paths.makedirs() exists and is unit-tested for at least five cases -- path missing, path already a valid directory (incl. via a live symlink), path itself is a dangling symlink (leaf case), path is blocked by a plain file, and a nested path whose ancestor (not the leaf) is a dangling symlink (e.g. cache/resources when cache/ itself is dangling)
   - All five existing os.makedirs/Path.mkdir call sites for data/cache directories (downloaders.py ResourceCache.ensure(), DataGatherer.ensure() x2, gettenberg/cache.py's two module-level mkdir calls) use the new utility
-  - DataGatherer.clear()'s per-entry check uses the loop variable instead of the constant parent path, with test_clear_removes_path's existing assertion unchanged
+  - DataGatherer.clear() is simplified to a direct shutil.rmtree(self.path) call with no behavior change; test_clear_removes_path passes completely unmodified
   - gettenberg/cache.py gains a symlink-safe clear function for cache/texts and cache/tmp, unit-tested
   - lcats clean CLI subcommand exists, clears data/ and cache/ contents while preserving symlinks, and is documented in --help
   - prepare-corpora-release.md's "Clear stale local state" step is updated to use lcats clean as the primary path
@@ -85,29 +85,47 @@ no `clear()` method at all today.
 - A new `lcats clean` CLI subcommand and a runbook update to use it.
 
 ## Required Changes
-1. Create `lcats/utils/paths.py` with a `makedirs()` function: no-op if the
-   path already resolves to a real directory (symlink or not); if the path
-   is a dangling symlink, recreate the symlink's target directory (`data/`
-   and `cache/` are both documented, in this same runbook, as disposable
-   regenerable caches, so auto-healing is consistent with their existing
-   contract — the proposed default, per this WI's own Risk Notes); if the
-   path is blocked by a plain file or anything else non-directory, raise a
-   clear `NotADirectoryError`-style message naming the exact conflict,
-   instead of letting a bare `FileExistsError` propagate.
-2. Update `lcats/gatherers/downloaders.py`: `ResourceCache.ensure()`
+1. Create `lcats/lcats/utils/paths.py` with a `makedirs()` function: no-op
+   if the path already resolves to a real directory (symlink or not); if
+   the path or any ancestor in it is a dangling symlink, recreate the
+   missing target directory (`data/` and `cache/` are both documented, in
+   this same runbook, as disposable regenerable caches, so auto-healing is
+   consistent with their existing contract — the proposed default, per
+   this WI's own Risk Notes); if the path is blocked by a plain file or
+   anything else non-directory, raise a clear `NotADirectoryError`-style
+   message naming the exact conflict, instead of letting a bare
+   `FileExistsError`/`FileNotFoundError` propagate. Must handle both a
+   dangling *leaf* (e.g. `data` itself, which raises `FileExistsError` from
+   plain `os.makedirs`) and a dangling *ancestor* of a nested path (e.g.
+   `cache/resources` when `cache` itself is the dangling symlink, which
+   raises the differently-shaped `FileNotFoundError` instead) — these are
+   confirmed to be genuinely different underlying failures, not variants
+   of the same one.
+2. Update `lcats/lcats/gatherers/downloaders.py`: `ResourceCache.ensure()`
    (line ~71) and `DataGatherer.ensure()` (lines ~204, ~208) to call
    `paths.makedirs()` instead of `os.makedirs()`.
-3. Fix `DataGatherer.clear()` (lines ~272-287): change the per-entry
-   `if os.path.isfile(self.path)...` checks to check `file_path` (the loop
-   variable), not `self.path`. `test_clear_removes_path`'s assertion (the
-   whole gatherer directory is gone afterward) must still pass unchanged.
-4. Update `lcats/gettenberg/cache.py`'s module-level
+3. Simplify `DataGatherer.clear()` (lines ~272-287) to a direct
+   `shutil.rmtree(self.path)` when `self.path` exists, removing the
+   current per-entry `os.listdir()` loop and its file/symlink/directory
+   branching — that branching is currently dead code (every check tests
+   the constant `self.path`, not the loop variable, so it always takes the
+   same branch regardless of what's actually in the directory) that
+   happens to produce today's tested result by accident. This is a
+   clarity fix with **no behavior change**: `test_clear_removes_path`'s
+   existing assertion (the whole gatherer directory, e.g. `data/sherlock`,
+   is gone afterward) must continue to pass completely unmodified. Do not
+   change this method to clear contents while preserving `self.path`
+   itself — `self.path` (e.g. `data/sherlock`) is always a real
+   subdirectory *inside* whatever `data/` resolves to, never the `data/`
+   symlink itself, so removing it wholesale is already symlink-safe and
+   requires no further change here.
+4. Update `lcats/lcats/gettenberg/cache.py`'s module-level
    `GUTENBERG_TEXTS.mkdir(...)`/`GUTENBERG_TMP.mkdir(...)` (lines ~31, ~33)
    to use `paths.makedirs()`, and add a new `clear()`-equivalent function
    for both directories, symlink-safe by construction.
-5. Create `lcats/analysis/corpus/clean_cli.py` (following the
+5. Create `lcats/lcats/analysis/corpus/clean_cli.py` (following the
    `promote_cli.py`/`assess_cli.py` pattern) and wire a `clean` subcommand
-   into `lcats/cli.py`, clearing `data/` (all gatherers) and `cache/`
+   into `lcats/lcats/cli.py`, clearing `data/` (all gatherers) and `cache/`
    (both cache mechanisms) via the functions above.
 6. Update `lcats/docs/reference/prepare-corpora-release.md`'s "Clear stale
    local state" section to recommend `lcats clean` as the primary path,
@@ -126,8 +144,11 @@ no `clear()` method at all today.
   `lcats` on `PATH` yet.
 
 ## Acceptance Criteria
-- `lcats.utils.paths.makedirs()` is unit-tested for all four cases listed
-  in the frontmatter `acceptance` list.
+- `lcats.utils.paths.makedirs()` is unit-tested for all five cases listed
+  in the frontmatter `acceptance` list, including the ancestor-dangling
+  case distinct from the leaf-dangling case (they raise different
+  underlying exceptions -- `FileNotFoundError` vs. `FileExistsError` --
+  and a fix for one does not imply a fix for the other).
 - All five call sites use the new utility; no remaining unsafe
   `os.makedirs`/`Path.mkdir` calls for these two directory trees.
 - `lcats clean` clears `data/`/`cache/` contents while preserving a

--- a/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
+++ b/lcats/project/workstreams/proposed/WS-SPECIALS-CLEANUP.md
@@ -22,6 +22,7 @@ work_items:
   - WI-RESIDUAL-0019
   - WI-PROMOTE-0020
   - WI-RELEASE-0021
+  - WI-CLEAN-0022
 exit_criteria:
   - lcats survey --mode specials over freshly regenerated data/ reports zero unaddressed mojibake findings — every measured residual occurrence is repaired by rule, covered by a per-story override, or explicitly allowlisted
   - Repair rules and per-story overrides are versioned repo inputs applied during gathering, so clearing the cache and regenerating data/ reproduces the same repaired output deterministically


### PR DESCRIPTION
## Summary

Planning artifact for WI-CLEAN-0022. No implementation in this PR.

Discovered during a maintainer's manual dogfood run of
`prepare-corpora-release.md` (WI-RELEASE-0021): `lcats gather` crashed with
`FileExistsError: 'data'` after the maintainer's `data/` symlink was left
dangling (its target directory was deleted, not just emptied). Root-caused
by live reproduction and by reading the installed CPython `os.py` source
directly — critically, `exist_ok=True` does **not** fix this, since both
`os.makedirs` and `pathlib.Path.mkdir` gate their `exist_ok` suppression on
`isdir()`, which is `False` for a dangling symlink too.

While scoping the fix, also found a related dead-logic bug in
`DataGatherer.clear()` (checks the constant parent path instead of the
loop variable — currently harmless by accident, but worth fixing while
touching this file) and an opportunity to ship a proper `lcats clean`
command so nobody needs shell-glob reasoning to safely clear
`data/`/`cache/` again.

**Type:** deliverable
**Related workstream:** WS-SPECIALS-CLEANUP

## Acceptance criteria

- `lcats.utils.paths.makedirs()` exists and is unit-tested for all four
  cases: path missing, already a valid directory (incl. via a live
  symlink), a dangling symlink, blocked by a plain file.
- All five existing unsafe `os.makedirs`/`Path.mkdir` call sites use it.
- `DataGatherer.clear()`'s per-entry check is fixed (no behavior change).
- `gettenberg/cache.py` gains a symlink-safe clear function for
  `cache/texts`/`cache/tmp`.
- `lcats clean` CLI subcommand exists, documented in `--help`.
- `prepare-corpora-release.md`'s clear-step recommends `lcats clean`.
- `lrh validate` reports 0 errors.

## Test plan

- [x] `lrh validate` — 0 errors, 26 warnings (1 new, matching the
      pre-existing `owner: unassigned` pattern on every other WI)
- [x] `lrh work-items readiness WI-CLEAN-0022` — `prompt_ready: yes`
- [ ] Implementation (separate PR, via `/lrh-implement WI-CLEAN-0022`)
