### PR TITLE
Document lcats clean's full cache-clearing scope in the release runbook

### DIFF
--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -55,15 +55,23 @@ source list (or renamed) leaves a stale file behind that `lcats survey` and
 lcats clean
 ```
 
-`lcats clean` clears every `data/<gatherer>` directory and both cache
-mechanisms (`cache/resources`, and `mass_quantities`'s separate
-`cache/texts`/`cache/tmp`). It's safe on a symlinked `data/`/`cache/`
-setup (some machines point these at a scratch/tempspace location, to keep
-large regenerated data out of a backup system) — only contents are ever
-removed, never the directory or symlink itself — and it self-heals a
-dangling symlink it encounters along the way (one whose target directory
-no longer exists), rather than crashing on the next `lcats gather` the way
-a bare `os.makedirs` does.
+`lcats clean` clears every `data/<gatherer>` directory and every cache
+mechanism: `cache/resources`, plus `mass_quantities`'s separate
+`cache/texts`/`cache/tmp` and its Gutenberg metadata cache
+(`cache/gutenbergindex.db`, `cache/rdf-files.tar.bz2`). It's safe on a
+symlinked `data/`/`cache/` setup (some machines point these at a
+scratch/tempspace location, to keep large regenerated data out of a
+backup system) — only contents are ever removed, never the directory or
+symlink itself — and it self-heals a dangling symlink it encounters along
+the way (one whose target directory no longer exists), rather than
+crashing on the next `lcats gather` the way a bare `os.makedirs` does.
+
+Clearing the Gutenberg metadata cache means the *first* metadata lookup
+in the next `lcats gather mass_quantities` rebuilds it from scratch —
+downloading and parsing the whole Gutenberg RDF catalog, not just the
+per-story text this section already warns about. Expect that one rebuild
+to take a while, regardless of how small a subset of `mass_quantities`
+you're regenerating.
 
 To re-check a single collection instead of the whole corpus, scope the
 clear to just that gatherer, e.g. `lcats clean mass_quantities`. This

--- a/lcats/project/executions/AD_HOC/2026_07_18_14_26_12_RUNBOOK_CACHE_CLEAN_DOC_GAP.md
+++ b/lcats/project/executions/AD_HOC/2026_07_18_14_26_12_RUNBOOK_CACHE_CLEAN_DOC_GAP.md
@@ -1,0 +1,60 @@
+---
+execution_id: 2026_07_18_14_26_12_RUNBOOK_CACHE_CLEAN_DOC_GAP
+prompt_id: PROMPT(AD_HOC:RUNBOOK_CACHE_CLEAN_DOC_GAP)[2026-07-18T14:23:01-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/132
+commit: 
+created_at: 2026-07-18T14:26:12-04:00
+agent: claude_app
+instruction_source: user request to re-verify prepare-corpora-release.md against current code after WI-CLEAN-0022 (PR #131) merged
+session_transcript: pending
+---
+
+# Summary
+
+The maintainer asked whether `prepare-corpora-release.md` was still fully
+valid after WI-CLEAN-0022 (PR #131) merged. Re-verified every claim in the
+doc against current code rather than just re-reading it; found one real
+gap and fixed it.
+
+# Result
+
+Verified against current code (all still accurate, no changes needed):
+Pre-flight commands against `lcats/README.md`'s Building section, the
+`lcats gather` gatherer name list against `gatherers/main.py`'s
+`GATHERERS` dict, the "most gatherers skip existing files, mass_quantities
+always overwrites" claim against `downloaders.py`/`parser.py`, and every
+cross-referenced doc anchor (`corpus-promotion.md#collection-name-mapping`,
+the assess how-to link).
+
+Found one real gap: step 2's description of what `lcats clean` clears
+said "`cache/resources`, and `mass_quantities`'s separate
+`cache/texts`/`cache/tmp`" -- three things. But PR #131's own review
+(see `2026_07_18_02_20_53_WI_CLEAN_0022_IMPL_REVIEW`) extended
+`gettenberg_cache.clear_all()` to also remove
+`cache/gutenbergindex.db`/`cache/rdf-files.tar.bz2` (comment #6 on PR
+#131), and the runbook was never updated to reflect that -- confirmed by
+reading `clear_all()`'s current source directly, not from memory.
+
+Also added a new, previously-undocumented consequence, confirmed against
+`ensure_gutenberg_cache()`: clearing the Gutenberg metadata cache means
+the *first* metadata lookup in the next `lcats gather mass_quantities`
+rebuilds the whole RDF catalog from scratch (the code's own comment says
+"may take a while, so go get a coffee or soda") -- a slow operation
+distinct from and in addition to the per-story downloads the runbook
+already warned about.
+
+# Validation
+
+- `scripts/format --check --diff` -- clean, 153 files unchanged
+- `scripts/lint` -- ruff + black pass
+- `scripts/test` -- 1346 tests OK (doc-only change, unaffected suite)
+- `lrh validate` -- 0 errors, 26 pre-existing owner-role/orphan warnings
+
+# Follow-up
+
+- On merge: update this record to `landed`.
+- No further known gaps in the runbook as of this check; the maintainer's
+  dogfood run can proceed on the assumption the doc matches current code.


### PR DESCRIPTION
## Summary

Small follow-up to WI-CLEAN-0022 (PR #131): the maintainer asked me to
re-verify the whole `prepare-corpora-release.md` runbook against the
current codebase, and this was the one real gap found.

PR #131's own review extended `lcats clean`/`gettenberg_cache.clear_all()`
to also remove `cache/gutenbergindex.db` and `cache/rdf-files.tar.bz2`
(the Gutenberg metadata catalog and RDF archive) — but the runbook's
description of what gets cleared was never updated to match, and still
only mentions `cache/resources` and `cache/texts`/`cache/tmp`.

Also documents a real consequence I confirmed against
`ensure_gutenberg_cache()`: clearing that metadata cache means the next
`lcats gather mass_quantities` rebuilds the whole Gutenberg RDF catalog
from scratch on its first metadata lookup — a slow operation, separate
from and in addition to the per-story downloads the runbook already warns
about.

Verified everything else in the runbook against current code before
concluding this was the only gap: the Pre-flight commands against
`lcats/README.md`, the gatherer name list against `gatherers/main.py`'s
`GATHERERS` dict, the "most gatherers skip existing files" claim against
`downloaders.py`, and all cross-referenced doc anchors.

PROMPT(AD_HOC:RUNBOOK_CACHE_CLEAN_DOC_GAP)[2026-07-18T14:23:01-04:00]

## Test plan

- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — ruff + black pass
- [x] `scripts/test` — 1346 tests OK (doc-only change, unaffected suite)
- [x] `lrh validate` — 0 errors, 26 pre-existing warnings
