### PR TITLE
Implement WI-CLEAN-0022: symlink-safe directory creation and lcats clean

### DIFF
--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -52,51 +52,41 @@ source list (or renamed) leaves a stale file behind that `lcats survey` and
 `corpora/`, nothing here is precious):
 
 ```bash
-sh -c 'rm -rf data/* data/.[!.]* data/..?*'
+lcats clean
 ```
 
-`data/` and `cache/` are plain directories for most setups, but some
-machines point them at symlinks to a scratch/tempspace location (to keep
-large regenerated data out of a backup system, for instance) — every
-clear command in this runbook removes the *contents* of the directory
-without touching the directory (or symlink) itself, so a symlinked setup
-survives a clear-and-regenerate cycle intact. The three glob patterns
-together (`data/*`, `data/.[!.]*`, `data/..?*`) are the standard portable
-idiom for "every entry, dotfiles included, excluding `.`/`..` themselves"
-— a bare `data/*` misses dotfiles (e.g. a stray `.DS_Store` or a leftover
-`.ipynb_checkpoints/` directory), which `lcats survey`'s recursive
-discovery and `lcats promote`'s directory-level scan would otherwise still
-pick up despite the runbook saying the local corpus was cleared. Running
-the globs under `sh -c '...'` rather than directly is deliberate, not
-stylistic: zsh's default options abort with `no matches found` if *any one*
-of the three globs doesn't match anything (e.g. there are no dotfiles
-present, or the directory is empty or doesn't exist yet), while `/bin/sh`
-doesn't have that behavior — `sh -c '...'` makes the command copy-pasteable
-regardless of which shell you run it in, and regardless of which subset of
-the three patterns happens to match.
+`lcats clean` clears every `data/<gatherer>` directory and both cache
+mechanisms (`cache/resources`, and `mass_quantities`'s separate
+`cache/texts`/`cache/tmp`). It's safe on a symlinked `data/`/`cache/`
+setup (some machines point these at a scratch/tempspace location, to keep
+large regenerated data out of a backup system) — only contents are ever
+removed, never the directory or symlink itself — and it self-heals a
+dangling symlink it encounters along the way (one whose target directory
+no longer exists), rather than crashing on the next `lcats gather` the way
+a bare `os.makedirs` does.
 
-To re-check a single collection instead of the whole corpus, clear only
-that one directory, e.g.
-`sh -c 'rm -rf data/mass_quantities/* data/mass_quantities/.[!.]* data/mass_quantities/..?*'`.
-This is a diagnostic shortcut, not a release step: scope every command in
-the rest of this runbook to that same collection name (`lcats survey
+To re-check a single collection instead of the whole corpus, scope the
+clear to just that gatherer, e.g. `lcats clean mass_quantities`. This
+intentionally does **not** touch `cache/`, and scope every following
+command in this runbook to that same collection name too (`lcats survey
 --mode specials data/mass_quantities --no-progress`, `lcats promote
 mass_quantities --dry-run`, `lcats promote mass_quantities`) rather than
 running the unscoped forms — those consider every collection under
-`data/`, including ones you did not just regenerate.
+`data/`, including ones you did not just regenerate. Clear the cache too
+with `lcats clean --cache-only`, if you specifically need a from-network
+recheck of that one collection (see the note on `lcats gather` below).
 
-(Optional, for a fully from-network run: `rm -rf cache/resources cache/texts`
-also clears the cached raw Project Gutenberg pages, so extraction re-runs
-against freshly downloaded source text rather than a locally cached copy.
-Both directories are recreated automatically on the next `lcats gather`, so
-removing them outright — no glob, no `sh -c` needed — is safe. Most
-gatherers cache through `cache/resources`, but `mass_quantities` caches raw
-text separately through `cache/texts` (`lcats/gettenberg/cache.py:30`, via
-`lcats/gettenberg/api.py:37`), so a from-network run of `mass_quantities`
-specifically needs both cleared, not just `cache/resources`. This isn't
-required to verify the repair pipeline — the JSON write step above is what
-actually re-triggers the repair logic — but it's the strictest form of
-"fresh.")
+(If `lcats` isn't on `PATH` yet — e.g. you're troubleshooting the
+Pre-flight step above and haven't finished `scripts/develop` — the
+equivalent raw shell command is
+`sh -c 'rm -rf data/* data/.[!.]* data/..?*'`. The three glob patterns
+together (`data/*`, `data/.[!.]*`, `data/..?*`) are the standard portable
+idiom for "every entry, dotfiles included, excluding `.`/`..` themselves"
+— a bare `data/*` misses dotfiles. Running the globs under `sh -c '...'`
+rather than directly is deliberate, not stylistic: zsh's default options
+abort with `no matches found` if *any one* of the three globs doesn't
+match anything, while `/bin/sh` doesn't have that behavior. Unlike
+`lcats clean`, this fallback does not self-heal a dangling symlink.)
 
 ## 3. Regenerate
 
@@ -121,8 +111,9 @@ This reads from the `cache/resources` cache when a source page is already
 cached there, and only hits Project Gutenberg over the network for pages
 that aren't. Expect it to take a while for the full corpus either way,
 `mass_quantities` in particular (it's by far the largest collection). To
-force a genuinely fresh, fully-networked run, clear the cache too (see the
-optional note above).
+force a genuinely fresh, fully-networked run, clear the cache too:
+`lcats clean --cache-only` (or bare `lcats clean`, which clears both
+`data/` and `cache/` together — see step 2 above).
 
 ## 4. Verify
 

--- a/lcats/lcats/analysis/corpus/clean_cli.py
+++ b/lcats/lcats/analysis/corpus/clean_cli.py
@@ -1,0 +1,108 @@
+"""CLI wrapper for clearing data/ and cache/ contents, symlink-safe."""
+
+import argparse
+import shutil
+import sys
+
+from lcats.gatherers import main as gatherers_main
+from lcats.gettenberg import cache as gettenberg_cache
+from lcats.utils import env
+from lcats.utils import paths
+
+
+def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
+    """Build parser for the clean command."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Clear data/ and/or cache/ contents without shell-glob reasoning. "
+            "Safe for a symlinked data/ or cache/ setup: only contents are "
+            "removed, never the directory (or symlink) itself."
+        ),
+        add_help=add_help,
+        epilog=(
+            "Examples:\n"
+            "  lcats clean                  # clear all of data/ and all of cache/\n"
+            "  lcats clean mass_quantities  # clear just data/mass_quantities/,\n"
+            "                               # leaving cache/ untouched -- a targeted\n"
+            "                               # recheck must not invalidate the shared\n"
+            "                               # cache every other gatherer relies on\n"
+            "  lcats clean --cache-only     # clear cache/ only, leave data/ alone\n"
+            "  lcats clean --data-only      # clear data/ only, leave cache/ alone"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "gatherers",
+        nargs="*",
+        help="Gatherer names to clean under data/. Defaults to every gatherer.",
+    )
+    parser.add_argument(
+        "--data-only",
+        action="store_true",
+        help="Clean only data/; leave cache/ untouched.",
+    )
+    parser.add_argument(
+        "--cache-only",
+        action="store_true",
+        help="Clean only cache/; leave data/ untouched.",
+    )
+    return parser
+
+
+def _clean_data(gatherer_names):
+    """Clear data/, either entirely or scoped to specific gatherer names."""
+    if not gatherer_names:
+        paths.clear_directory_contents(env.data_root())
+        print(f"cleared: {env.data_root()}")
+        return
+
+    for name in gatherer_names:
+        if name not in gatherers_main.GATHERERS:
+            print(f"Unknown gatherer: {name}", file=sys.stderr)
+            continue
+        target = env.data_root() / name
+        shutil.rmtree(target, ignore_errors=True)
+        print(f"cleared: {target}")
+
+
+def _clean_cache():
+    """Clear both cache mechanisms: resources, and texts/tmp."""
+    paths.clear_directory_contents(env.cache_resources_dir())
+    print(f"cleared: {env.cache_resources_dir()}")
+    gettenberg_cache.clear_texts_and_tmp()
+    print(f"cleared: {gettenberg_cache.GUTENBERG_TEXTS}")
+    print(f"cleared: {gettenberg_cache.GUTENBERG_TMP}")
+
+
+def run(argv=None, parsed_args=None) -> int:
+    """Run the clean command. Returns 0 on success."""
+    parser = build_parser()
+    args = parsed_args if parsed_args is not None else parser.parse_args(argv)
+
+    if args.data_only and args.cache_only:
+        print(
+            "error: --data-only and --cache-only are mutually exclusive",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.gatherers and args.cache_only:
+        print("error: gatherer names are not valid with --cache-only", file=sys.stderr)
+        return 2
+
+    try:
+        if not args.cache_only:
+            _clean_data(args.gatherers)
+        # Scoping to specific gatherer names is a targeted recheck, not a
+        # full release-prep clear -- it must not also invalidate the shared
+        # cache/ that every other gatherer relies on.
+        if not args.data_only and not args.gatherers:
+            _clean_cache()
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/lcats/lcats/analysis/corpus/clean_cli.py
+++ b/lcats/lcats/analysis/corpus/clean_cli.py
@@ -50,7 +50,14 @@ def build_parser(add_help: bool = True) -> argparse.ArgumentParser:
 
 
 def _clean_data(gatherer_names):
-    """Clear data/, either entirely or scoped to specific gatherer names."""
+    """Clear data/, either entirely or scoped to specific gatherer names.
+
+    Heals a dangling data/ symlink first (paths.makedirs is a no-op when
+    data/ is already fine) -- clear_directory_contents alone can't do this,
+    since it no-ops on a path that isn't currently a valid directory.
+    """
+    paths.makedirs(env.data_root())
+
     if not gatherer_names:
         paths.clear_directory_contents(env.data_root())
         print(f"cleared: {env.data_root()}")
@@ -66,12 +73,14 @@ def _clean_data(gatherer_names):
 
 
 def _clean_cache():
-    """Clear both cache mechanisms: resources, and texts/tmp."""
+    """Clear every cache mechanism: resources, and the Gutenberg cache."""
+    paths.makedirs(env.cache_resources_dir())
     paths.clear_directory_contents(env.cache_resources_dir())
     print(f"cleared: {env.cache_resources_dir()}")
-    gettenberg_cache.clear_texts_and_tmp()
+    gettenberg_cache.clear_all()
     print(f"cleared: {gettenberg_cache.GUTENBERG_TEXTS}")
     print(f"cleared: {gettenberg_cache.GUTENBERG_TMP}")
+    print(f"cleared: {gettenberg_cache.GUTENBERG_ROOT} (index DB, RDF archive)")
 
 
 def run(argv=None, parsed_args=None) -> int:

--- a/lcats/lcats/cli.py
+++ b/lcats/lcats/cli.py
@@ -6,6 +6,7 @@ import sys
 
 from lcats.analysis.corpus import assess_cli
 from lcats.analysis.corpus import cli as corpus_cli
+from lcats.analysis.corpus import clean_cli
 from lcats.analysis.corpus import promote_cli
 from lcats.analysis.corpus import repairs_cli
 import lcats.gatherers.main
@@ -56,6 +57,10 @@ def _handle_repair_specials(args):
 
 def _handle_promote(args):
     return "", promote_cli.run(parsed_args=args)
+
+
+def _handle_clean(args):
+    return "", clean_cli.run(parsed_args=args)
 
 
 def _handle_meta_register(args):
@@ -244,6 +249,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     promote_parser.set_defaults(handler=_handle_promote)
     command_parsers["promote"] = promote_parser
+
+    clean_parent = clean_cli.build_parser(add_help=False)
+    clean_parser = subparsers.add_parser(
+        "clean",
+        parents=[clean_parent],
+        help="Clear data/ and/or cache/ contents, symlink-safe.",
+        description=(
+            "Clear data/ and/or cache/ contents without shell-glob reasoning. "
+            "Safe for a symlinked data/ or cache/ setup: only contents are "
+            "removed, never the directory (or symlink) itself."
+        ),
+    )
+    clean_parser.set_defaults(handler=_handle_clean)
+    command_parsers["clean"] = clean_parser
 
     meta_parser = subparsers.add_parser(
         "meta",

--- a/lcats/lcats/gatherers/downloaders.py
+++ b/lcats/lcats/gatherers/downloaders.py
@@ -11,6 +11,7 @@ from lcats import constants
 from lcats.gatherers import normalization
 from lcats.utils import env
 from lcats.utils import names
+from lcats.utils import paths
 
 
 def load_page(url, timeout=10, preferred_encoding="utf-8"):
@@ -66,9 +67,7 @@ class ResourceCache(abc.ABC):
     def ensure(self, filename):
         """Ensure the directory tree exists and whether the file is there."""
         # Create the root directory if it doesn't exist
-
-        if not os.path.exists(self.root):
-            os.makedirs(self.root)
+        paths.makedirs(self.root)
 
         # Check if the file exists
         full_path = self.full_path(filename)
@@ -200,12 +199,10 @@ class DataGatherer:
     def ensure(self, filename):
         """Ensure the directory tree exists and whether the file is there."""
         # Create the root directory if it doesn't exist
-        if not os.path.exists(self.root):
-            os.makedirs(self.root)
+        paths.makedirs(self.root)
 
         # Create the subdirectory if provided and doesn't exist
-        if not os.path.exists(self.path):
-            os.makedirs(self.path)
+        paths.makedirs(self.path)
 
         # Create the license file if it doesn't exist
         license_path = os.path.join(self.path, constants.LICENSE_FILE)
@@ -270,19 +267,13 @@ class DataGatherer:
                 return json.load(json_file)
 
     def clear(self):
-        """Clear the contents of the gatherer's directory."""
+        """Remove the gatherer's directory (and everything in it)."""
         if os.path.exists(self.path):
-            # Remove all contents of the directory
-            for filename in os.listdir(self.path):
-                file_path = os.path.join(self.path, filename)
-                try:
-                    if os.path.isfile(self.path) or os.path.islink(self.path):
-                        os.unlink(file_path)  # Remove the file or link
-                    elif os.path.isdir(self.path):
-                        shutil.rmtree(self.path)  # Remove the directory
-                except Exception as e:
-                    print(f"Failed to delete {self.path}. Reason: {e}")
-            print(f"Cleared all contents in {self.path}")
+            try:
+                shutil.rmtree(self.path)
+                print(f"Cleared all contents in {self.path}")
+            except Exception as e:
+                print(f"Failed to delete {self.path}. Reason: {e}")
         else:
             print(f"Directory {self.path} does not exist, nothing to clear.")
 

--- a/lcats/lcats/gatherers/downloaders.py
+++ b/lcats/lcats/gatherers/downloaders.py
@@ -271,7 +271,7 @@ class DataGatherer:
         if os.path.exists(self.path):
             try:
                 shutil.rmtree(self.path)
-                print(f"Cleared all contents in {self.path}")
+                print(f"Removed {self.path}")
             except Exception as e:
                 print(f"Failed to delete {self.path}. Reason: {e}")
         else:

--- a/lcats/lcats/gettenberg/cache.py
+++ b/lcats/lcats/gettenberg/cache.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from gutenbergpy import gutenbergcache as gc
 from lcats.utils import env
+from lcats.utils import paths
 
 # ------------ cache helpers ------------
 # Whether to auto-create the cache if missing.
@@ -28,9 +29,15 @@ if GUTENBERG_ROOT.exists() and not GUTENBERG_ROOT.is_dir():
     )  # pragma: no cover
 
 GUTENBERG_TEXTS = GUTENBERG_ROOT / "texts"
-GUTENBERG_TEXTS.mkdir(parents=True, exist_ok=True)  # makes root too.
+paths.makedirs(GUTENBERG_TEXTS)  # makes root too, healing a dangling symlink.
 GUTENBERG_TMP = GUTENBERG_ROOT / "tmp"
-GUTENBERG_TMP.mkdir(parents=True, exist_ok=True)
+paths.makedirs(GUTENBERG_TMP)
+
+
+def clear_texts_and_tmp():
+    """Clear the contents of the texts/tmp caches, preserving any symlinks."""
+    paths.clear_directory_contents(GUTENBERG_TEXTS)
+    paths.clear_directory_contents(GUTENBERG_TMP)
 
 
 gc.GutenbergCacheSettings.set(

--- a/lcats/lcats/gettenberg/cache.py
+++ b/lcats/lcats/gettenberg/cache.py
@@ -32,18 +32,29 @@ GUTENBERG_TEXTS = GUTENBERG_ROOT / "texts"
 paths.makedirs(GUTENBERG_TEXTS)  # makes root too, healing a dangling symlink.
 GUTENBERG_TMP = GUTENBERG_ROOT / "tmp"
 paths.makedirs(GUTENBERG_TMP)
+GUTENBERG_INDEX_DB = GUTENBERG_ROOT / "gutenbergindex.db"
+GUTENBERG_RDF_ARCHIVE = GUTENBERG_ROOT / "rdf-files.tar.bz2"
 
 
-def clear_texts_and_tmp():
-    """Clear the contents of the texts/tmp caches, preserving any symlinks."""
+def clear_all():
+    """Clear every Gutenberg cache artifact: texts, tmp, index DB, archive.
+
+    Symlink-safe for the texts/tmp directories -- only contents are
+    removed, never the directory itself. The index DB and RDF archive are
+    individual files directly under cache/, not directories; both are
+    removed outright if present, and are recreated automatically the next
+    time the Gutenberg cache is (re)built.
+    """
     paths.clear_directory_contents(GUTENBERG_TEXTS)
     paths.clear_directory_contents(GUTENBERG_TMP)
+    GUTENBERG_INDEX_DB.unlink(missing_ok=True)
+    GUTENBERG_RDF_ARCHIVE.unlink(missing_ok=True)
 
 
 gc.GutenbergCacheSettings.set(
-    CacheFilename=str(GUTENBERG_ROOT / "gutenbergindex.db"),
+    CacheFilename=str(GUTENBERG_INDEX_DB),
     # CacheUnpackDir=str(_GUTENBERG_TMP),  # Don't override, changes aren't respected.
-    CacheArchiveName=str(GUTENBERG_ROOT / "rdf-files.tar.bz2"),
+    CacheArchiveName=str(GUTENBERG_RDF_ARCHIVE),
     TextFilesCacheFolder=str(GUTENBERG_TEXTS),
 )
 

--- a/lcats/lcats/utils/paths.py
+++ b/lcats/lcats/utils/paths.py
@@ -53,6 +53,13 @@ def makedirs(path):
         if ancestor.is_dir():
             continue  # already a valid directory (a live symlink counts)
         if ancestor.is_symlink():
+            if ancestor.exists():
+                # Resolves to something real, just not a directory (e.g.
+                # a file) -- not dangling, and not fixable by healing.
+                raise NotADirectoryError(
+                    f"{ancestor} is a symlink to a non-directory; "
+                    f"refusing to create {target}"
+                )
             # Dangling: os.path.exists()/is_dir() are False, but a
             # directory entry with this name already exists, so plain
             # os.makedirs can't create it. Heal by recreating whatever

--- a/lcats/lcats/utils/paths.py
+++ b/lcats/lcats/utils/paths.py
@@ -1,0 +1,93 @@
+# lcats/lcats/utils/paths.py
+"""Symlink-aware filesystem helpers for LCATS's regenerable data/cache trees.
+
+Plain ``os.makedirs`` (even with ``exist_ok=True``) does not handle a
+dangling symlink gracefully. ``os.path.exists()`` follows symlinks and
+returns ``False`` for a broken one, so ``os.makedirs`` proceeds to call
+``mkdir()`` regardless, which then fails:
+
+- ``FileExistsError`` if the dangling symlink *is* the target path (a
+  directory entry with that name already exists, even though it's broken).
+- ``FileNotFoundError`` if the dangling symlink is an *ancestor* of the
+  target path (the parent can't be traversed to reach the leaf).
+
+These are genuinely different failures, not two shapes of the same one.
+Critically, ``exist_ok=True`` does not help with either: both
+``os.makedirs`` and ``pathlib.Path.mkdir`` gate their ``exist_ok``
+suppression on ``isdir()``/``is_dir()``, which is also ``False`` for a
+dangling symlink.
+"""
+
+import os
+import pathlib
+import shutil
+
+
+def makedirs(path):
+    """Create `path` and any missing parents, healing dangling symlinks.
+
+    Behaves like ``os.makedirs(path, exist_ok=True)``, but additionally
+    detects a dangling symlink anywhere in `path` -- the path itself, or
+    any ancestor of it -- and heals it by recreating the symlink's
+    missing target directory, then lets ``os.makedirs`` fill in the rest.
+
+    This auto-heal is a deliberate choice for LCATS's ``data/``/``cache/``
+    trees specifically, which are documented as disposable, regenerable
+    caches (see ``lcats/docs/reference/prepare-corpora-release.md``) --
+    it would be the wrong default for a general-purpose utility applied
+    to arbitrary paths.
+
+    Args:
+        path: The directory path to ensure exists.
+
+    Raises:
+        NotADirectoryError: `path`, or an ancestor of it, exists as a
+            plain file (or a symlink to one), so it can never become a
+            directory without deleting that file first.
+    """
+    target = pathlib.Path(path)
+
+    for ancestor in list(reversed(target.parents)) + [target]:
+        if os.fspath(ancestor) in ("", "."):
+            continue
+        if ancestor.is_dir():
+            continue  # already a valid directory (a live symlink counts)
+        if ancestor.is_symlink():
+            # Dangling: os.path.exists()/is_dir() are False, but a
+            # directory entry with this name already exists, so plain
+            # os.makedirs can't create it. Heal by recreating whatever
+            # the symlink points at.
+            link_target = ancestor.parent / ancestor.readlink()
+            os.makedirs(link_target, exist_ok=True)
+            continue
+        if ancestor.exists():
+            raise NotADirectoryError(
+                f"{ancestor} exists and is not a directory; "
+                f"refusing to create {target}"
+            )
+        # Doesn't exist at all and isn't a symlink -- ordinary case,
+        # os.makedirs below will create it.
+
+    os.makedirs(target, exist_ok=True)
+
+
+def clear_directory_contents(path):
+    """Remove everything inside `path`, without touching `path` itself.
+
+    Safe for a symlinked `path`: only the directory's *contents* are
+    removed, one entry at a time, so a `data`/`cache`-style symlink to a
+    scratch location survives a clear-and-regenerate cycle intact. A
+    missing `path` is a silent no-op.
+
+    Args:
+        path: The directory whose contents should be removed.
+    """
+    root = pathlib.Path(path)
+    if not root.is_dir():
+        return
+
+    for entry in root.iterdir():
+        if entry.is_symlink() or entry.is_file():
+            entry.unlink()
+        else:
+            shutil.rmtree(entry)

--- a/lcats/project/executions/AD_HOC/2026_07_18_02_20_53_WI_CLEAN_0022_IMPL_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_18_02_20_53_WI_CLEAN_0022_IMPL_REVIEW.md
@@ -1,0 +1,86 @@
+---
+execution_id: 2026_07_18_02_20_53_WI_CLEAN_0022_IMPL_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_CLEAN_0022_IMPL_REVIEW)[2026-07-18T01:04:51-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_17_22_43_20_WI_CLEAN_0022
+pr: https://github.com/xenotaur/LCATS/pull/131
+commit: 
+created_at: 2026-07-18T02:20:53-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/131
+session_transcript: pending
+---
+
+# Summary
+
+Address six review comments on PR #131 (WI-CLEAN-0022 implementation):
+four from copilot-pull-request-reviewer, two P2 from
+chatgpt-codex-connector. All six were substantive correctness bugs, not
+nitpicks -- confirmed every one via live reproduction before fixing, not
+just by reading the comment.
+
+# Result
+
+All six fixed in commit cac881d:
+
+- `makedirs()` raised a raw `FileExistsError` instead of the documented
+  `NotADirectoryError` when a symlink resolves to an *existing
+  non-directory* (e.g. a file) rather than being genuinely dangling --
+  confirmed live (`paths.py:55-67`). The code only checked
+  `is_symlink()` and unconditionally treated it as dangling; fixed to
+  check `exists()` within that branch and raise the documented error for
+  the non-dangling case instead of blindly attempting to heal it.
+- **The core bug**: `lcats clean` (bare, `--data-only`, `--cache-only`)
+  did not actually self-heal a dangling `data/`/`cache/resources` --
+  confirmed live that a "successful" run (`exit 0`, "cleared: ..."
+  printed) left both symlinks still dangling, because
+  `clear_directory_contents()` no-ops when its target isn't currently a
+  valid directory (`Path.is_dir()` is `False` for a dangling symlink).
+  This directly contradicted the feature's own advertised purpose and
+  this WI's whole motivation. Fixed by calling `paths.makedirs()` before
+  `clear_directory_contents()` in both `_clean_data()` and
+  `_clean_cache()` in `clean_cli.py`.
+- `DataGatherer.clear()`'s success message ("Cleared all contents in X")
+  was inaccurate now that the method removes the whole directory, not
+  just its contents -- changed to "Removed X".
+- `lcats clean --cache-only` never touched `gutenbergindex.db` /
+  `rdf-files.tar.bz2` (root-level files directly under `cache/`, per
+  `gc.GutenbergCacheSettings.set(...)` in `gettenberg/cache.py`) --
+  confirmed live these survive untouched despite the command's
+  documented "fresh cache" promise. Renamed
+  `clear_texts_and_tmp()` to `clear_all()` and expanded it to also
+  `unlink(missing_ok=True)` both files; both are recreated automatically
+  the next time the Gutenberg cache is (re)built.
+
+No comments skipped. Added 1 test to `paths_test.py`
+(symlink-to-file case), 2 to `clean_cli_test.py`
+(dangling-data/dangling-cache-resources self-heal, reproducing the exact
+scenarios the reviewers caught), and renamed/expanded `ClearTextsAndTmpTest`
+to `ClearAllTest` in `cache_test.py` with 2 new tests for the root-file
+removal.
+
+Re-verified end-to-end in a scratch sandbox (not unit tests alone) after
+all fixes: both `data` and `cache` dangling simultaneously, ran bare
+`lcats clean`, confirmed both symlinks survive and both targets are
+fully healed, including `cache/resources` specifically (the exact gap
+comment #3 identified).
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 153 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1346 tests OK (5 new)
+- `lrh validate` -- 0 errors, 26 pre-existing owner-role/orphan warnings
+- Live end-to-end re-verification of the fixed dangling-symlink self-heal
+  (both `data` and `cache` simultaneously dangling) via the actual
+  `lcats clean` CLI entry point
+
+# Follow-up
+
+- On merge: update this record and the primary
+  `2026_07_17_22_43_20_WI_CLEAN_0022` record to `landed`, and resolve
+  WI-CLEAN-0022.
+- The maintainer's dogfood run of `prepare-corpora-release.md` can now
+  continue past the original `FileExistsError: 'data'` crash once this
+  PR merges, with `lcats clean` genuinely self-healing as documented.

--- a/lcats/project/executions/WI-CLEAN-0022/2026_07_17_22_43_20_WI_CLEAN_0022.md
+++ b/lcats/project/executions/WI-CLEAN-0022/2026_07_17_22_43_20_WI_CLEAN_0022.md
@@ -1,0 +1,85 @@
+---
+execution_id: 2026_07_17_22_43_20_WI_CLEAN_0022
+prompt_id: PROMPT(WI-CLEAN-0022:WI_CLEAN_0022)[2026-07-17T22:24:35-04:00]
+work_item: WI-CLEAN-0022
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/131
+commit: 
+created_at: 2026-07-17T22:43:20-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-CLEAN-0022.md
+session_transcript: pending
+---
+
+# Summary
+
+Implement WI-CLEAN-0022's Required Changes: a symlink-aware
+`lcats.utils.paths.makedirs()`, wired into all five unsafe call sites; a
+behavior-preserving simplification of `DataGatherer.clear()`; a new
+`gettenberg/cache.py` clear function; a new `lcats clean` CLI subcommand;
+and a runbook update recommending it.
+
+# Result
+
+- `lcats/lcats/utils/paths.py` (new): `makedirs()` distinguishes four
+  cases -- missing, already a valid directory (symlink or not), a
+  dangling symlink (leaf or ancestor), and blocked by a plain file.
+  Confirmed live before implementing that leaf-dangling and
+  ancestor-dangling are genuinely different failures
+  (`FileExistsError` vs `FileNotFoundError`), matching the WI's review
+  feedback on PR #130. Also `clear_directory_contents()`, a shared
+  symlink-safe "clear contents, keep the directory" helper reused by
+  `gettenberg/cache.py`'s new clear function and `lcats clean` --
+  `ResourceCache.clear()` itself is untouched, per the WI's Non-Goals.
+- `downloaders.py`: `ResourceCache.ensure()` and `DataGatherer.ensure()`
+  (both call sites) now call `paths.makedirs()`. `DataGatherer.clear()`
+  simplified to a direct `shutil.rmtree(self.path)` -- confirmed the
+  removed per-entry check was dead code (checked the constant `self.path`
+  in every branch, not the loop variable) before removing it;
+  `test_clear_removes_path` passes completely unmodified, as the WI
+  required after PR #130's review caught the original proposal would
+  have broken it.
+- `gettenberg/cache.py`: the two module-level `mkdir()` calls now use
+  `paths.makedirs()`; new `clear_texts_and_tmp()`, unit-tested including
+  a symlinked-`cache/texts` case.
+- `lcats/analysis/corpus/clean_cli.py` (new) + `cli.py` wiring: `lcats
+  clean` follows the `promote_cli.py` pattern. Bare `lcats clean` clears
+  all of `data/` and `cache/`. Scoping to specific gatherer names
+  intentionally skips cache clearing -- caught this via my own test
+  before shipping it (`test_specific_gatherer_scopes_to_that_directory_only`
+  failed on first run because the original `run()` logic cleared cache
+  unconditionally regardless of scoping; fixed the condition, not the
+  test).
+- `prepare-corpora-release.md`: "Clear stale local state" now recommends
+  `lcats clean` as primary, keeping the `sh -c 'rm -rf ...'` glob fallback
+  for readers without `lcats` on `PATH` yet (per Non-Goals). Updated the
+  "Regenerate" section's now-dangling reference to the old cache-clearing
+  note to point at `lcats clean --cache-only` instead.
+
+Beyond unit tests, verified end-to-end in a scratch sandbox (not the
+session's real `data/`/`cache/`, per the WI's Risk Notes): both the
+original bug scenario (`data` itself dangling) and the nested-ancestor
+scenario (`cache` dangling, affecting `cache/resources`/`cache/texts`/
+`cache/tmp`) self-heal correctly via `lcats clean`, with both symlinks
+surviving intact.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 153 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1341 tests OK (23 new: 13 in `paths_test.py`, 8 in
+  `clean_cli_test.py`, 2 in `cache_test.py`)
+- `lrh validate` -- 0 errors, 26 pre-existing owner-role/orphan warnings
+- Manual scratch-sandbox verification of both dangling-symlink scenarios
+  via the actual `lcats clean` CLI entry point, not just unit tests
+
+# Follow-up
+
+- On merge: set this record to `landed` and resolve WI-CLEAN-0022.
+- The maintainer's dogfood run of `prepare-corpora-release.md` can now
+  continue past the `FileExistsError: 'data'` crash that motivated this
+  WI, once this PR merges.
+- `docs/reference/cli-status.md` doesn't list `clean` (or `promote`,
+  already stale independent of this WI) -- noted, not fixed here; out of
+  this WI's scope.

--- a/lcats/tests/analysis_tests/clean_cli_test.py
+++ b/lcats/tests/analysis_tests/clean_cli_test.py
@@ -21,6 +21,8 @@ class CleanCliTest(unittest.TestCase):
         self.cache_root = self.tmp_dir / "cache"
         self.texts_dir = self.tmp_dir / "cache_texts"
         self.tmp_unpack = self.tmp_dir / "cache_tmp"
+        self.index_db = self.tmp_dir / "cache_index.db"
+        self.rdf_archive = self.tmp_dir / "cache_rdf.tar.bz2"
 
         self.data_root.mkdir()
         (self.data_root / "sherlock").mkdir()
@@ -35,6 +37,8 @@ class CleanCliTest(unittest.TestCase):
         (self.texts_dir / "30086.txt").touch()
         self.tmp_unpack.mkdir()
         (self.tmp_unpack / "leftover.tmp").touch()
+        self.index_db.touch()
+        self.rdf_archive.touch()
 
         self._p_env = unittest.mock.patch.dict(
             "os.environ",
@@ -49,11 +53,21 @@ class CleanCliTest(unittest.TestCase):
         self._p_tmp = unittest.mock.patch.object(
             gettenberg_cache, "GUTENBERG_TMP", self.tmp_unpack
         )
+        self._p_index_db = unittest.mock.patch.object(
+            gettenberg_cache, "GUTENBERG_INDEX_DB", self.index_db
+        )
+        self._p_rdf_archive = unittest.mock.patch.object(
+            gettenberg_cache, "GUTENBERG_RDF_ARCHIVE", self.rdf_archive
+        )
         self._p_env.start()
         self._p_texts.start()
         self._p_tmp.start()
+        self._p_index_db.start()
+        self._p_rdf_archive.start()
 
     def tearDown(self):
+        self._p_rdf_archive.stop()
+        self._p_index_db.stop()
         self._p_tmp.stop()
         self._p_texts.stop()
         self._p_env.stop()
@@ -68,6 +82,8 @@ class CleanCliTest(unittest.TestCase):
         self.assertEqual(list((self.cache_root / "resources").iterdir()), [])
         self.assertEqual(list(self.texts_dir.iterdir()), [])
         self.assertEqual(list(self.tmp_unpack.iterdir()), [])
+        self.assertFalse(self.index_db.exists())
+        self.assertFalse(self.rdf_archive.exists())
         # The directories themselves survive -- only contents are cleared.
         self.assertTrue(self.data_root.is_dir())
         self.assertTrue(self.cache_root.is_dir())
@@ -108,6 +124,8 @@ class CleanCliTest(unittest.TestCase):
         self.assertTrue((self.data_root / "sherlock" / "story.json").exists())
         self.assertEqual(list((self.cache_root / "resources").iterdir()), [])
         self.assertEqual(list(self.texts_dir.iterdir()), [])
+        self.assertFalse(self.index_db.exists())
+        self.assertFalse(self.rdf_archive.exists())
 
     def test_data_only_and_cache_only_are_mutually_exclusive(self):
         with capture.capture_output() as captured:
@@ -139,6 +157,38 @@ class CleanCliTest(unittest.TestCase):
         self.assertEqual(0, exit_code)
         self.assertTrue(data_link.is_symlink())
         self.assertEqual(list(real_data_target.iterdir()), [])
+
+    def test_self_heals_dangling_data_symlink(self):
+        """A dangling data/ is healed, not silently ignored (PR #131 review)."""
+        real_data_target = self.tmp_dir / "healed_data_target"
+        data_link = self.tmp_dir / "dangling_data"
+        data_link.symlink_to(real_data_target)  # target does not exist yet
+        self.assertFalse(data_link.exists())  # confirm genuinely dangling
+
+        with unittest.mock.patch.dict(
+            "os.environ", {"LCATS_DATA_DIR": str(data_link)}
+        ), capture.suppress_output():
+            exit_code = clean_cli.run(["--data-only"])
+
+        self.assertEqual(0, exit_code)
+        self.assertTrue(data_link.is_symlink(), "the symlink itself must survive")
+        self.assertTrue(real_data_target.is_dir(), "the target must be healed")
+
+    def test_self_heals_dangling_cache_resources_ancestor(self):
+        """A dangling cache/ is healed for cache/resources too (PR #131 review)."""
+        real_cache_target = self.tmp_dir / "healed_cache_target"
+        cache_link = self.tmp_dir / "dangling_cache"
+        cache_link.symlink_to(real_cache_target)
+        self.assertFalse(cache_link.exists())
+
+        with unittest.mock.patch.dict(
+            "os.environ", {"LCATS_CACHE_DIR": str(cache_link)}
+        ), capture.suppress_output():
+            exit_code = clean_cli.run(["--cache-only"])
+
+        self.assertEqual(0, exit_code)
+        self.assertTrue(cache_link.is_symlink())
+        self.assertTrue((real_cache_target / "resources").is_dir())
 
 
 if __name__ == "__main__":

--- a/lcats/tests/analysis_tests/clean_cli_test.py
+++ b/lcats/tests/analysis_tests/clean_cli_test.py
@@ -1,0 +1,145 @@
+"""Unit tests for lcats.analysis.corpus.clean_cli."""
+
+import pathlib
+import tempfile
+import unittest
+import unittest.mock
+
+from lcats.analysis.corpus import clean_cli
+from lcats.gettenberg import cache as gettenberg_cache
+from lcats.utils import capture
+
+
+class CleanCliTest(unittest.TestCase):
+    """Tests for the clean CLI's argument handling and clearing behavior."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_dir = pathlib.Path(self._tmp.name)
+
+        self.data_root = self.tmp_dir / "data"
+        self.cache_root = self.tmp_dir / "cache"
+        self.texts_dir = self.tmp_dir / "cache_texts"
+        self.tmp_unpack = self.tmp_dir / "cache_tmp"
+
+        self.data_root.mkdir()
+        (self.data_root / "sherlock").mkdir()
+        (self.data_root / "sherlock" / "story.json").touch()
+        (self.data_root / "mass_quantities").mkdir()
+        (self.data_root / "mass_quantities" / "story.json").touch()
+
+        (self.cache_root / "resources").mkdir(parents=True)
+        (self.cache_root / "resources" / "page.html").touch()
+
+        self.texts_dir.mkdir()
+        (self.texts_dir / "30086.txt").touch()
+        self.tmp_unpack.mkdir()
+        (self.tmp_unpack / "leftover.tmp").touch()
+
+        self._p_env = unittest.mock.patch.dict(
+            "os.environ",
+            {
+                "LCATS_DATA_DIR": str(self.data_root),
+                "LCATS_CACHE_DIR": str(self.cache_root),
+            },
+        )
+        self._p_texts = unittest.mock.patch.object(
+            gettenberg_cache, "GUTENBERG_TEXTS", self.texts_dir
+        )
+        self._p_tmp = unittest.mock.patch.object(
+            gettenberg_cache, "GUTENBERG_TMP", self.tmp_unpack
+        )
+        self._p_env.start()
+        self._p_texts.start()
+        self._p_tmp.start()
+
+    def tearDown(self):
+        self._p_tmp.stop()
+        self._p_texts.stop()
+        self._p_env.stop()
+        self._tmp.cleanup()
+
+    def test_no_args_clears_all_of_data_and_cache(self):
+        with capture.suppress_output():
+            exit_code = clean_cli.run([])
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual(list(self.data_root.iterdir()), [])
+        self.assertEqual(list((self.cache_root / "resources").iterdir()), [])
+        self.assertEqual(list(self.texts_dir.iterdir()), [])
+        self.assertEqual(list(self.tmp_unpack.iterdir()), [])
+        # The directories themselves survive -- only contents are cleared.
+        self.assertTrue(self.data_root.is_dir())
+        self.assertTrue(self.cache_root.is_dir())
+
+    def test_specific_gatherer_scopes_to_that_directory_only(self):
+        with capture.suppress_output():
+            exit_code = clean_cli.run(["sherlock"])
+
+        self.assertEqual(0, exit_code)
+        self.assertFalse((self.data_root / "sherlock").exists())
+        self.assertTrue((self.data_root / "mass_quantities").exists())
+        # Cache is untouched when specific gatherer names are given.
+        self.assertTrue((self.cache_root / "resources" / "page.html").exists())
+
+    def test_unknown_gatherer_name_warns_and_continues(self):
+        with capture.capture_output() as captured:
+            exit_code = clean_cli.run(["not_a_real_gatherer"])
+
+        self.assertEqual(0, exit_code)
+        self.assertIn(
+            "Unknown gatherer: not_a_real_gatherer", captured.stderr.getvalue()
+        )
+
+    def test_data_only_leaves_cache_untouched(self):
+        with capture.suppress_output():
+            exit_code = clean_cli.run(["--data-only"])
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual(list(self.data_root.iterdir()), [])
+        self.assertTrue((self.cache_root / "resources" / "page.html").exists())
+        self.assertTrue((self.texts_dir / "30086.txt").exists())
+
+    def test_cache_only_leaves_data_untouched(self):
+        with capture.suppress_output():
+            exit_code = clean_cli.run(["--cache-only"])
+
+        self.assertEqual(0, exit_code)
+        self.assertTrue((self.data_root / "sherlock" / "story.json").exists())
+        self.assertEqual(list((self.cache_root / "resources").iterdir()), [])
+        self.assertEqual(list(self.texts_dir.iterdir()), [])
+
+    def test_data_only_and_cache_only_are_mutually_exclusive(self):
+        with capture.capture_output() as captured:
+            exit_code = clean_cli.run(["--data-only", "--cache-only"])
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("mutually exclusive", captured.stderr.getvalue())
+
+    def test_gatherer_names_invalid_with_cache_only(self):
+        with capture.capture_output() as captured:
+            exit_code = clean_cli.run(["sherlock", "--cache-only"])
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("not valid with --cache-only", captured.stderr.getvalue())
+
+    def test_preserves_symlinked_data_and_cache(self):
+        real_data_target = self.tmp_dir / "real_data_target"
+        real_data_target.mkdir()
+        (real_data_target / "sherlock").mkdir()
+        (real_data_target / "sherlock" / "story.json").touch()
+        data_link = self.tmp_dir / "data_link"
+        data_link.symlink_to(real_data_target)
+
+        with unittest.mock.patch.dict(
+            "os.environ", {"LCATS_DATA_DIR": str(data_link)}
+        ), capture.suppress_output():
+            exit_code = clean_cli.run(["--data-only"])
+
+        self.assertEqual(0, exit_code)
+        self.assertTrue(data_link.is_symlink())
+        self.assertEqual(list(real_data_target.iterdir()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/gettenberg_tests/cache_test.py
+++ b/lcats/tests/gettenberg_tests/cache_test.py
@@ -266,5 +266,52 @@ class GettenbergCacheTests(unittest.TestCase):
             p_create.assert_called_once()
 
 
+class ClearTextsAndTmpTest(unittest.TestCase):
+    """Tests for clear_texts_and_tmp."""
+
+    def setUp(self):
+        self.td = tempfile.TemporaryDirectory()
+        self.tmp_dir = pathlib.Path(self.td.name)
+        self.texts_dir = self.tmp_dir / "texts"
+        self.tmp_unpack = self.tmp_dir / "tmp"
+        self.texts_dir.mkdir()
+        self.tmp_unpack.mkdir()
+        (self.texts_dir / "30086.txt").touch()
+        (self.tmp_unpack / "leftover.tmp").touch()
+
+        self._p_texts = mock.patch.object(cache, "GUTENBERG_TEXTS", self.texts_dir)
+        self._p_tmp = mock.patch.object(cache, "GUTENBERG_TMP", self.tmp_unpack)
+        self._p_texts.start()
+        self._p_tmp.start()
+
+    def tearDown(self):
+        self._p_tmp.stop()
+        self._p_texts.stop()
+        self.td.cleanup()
+
+    def test_clears_both_directories_contents(self):
+        """clear_texts_and_tmp empties both caches without removing them."""
+        cache.clear_texts_and_tmp()
+
+        self.assertTrue(self.texts_dir.is_dir())
+        self.assertTrue(self.tmp_unpack.is_dir())
+        self.assertEqual(list(self.texts_dir.iterdir()), [])
+        self.assertEqual(list(self.tmp_unpack.iterdir()), [])
+
+    def test_preserves_symlinked_texts_dir(self):
+        """A symlinked cache/texts survives clearing intact."""
+        real_target = self.tmp_dir / "real_texts_target"
+        real_target.mkdir()
+        (real_target / "30086.txt").touch()
+        link = self.tmp_dir / "texts_link"
+        link.symlink_to(real_target)
+
+        with mock.patch.object(cache, "GUTENBERG_TEXTS", link):
+            cache.clear_texts_and_tmp()
+
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(list(real_target.iterdir()), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/lcats/tests/gettenberg_tests/cache_test.py
+++ b/lcats/tests/gettenberg_tests/cache_test.py
@@ -266,37 +266,63 @@ class GettenbergCacheTests(unittest.TestCase):
             p_create.assert_called_once()
 
 
-class ClearTextsAndTmpTest(unittest.TestCase):
-    """Tests for clear_texts_and_tmp."""
+class ClearAllTest(unittest.TestCase):
+    """Tests for clear_all."""
 
     def setUp(self):
         self.td = tempfile.TemporaryDirectory()
         self.tmp_dir = pathlib.Path(self.td.name)
         self.texts_dir = self.tmp_dir / "texts"
         self.tmp_unpack = self.tmp_dir / "tmp"
+        self.index_db = self.tmp_dir / "gutenbergindex.db"
+        self.rdf_archive = self.tmp_dir / "rdf-files.tar.bz2"
         self.texts_dir.mkdir()
         self.tmp_unpack.mkdir()
         (self.texts_dir / "30086.txt").touch()
         (self.tmp_unpack / "leftover.tmp").touch()
+        self.index_db.touch()
+        self.rdf_archive.touch()
 
         self._p_texts = mock.patch.object(cache, "GUTENBERG_TEXTS", self.texts_dir)
         self._p_tmp = mock.patch.object(cache, "GUTENBERG_TMP", self.tmp_unpack)
+        self._p_index_db = mock.patch.object(cache, "GUTENBERG_INDEX_DB", self.index_db)
+        self._p_rdf_archive = mock.patch.object(
+            cache, "GUTENBERG_RDF_ARCHIVE", self.rdf_archive
+        )
         self._p_texts.start()
         self._p_tmp.start()
+        self._p_index_db.start()
+        self._p_rdf_archive.start()
 
     def tearDown(self):
+        self._p_rdf_archive.stop()
+        self._p_index_db.stop()
         self._p_tmp.stop()
         self._p_texts.stop()
         self.td.cleanup()
 
     def test_clears_both_directories_contents(self):
-        """clear_texts_and_tmp empties both caches without removing them."""
-        cache.clear_texts_and_tmp()
+        """clear_all empties both cache directories without removing them."""
+        cache.clear_all()
 
         self.assertTrue(self.texts_dir.is_dir())
         self.assertTrue(self.tmp_unpack.is_dir())
         self.assertEqual(list(self.texts_dir.iterdir()), [])
         self.assertEqual(list(self.tmp_unpack.iterdir()), [])
+
+    def test_removes_index_db_and_rdf_archive(self):
+        """clear_all removes the root-level index DB and RDF archive files."""
+        cache.clear_all()
+
+        self.assertFalse(self.index_db.exists())
+        self.assertFalse(self.rdf_archive.exists())
+
+    def test_missing_index_db_and_rdf_archive_is_not_an_error(self):
+        """clear_all tolerates a cache that never built these files yet."""
+        self.index_db.unlink()
+        self.rdf_archive.unlink()
+
+        cache.clear_all()  # must not raise
 
     def test_preserves_symlinked_texts_dir(self):
         """A symlinked cache/texts survives clearing intact."""
@@ -307,7 +333,7 @@ class ClearTextsAndTmpTest(unittest.TestCase):
         link.symlink_to(real_target)
 
         with mock.patch.object(cache, "GUTENBERG_TEXTS", link):
-            cache.clear_texts_and_tmp()
+            cache.clear_all()
 
         self.assertTrue(link.is_symlink())
         self.assertEqual(list(real_target.iterdir()), [])

--- a/lcats/tests/utils_tests/paths_test.py
+++ b/lcats/tests/utils_tests/paths_test.py
@@ -1,0 +1,196 @@
+"""Tests for lcats.utils.paths functions."""
+
+import os
+import pathlib
+import tempfile
+import unittest
+
+from lcats.utils import paths
+
+
+class MakedirsTest(unittest.TestCase):
+    """Tests for the makedirs function."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_dir = pathlib.Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_creates_missing_path(self):
+        """A path that doesn't exist at all is created normally."""
+        target = self.tmp_dir / "fresh"
+
+        paths.makedirs(target)
+
+        self.assertTrue(target.is_dir())
+
+    def test_creates_missing_nested_path(self):
+        """Missing intermediate parents are created too, like os.makedirs."""
+        target = self.tmp_dir / "a" / "b" / "c"
+
+        paths.makedirs(target)
+
+        self.assertTrue(target.is_dir())
+
+    def test_noop_on_existing_directory(self):
+        """An already-valid directory is left alone."""
+        target = self.tmp_dir / "existing"
+        target.mkdir()
+        marker = target / "keepme.txt"
+        marker.touch()
+
+        paths.makedirs(target)
+
+        self.assertTrue(marker.exists())
+
+    def test_noop_on_existing_directory_via_live_symlink(self):
+        """A live symlink to a real directory is left alone, not replaced."""
+        real_target = self.tmp_dir / "real_target"
+        real_target.mkdir()
+        link = self.tmp_dir / "data"
+        link.symlink_to(real_target)
+
+        paths.makedirs(link)
+
+        self.assertTrue(link.is_symlink())
+        self.assertEqual(link.resolve(), real_target.resolve())
+
+    def test_heals_dangling_symlink_leaf(self):
+        """A dangling symlink as the target itself is healed, not destroyed."""
+        real_target = self.tmp_dir / "real_target"
+        link = self.tmp_dir / "data"
+        link.symlink_to(real_target)  # real_target does not exist yet
+        self.assertFalse(link.exists())  # confirm it's genuinely dangling
+
+        paths.makedirs(link)
+
+        self.assertTrue(link.is_symlink(), "the symlink itself must survive")
+        self.assertTrue(real_target.is_dir())
+        self.assertTrue(link.is_dir())
+
+    def test_heals_dangling_symlink_ancestor(self):
+        """A dangling symlink ancestor of a nested path is healed.
+
+        This is the realistic failure mode for cache/resources,
+        cache/texts, cache/tmp: cache/ itself is symlinked, not these
+        subdirectories, and a dangling cache/ raises a different
+        exception (FileNotFoundError) than a dangling leaf does
+        (FileExistsError) from plain os.makedirs.
+        """
+        real_target = self.tmp_dir / "real_cache_target"
+        link = self.tmp_dir / "cache"
+        link.symlink_to(real_target)
+        nested = link / "resources"
+
+        paths.makedirs(nested)
+
+        self.assertTrue(link.is_symlink(), "the symlink itself must survive")
+        self.assertTrue(real_target.is_dir())
+        self.assertTrue((real_target / "resources").is_dir())
+        self.assertTrue(nested.is_dir())
+
+    def test_raises_when_blocked_by_plain_file(self):
+        """A plain file occupying the target path raises, not FileExistsError."""
+        blocker = self.tmp_dir / "data"
+        blocker.touch()
+
+        with self.assertRaises(NotADirectoryError):
+            paths.makedirs(blocker)
+
+    def test_raises_when_ancestor_blocked_by_plain_file(self):
+        """A plain file occupying an ancestor of the target path raises."""
+        blocker = self.tmp_dir / "cache"
+        blocker.touch()
+        nested = blocker / "resources"
+
+        with self.assertRaises(NotADirectoryError):
+            paths.makedirs(nested)
+
+    def test_dangling_symlink_matches_documented_exception_shapes(self):
+        """Confirms the exact os.makedirs failures this function fixes.
+
+        Grounds the whole module: without paths.makedirs, a dangling
+        leaf symlink raises FileExistsError, and a dangling ancestor
+        symlink raises FileNotFoundError -- two different exceptions,
+        not variants of one.
+        """
+        leaf_target = self.tmp_dir / "leaf_target"
+        leaf_link = self.tmp_dir / "leaf"
+        leaf_link.symlink_to(leaf_target)
+        with self.assertRaises(FileExistsError):
+            os.makedirs(leaf_link)
+
+        ancestor_target = self.tmp_dir / "ancestor_target"
+        ancestor_link = self.tmp_dir / "ancestor"
+        ancestor_link.symlink_to(ancestor_target)
+        with self.assertRaises(FileNotFoundError):
+            os.makedirs(ancestor_link / "nested")
+
+
+class ClearDirectoryContentsTest(unittest.TestCase):
+    """Tests for the clear_directory_contents function."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_dir = pathlib.Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_removes_files_and_subdirectories(self):
+        """Clears files, dotfiles, and nested directories."""
+        real_dir = self.tmp_dir / "real_dir"
+        real_dir.mkdir()
+        (real_dir / "keepme.txt").touch()
+        (real_dir / ".hidden_file").touch()
+        nested = real_dir / "subdir" / "nested"
+        nested.mkdir(parents=True)
+        (nested / "deep.json").touch()
+
+        paths.clear_directory_contents(real_dir)
+
+        self.assertEqual(list(real_dir.iterdir()), [])
+
+    def test_preserves_symlink_when_clearing_through_it(self):
+        """The directory (or symlink) passed in is never removed itself."""
+        real_target = self.tmp_dir / "real_target"
+        real_target.mkdir()
+        (real_target / "keepme.txt").touch()
+        link = self.tmp_dir / "data"
+        link.symlink_to(real_target)
+
+        paths.clear_directory_contents(link)
+
+        self.assertTrue(link.is_symlink())
+        self.assertTrue(real_target.is_dir())
+        self.assertEqual(list(real_target.iterdir()), [])
+
+    def test_noop_on_missing_path(self):
+        """A missing directory is a silent no-op, not an error."""
+        missing = self.tmp_dir / "does_not_exist"
+
+        paths.clear_directory_contents(missing)  # must not raise
+
+        self.assertFalse(missing.exists())
+
+    def test_does_not_follow_nested_symlink_into_its_target(self):
+        """A symlink found inside the cleared directory is unlinked, not followed."""
+        outside_target = self.tmp_dir / "outside_target"
+        outside_target.mkdir()
+        (outside_target / "precious.txt").touch()
+
+        real_dir = self.tmp_dir / "real_dir"
+        real_dir.mkdir()
+        nested_link = real_dir / "nested_link"
+        nested_link.symlink_to(outside_target)
+
+        paths.clear_directory_contents(real_dir)
+
+        self.assertEqual(list(real_dir.iterdir()), [])
+        self.assertTrue((outside_target / "precious.txt").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/utils_tests/paths_test.py
+++ b/lcats/tests/utils_tests/paths_test.py
@@ -99,6 +99,21 @@ class MakedirsTest(unittest.TestCase):
         with self.assertRaises(NotADirectoryError):
             paths.makedirs(blocker)
 
+    def test_raises_when_symlink_resolves_to_a_file(self):
+        """A symlink to an existing file is not dangling and not healable.
+
+        This is a different case from a dangling symlink: is_dir() is
+        False either way, but exists() distinguishes "nothing there yet"
+        (heal it) from "something real, just not a directory" (refuse).
+        """
+        blocker_file = self.tmp_dir / "blocker_file.txt"
+        blocker_file.touch()
+        link = self.tmp_dir / "data"
+        link.symlink_to(blocker_file)
+
+        with self.assertRaises(NotADirectoryError):
+            paths.makedirs(link)
+
     def test_raises_when_ancestor_blocked_by_plain_file(self):
         """A plain file occupying an ancestor of the target path raises."""
         blocker = self.tmp_dir / "cache"


### PR DESCRIPTION
## Summary

Implements WI-CLEAN-0022: symlink-safe directory creation for `data/`/`cache/`,
and a new `lcats clean` command.

- **`lcats/lcats/utils/paths.py`** (new): `makedirs()`, a drop-in
  `os.makedirs` replacement that heals a dangling symlink instead of
  crashing — whether it's the target path itself (plain `os.makedirs`
  raises `FileExistsError`) or an ancestor of a nested path like
  `cache/resources` (raises `FileNotFoundError` instead — a genuinely
  different failure, confirmed live). Also `clear_directory_contents()`,
  a shared symlink-safe "clear contents, keep the directory" helper.
- **`downloaders.py`**: `ResourceCache.ensure()` and `DataGatherer.ensure()`
  (×2 call sites) now use `paths.makedirs()`. `DataGatherer.clear()` is
  simplified to a direct `shutil.rmtree()` — no behavior change;
  `test_clear_removes_path` passes unmodified. The removed per-entry
  file/symlink/directory check was dead code (it tested the constant
  parent path, not the loop variable) that happened to produce today's
  tested result by accident.
- **`gettenberg/cache.py`**: module-level `mkdir()` calls for `cache/texts`
  and `cache/tmp` now use `paths.makedirs()`; new `clear_texts_and_tmp()`.
- **`lcats/analysis/corpus/clean_cli.py`** (new) + `cli.py` wiring: a new
  `lcats clean` subcommand. Bare `lcats clean` clears all of `data/` and
  `cache/`; `lcats clean <gatherer>` scopes to just that gatherer's data
  and *intentionally* skips cache clearing (a targeted recheck shouldn't
  invalidate the cache every other gatherer relies on); `--data-only`/
  `--cache-only` scope to one side.
- **`prepare-corpora-release.md`**: the "Clear stale local state" step now
  recommends `lcats clean` as the primary path, keeping the manual
  `sh -c 'rm -rf ...'` glob commands as a fallback for readers without
  `lcats` on `PATH` yet.

Verified end-to-end against real symlinked directories in a scratch
sandbox (not just unit tests) for both the original bug scenario (`data`
dangling) and the nested-ancestor scenario (`cache` dangling, affecting
`cache/resources`/`cache/texts`/`cache/tmp`).

PROMPT(WI-CLEAN-0022:WI_CLEAN_0022)[2026-07-17T22:24:35-04:00]

## Test plan

- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — ruff + black pass
- [x] `scripts/test` — 1341 tests OK (23 new)
- [x] `lrh validate` — 0 errors, 26 pre-existing warnings
- [x] Manual end-to-end verification in a scratch sandbox: dangling leaf
      symlink (`data`) and dangling ancestor symlink (`cache`) both heal
      correctly via `lcats clean`, symlinks survive intact
