### PR TITLE
Normalize CLI, LLM-backend, and assess reference docs (WI-DOCS-0014)

### DIFF
--- a/lcats/docs/how-to/run-assess.md
+++ b/lcats/docs/how-to/run-assess.md
@@ -1,0 +1,66 @@
+# How to run `lcats assess`
+
+`lcats assess` is the LLM-powered curation layer that sits on top of the
+detector pipeline. It calls the Claude API with a structured tool schema,
+runs pre-flight QA via `run_preflight`, and returns an `AssessmentResult`
+with verdict, genre detection, and quality annotations.
+
+## Modes
+
+| Mode | Command | When to use |
+|---|---|---|
+| Detect | `lcats assess <files> --format human` | Unknown/mixed corpus — model identifies genre independently |
+| Lens | `lcats assess <files> --genre horror --format human` | Curation run — model detects genre then evaluates the claimed genre |
+
+Both modes always return `detected_genre` and `detected_genre_confidence`.
+Lens mode additionally returns `genre_verdict` in `[confirmed, disputed, wrong]`
+(detect mode sets it to `detected`).
+
+## Manual prompt validation
+
+Before running a full corpus assessment with new or modified system prompts,
+spot-check on 2–3 representative stories per mode:
+
+```bash
+# Detect mode — pick one story you know well
+lcats assess data/path/to/story.json --format human
+
+# Lens mode — same story with its expected genre
+lcats assess data/path/to/story.json --genre "science fiction" --format human
+```
+
+**What to verify:**
+
+- `detected_genre` matches your expectation for the story.
+- `detected_genre_confidence` is high (≥0.8) for clear cases and lower for
+  genuinely borderline ones.
+- `genre_verdict` in lens mode is `confirmed` for a clear match, `disputed`
+  for a borderline match, `wrong` for a clear mismatch.
+- `verdict` (`include`/`exclude`/`review`) aligns with your curation judgment.
+  In lens mode: `disputed` should produce `review`, not `include`.
+- `summary` accurately describes the story in one or two sentences.
+- `issues` lists any pre-flight QA findings you would also flag by hand.
+
+A good spot-check set includes: one story that clearly belongs to the target
+genre, one that belongs to a different target genre, and one that is
+borderline or mixed. If the model misclassifies the clear case or returns
+implausible confidence scores, the system prompt needs adjustment before a
+bulk run.
+
+## Dry run
+
+Use `--dry-run` to verify file discovery and pre-flight QA without making
+API calls:
+
+```bash
+lcats assess data/ --dry-run                     # detect mode
+lcats assess data/ --genre western --dry-run     # lens mode
+```
+
+## See also
+
+- [`docs/reference/cli-commands.md`](../reference/cli-commands.md) for the
+  full `lcats assess` flag reference (`--model`, `--max-body-chars`,
+  `--format`, `--output`).
+- [Preparing a corpora release](../reference/prepare-corpora-release.md)'s
+  "Optional next step" section for `lcats assess` in the release workflow.

--- a/lcats/docs/index.md
+++ b/lcats/docs/index.md
@@ -19,12 +19,14 @@ Tutorials are not scaffolded in this phase.
 ### How-to guides
 
 - [Set up API keys](secrets-setup.md)
-- [Run `lcats assess`](../lcats/analysis/corpus/README.md#9-story-assessment-lcats-assess) — usage, manual prompt validation, and dry-run guidance (interim location; pending extraction into `docs/how-to/` in a future phase)
+- [Run `lcats assess`](how-to/run-assess.md) — modes, manual prompt validation, and dry-run guidance
 - [Prepare a corpora release](reference/prepare-corpora-release.md) — manual, agent-free runbook: clear, regenerate, verify, and promote `data/` into `corpora/`
 
 ### Reference
 
 - [CLI status matrix](reference/cli-status.md)
+- [CLI command reference](reference/cli-commands.md) — flags and arguments for every `lcats` subcommand
+- [LLMBackend reference](reference/llm-backend.md) — the `LLMBackend` Protocol and its providers
 - [Corpus promotion (`lcats promote`)](reference/corpus-promotion.md) — command reference and collection-name mapping
 
 ### Explanation

--- a/lcats/docs/reference/README.md
+++ b/lcats/docs/reference/README.md
@@ -3,5 +3,7 @@
 Reference pages describe exact interfaces and current behavior.
 
 - [CLI status matrix](cli-status.md)
+- [CLI command reference](cli-commands.md)
+- [LLMBackend reference](llm-backend.md)
 
 See also: [API key setup](../secrets-setup.md) (how-to, not reference).

--- a/lcats/docs/reference/cli-commands.md
+++ b/lcats/docs/reference/cli-commands.md
@@ -32,7 +32,7 @@ lcats gather [--dry-run] [gatherers ...]
 
 Gather one or more configured corpora.
 
-| Flag | Description |
+| Argument / Flag | Description |
 |---|---|
 | `gatherers` | Optional gatherer names. Defaults to all gatherers. |
 | `--dry-run` | Show which gatherers would run without executing downloads. |
@@ -72,7 +72,7 @@ lcats survey [--mode {qa,specials}] [--check-for CHECK_FOR]
 Survey LCATS corpus JSON files for quality issues such as special characters
 and boundary contamination.
 
-| Flag | Description |
+| Argument / Flag | Description |
 |---|---|
 | `directories` | Directories or files to survey. |
 | `--mode {qa,specials}` | Survey mode. `qa` (default) for normal checks, or `specials` to default to special-character extraction. |
@@ -116,7 +116,7 @@ Assess LCATS corpus JSON files for quality and genre fit. Calls the Claude
 API to produce structured include/exclude/review verdicts, genre confidence
 scores, issue lists, and story summaries.
 
-| Flag | Description |
+| Argument / Flag | Description |
 |---|---|
 | `directories` | Directories or JSON files to assess (default: `data/`). |
 | `--genre GENRE` | Target genre for curation (lens mode): `science fiction`, `horror`, `western`, `romance`. Quote multi-word genres. Omit to detect genre automatically (detect mode). |
@@ -148,7 +148,7 @@ lcats stats [--dedupe] [--no-dedupe] [--story-output STORY_OUTPUT]
 Compute story-level and author-level statistics for one or more corpus
 directories or JSON files.
 
-| Flag | Description |
+| Argument / Flag | Description |
 |---|---|
 | `directories` | Directories or files to compute statistics for. |
 | `--dedupe` / `--no-dedupe` | Toggle deduplication by story identity. |
@@ -170,7 +170,7 @@ lcats repair-specials [--header] [--format {tsv,jsonl}] files [files ...]
 Generate conservative repair proposals for known mojibake fragments. This
 command is non-destructive — it never modifies the input files.
 
-| Flag | Description |
+| Argument / Flag | Description |
 |---|---|
 | `files` | Story JSON files to generate repair proposals for. |
 | `--header` | Include a header row (TSV format only). |
@@ -186,7 +186,7 @@ Promote `data/` collections into `corpora/`. A collection with any mojibake
 finding is skipped and reported rather than promoted; clean collections
 wholesale-replace their `corpora/` counterpart.
 
-| Flag | Description |
+| Argument / Flag | Description |
 |---|---|
 | `collections` | Collection names to consider. Defaults to every collection under `--source`. |
 | `--source SOURCE` | Root directory of source collections (default: `data/`). |
@@ -206,9 +206,9 @@ Clear `data/` and/or `cache/` contents without shell-glob reasoning. Safe for
 a symlinked `data/` or `cache/` setup: only contents are removed, never the
 directory (or symlink) itself.
 
-| Flag | Description |
+| Argument / Flag | Description |
 |---|---|
-| `gatherers` | Gatherer names to clean under `data/`. Defaults to every gatherer. |
+| `gatherers` | Gatherer names to clean under `data/`. **With no names given, this does not scope to "every configured gatherer" one by one — it wholesale-clears everything under `data/`, including any custom or unregistered directories that aren't a known gatherer.** Naming specific gatherers instead removes only those subdirectories. |
 | `--data-only` | Clean only `data/`; leave `cache/` untouched. |
 | `--cache-only` | Clean only `cache/`; leave `data/` untouched. |
 

--- a/lcats/docs/reference/cli-commands.md
+++ b/lcats/docs/reference/cli-commands.md
@@ -1,0 +1,240 @@
+# LCATS CLI command reference
+
+Flags and arguments for every `lcats` subcommand, verified against
+`lcats <command> --help`. For which commands are implemented vs. placeholder,
+see [`cli-status.md`](cli-status.md).
+
+## `help`
+
+```
+lcats help [topic]
+```
+
+Display LCATS help, including command-specific help.
+
+| Argument | Description |
+|---|---|
+| `topic` | Optional command name, e.g. `lcats help survey`. |
+
+## `info`
+
+```
+lcats info
+```
+
+Describe LCATS, the literary captain's advisory tool system.
+
+## `gather`
+
+```
+lcats gather [--dry-run] [gatherers ...]
+```
+
+Gather one or more configured corpora.
+
+| Flag | Description |
+|---|---|
+| `gatherers` | Optional gatherer names. Defaults to all gatherers. |
+| `--dry-run` | Show which gatherers would run without executing downloads. |
+
+## `inspect`
+
+```
+lcats inspect [files ...]
+```
+
+Inspect one or more story JSON files and print summaries.
+
+## `display`
+
+```
+lcats display [files ...]
+```
+
+Display one or more story JSON files in human-readable form.
+
+## `survey`
+
+```
+lcats survey [--mode {qa,specials}] [--check-for CHECK_FOR]
+              [--print-clean-filenames] [--allowlist-config ALLOWLIST_CONFIG]
+              [--allow-smart] [--no-allow-smart] [--context CONTEXT]
+              [--nocontext] [--name-width NAME_WIDTH]
+              [--identifier {path,filename,title}]
+              [--unicode-name-width UNICODE_NAME_WIDTH] [--header]
+              [--no-header] [--format {human,tsv}] [--output OUTPUT]
+              [--progress] [--no-progress]
+              [--exclude-codepoint EXCLUDE_CODEPOINT]
+              [--exclude-char EXCLUDE_CHAR]
+              [directories ...]
+```
+
+Survey LCATS corpus JSON files for quality issues such as special characters
+and boundary contamination.
+
+| Flag | Description |
+|---|---|
+| `directories` | Directories or files to survey. |
+| `--mode {qa,specials}` | Survey mode. `qa` (default) for normal checks, or `specials` to default to special-character extraction. |
+| `--check-for CHECK_FOR` | Check(s) to run. Repeatable or comma-separated: `special-characters`, `boundary-contamination`, `the_end-contamination`. |
+| `--print-clean-filenames` | Print filenames of clean (finding-free) files. |
+| `--allowlist-config ALLOWLIST_CONFIG` | Path to an allowlist config JSON. Defaults to the packaged corpus allowlist; pass an empty string to disable. |
+| `--allow-smart` / `--no-allow-smart` | Toggle smart-punctuation allowlisting. |
+| `--context CONTEXT` / `--nocontext` | Toggle surrounding-text context in findings. |
+| `--name-width NAME_WIDTH` | Column width for filenames in human-format output. |
+| `--identifier {path,filename,title}` | Identifier shown in TSV reports. Defaults to `path`. |
+| `--unicode-name-width UNICODE_NAME_WIDTH` | Maximum Unicode name width for TSV shown on a TTY. `0` disables truncation. |
+| `--header` / `--no-header` | Toggle TSV header row. |
+| `--format {human,tsv}` | Output format. |
+| `--output OUTPUT` | Write output to a file instead of stdout. |
+| `--progress` / `--no-progress` | Toggle progress display. |
+| `--exclude-codepoint EXCLUDE_CODEPOINT` | Exclude a specific Unicode codepoint from findings. |
+| `--exclude-char EXCLUDE_CHAR` | Exclude a specific character from findings. |
+
+**Note:** `--extract-script` also appears in `--help` output but is a legacy
+compatibility flag — extraction now runs in-process via
+`lcats.analysis.corpus.specials_cli`.
+
+```
+lcats survey --mode specials corpora/sherlock
+lcats survey corpora/sherlock --check-for special-characters
+lcats survey data/ --format tsv --output findings.tsv
+lcats survey corpora/sherlock --no-progress --print-clean-filenames
+```
+
+## `assess`
+
+```
+lcats assess [--genre GENRE] [--model MODEL]
+              [--max-body-chars MAX_BODY_CHARS]
+              [--format {jsonl,json,tsv,human}] [--output OUTPUT]
+              [--dry-run] [--progress] [--no-progress]
+              [directories ...]
+```
+
+Assess LCATS corpus JSON files for quality and genre fit. Calls the Claude
+API to produce structured include/exclude/review verdicts, genre confidence
+scores, issue lists, and story summaries.
+
+| Flag | Description |
+|---|---|
+| `directories` | Directories or JSON files to assess (default: `data/`). |
+| `--genre GENRE` | Target genre for curation (lens mode): `science fiction`, `horror`, `western`, `romance`. Quote multi-word genres. Omit to detect genre automatically (detect mode). |
+| `--model MODEL` | Claude model to use (default: `claude-opus-4-8`). |
+| `--max-body-chars MAX_BODY_CHARS` | Max story body characters sent to the API (default: `100000`). |
+| `--format {jsonl,json,tsv,human}` | Output format (default: `jsonl`). |
+| `--output OUTPUT` | Write output to a file instead of stdout. |
+| `--dry-run` | Run pre-flight QA checks and list files without calling the API. |
+| `--progress` / `--no-progress` | Toggle progress display. |
+
+See [`docs/how-to/run-assess.md`](../how-to/run-assess.md) for mode selection
+guidance, manual prompt validation, and dry-run usage.
+
+```
+lcats assess corpora/sherlock --genre 'science fiction'
+lcats assess data/ --genre horror --format tsv --output horror.tsv
+lcats assess data/ --genre western --dry-run
+ANTHROPIC_API_KEY=sk-... lcats assess corpora/ --genre romance --progress
+```
+
+## `stats`
+
+```
+lcats stats [--dedupe] [--no-dedupe] [--story-output STORY_OUTPUT]
+            [--author-output AUTHOR_OUTPUT]
+            [directories ...]
+```
+
+Compute story-level and author-level statistics for one or more corpus
+directories or JSON files.
+
+| Flag | Description |
+|---|---|
+| `directories` | Directories or files to compute statistics for. |
+| `--dedupe` / `--no-dedupe` | Toggle deduplication by story identity. |
+| `--story-output STORY_OUTPUT` | Write per-story stats to this file. |
+| `--author-output AUTHOR_OUTPUT` | Write per-author stats to this file. |
+
+```
+lcats stats corpora/sherlock
+lcats stats data/ --no-dedupe
+lcats stats data/ --story-output story_stats.tsv --author-output author_stats.tsv
+```
+
+## `repair-specials`
+
+```
+lcats repair-specials [--header] [--format {tsv,jsonl}] files [files ...]
+```
+
+Generate conservative repair proposals for known mojibake fragments. This
+command is non-destructive — it never modifies the input files.
+
+| Flag | Description |
+|---|---|
+| `files` | Story JSON files to generate repair proposals for. |
+| `--header` | Include a header row (TSV format only). |
+| `--format {tsv,jsonl}` | Dry-run report format (human TSV or machine JSONL). |
+
+## `promote`
+
+```
+lcats promote [--source SOURCE] [--dest DEST] [--dry-run] [collections ...]
+```
+
+Promote `data/` collections into `corpora/`. A collection with any mojibake
+finding is skipped and reported rather than promoted; clean collections
+wholesale-replace their `corpora/` counterpart.
+
+| Flag | Description |
+|---|---|
+| `collections` | Collection names to consider. Defaults to every collection under `--source`. |
+| `--source SOURCE` | Root directory of source collections (default: `data/`). |
+| `--dest DEST` | Root directory to promote clean collections into (default: `../corpora`). |
+| `--dry-run` | Survey and report without copying any files. |
+
+See [`corpus-promotion.md`](corpus-promotion.md) for the full command
+explanation, collection-name mapping, and exit-code semantics.
+
+## `clean`
+
+```
+lcats clean [--data-only] [--cache-only] [gatherers ...]
+```
+
+Clear `data/` and/or `cache/` contents without shell-glob reasoning. Safe for
+a symlinked `data/` or `cache/` setup: only contents are removed, never the
+directory (or symlink) itself.
+
+| Flag | Description |
+|---|---|
+| `gatherers` | Gatherer names to clean under `data/`. Defaults to every gatherer. |
+| `--data-only` | Clean only `data/`; leave `cache/` untouched. |
+| `--cache-only` | Clean only `cache/`; leave `data/` untouched. |
+
+See [Preparing a corpora release](prepare-corpora-release.md) step 2 for a
+worked walkthrough of when and why to use `lcats clean`.
+
+## `meta register`
+
+```
+lcats meta register [--force] repo_locator
+```
+
+Register a repository locator in the local workspace registry.
+
+| Argument / Flag | Description |
+|---|---|
+| `repo_locator` | The repository locator to register. |
+| `--force` | Allow duplicate `repo_locator` entries. |
+
+## Placeholder commands
+
+These commands are declared but not yet implemented — running them prints a
+"not yet implemented" message and exits.
+
+| Command | Description |
+|---|---|
+| `lcats index` | Preprocess a corpus to answer questions. |
+| `lcats advise` | Run the LCATS command-line advising tool. |
+| `lcats eval` | Evaluate LCATS on a benchmark suite. |

--- a/lcats/docs/reference/cli-status.md
+++ b/lcats/docs/reference/cli-status.md
@@ -13,6 +13,8 @@ This page summarizes top-level `lcats` CLI command status based on implementatio
 - `stats`
 - `repair-specials`
 - `assess`
+- `promote`
+- `clean`
 - `meta register`
 
 ## Placeholder commands (declared, not implemented)
@@ -25,3 +27,4 @@ This page summarizes top-level `lcats` CLI command status based on implementatio
 
 - This is a status reference page, not a tutorial.
 - Command options and examples should be verified against `lcats <command> --help` when writing detailed command references.
+- For full flag/argument documentation, see [`cli-commands.md`](cli-commands.md).

--- a/lcats/docs/reference/llm-backend.md
+++ b/lcats/docs/reference/llm-backend.md
@@ -1,0 +1,170 @@
+# LLMBackend reference
+
+`lcats.llm` (`lcats/lcats/llm/`) is the unified abstraction over LLM provider
+APIs. Every LLM call in the packaged pipeline (`lcats.analysis.llm_extractor`,
+`lcats.extraction`, `lcats.analysis.corpus.assess`) goes through an injected
+`LLMBackend` instance, so switching providers or models is a call-site
+argument, not a code change. Derived from
+[`project/design/unified-llm-backend-design.md`](../../project/design/unified-llm-backend-design.md)
+(`DESIGN-LLM-BACKEND`) and verified against the implementation in
+`lcats/lcats/llm/`.
+
+## Package layout
+
+```
+lcats/lcats/llm/
+├── __init__.py           re-exports all public names
+├── backend.py             LLMBackend Protocol + BackendResponse dataclass
+├── openai_backend.py       OpenAIBackend
+├── anthropic_backend.py    AnthropicBackend
+└── fake_backend.py         FakeBackend (test double)
+```
+
+## `LLMBackend` Protocol
+
+`lcats.llm.backend.LLMBackend` is a `typing.Protocol` (structural typing, not
+inheritance) with one method:
+
+```python
+def complete(
+    self,
+    *,
+    system: str,
+    messages: list,
+    model: str,
+    temperature: float = 0.2,
+    max_tokens: int = 4096,
+    tool: dict | None = None,
+) -> BackendResponse: ...
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `system` | `str` | System prompt text. |
+| `messages` | `list[dict]` | Chat messages excluding the system prompt, e.g. `[{"role": "user", "content": "..."}]`. |
+| `model` | `str` | Provider-specific model identifier. |
+| `temperature` | `float` | Sampling temperature (default `0.2`). |
+| `max_tokens` | `int` | Maximum tokens to generate (default `4096`). |
+| `tool` | `dict \| None` | Optional single tool schema. When provided, the backend forces the model to call this tool and returns its arguments in `tool_result`. When `None`, the backend requests free-form JSON-friendly text in `text` instead. |
+
+Being a `@runtime_checkable` Protocol means any object implementing
+`complete()` with this signature satisfies `isinstance(obj, LLMBackend)` —
+no explicit inheritance required.
+
+## `BackendResponse`
+
+```python
+@dataclass
+class BackendResponse:
+    text: str
+    tool_result: dict | None
+    model: str
+    input_tokens: int
+    output_tokens: int
+    raw: Any = field(repr=False)
+```
+
+| Field | Description |
+|---|---|
+| `text` | Free-text model output. Empty string when `tool` was provided. |
+| `tool_result` | Structured tool-use output. `None` when no tool was used. |
+| `model` | Exact model string echoed back by the provider's API response. |
+| `input_tokens` | Input/prompt tokens reported by the API. |
+| `output_tokens` | Output/completion tokens reported by the API. |
+| `raw` | The raw, provider-specific SDK response object, for debugging. Excluded from `repr()`. |
+
+## Providers
+
+### `AnthropicBackend`
+
+```python
+from lcats.llm import anthropic_backend
+
+backend = anthropic_backend.AnthropicBackend(api_key=None, use_streaming=True)
+```
+
+| Constructor argument | Description |
+|---|---|
+| `api_key` | Optional API key. When omitted, the Anthropic SDK reads `ANTHROPIC_API_KEY` from the environment. |
+| `use_streaming` | Uses `messages.stream()` internally by default, to avoid gateway timeouts on large story inputs (typical bodies are 40–100K characters). Set `False` for a blocking `messages.create()` call instead. |
+
+Raises `ImportError` at construction time if the `anthropic` package is not
+installed.
+
+**Temperature handling:** newer Claude models (`claude-opus-4-7`,
+`claude-opus-4-8`, `claude-fable-5`, and later — any versioned model where
+major > 4 or major == 4 and minor >= 7, plus all non-versioned model IDs)
+reject the `temperature` parameter with an HTTP 400 error. `AnthropicBackend`
+detects this from the model string and silently omits `temperature` from the
+API call for those models — this is not in the original design doc, but is
+implemented behavior worth knowing before debugging an unexpected-looking
+request.
+
+### `OpenAIBackend`
+
+```python
+from lcats.llm import openai_backend
+
+backend = openai_backend.OpenAIBackend(api_key=None)
+```
+
+| Constructor argument | Description |
+|---|---|
+| `api_key` | Optional API key. When omitted, the OpenAI SDK reads `OPENAI_API_KEY` from the environment. |
+
+Raises `ImportError` at construction time if the `openai` package is not
+installed. Non-tool calls request `response_format={"type": "json_object"}`
+rather than relying on prompt instructions alone.
+
+### `FakeBackend`
+
+```python
+from lcats.llm import fake_backend
+
+backend = fake_backend.FakeBackend(
+    response_text="",
+    tool_result=None,
+    model="fake-1.0",
+    input_tokens=0,
+    output_tokens=0,
+)
+```
+
+Deterministic test double — always returns a fixed `BackendResponse` built
+from the constructor arguments, and records every call's keyword arguments in
+`backend.calls` for assertions. Use this in tests instead of mocking
+`client.chat.completions.create`/`client.messages.stream` directly.
+
+## Provider wire-format translation
+
+| | OpenAI | Anthropic |
+|---|---|---|
+| System prompt | Prepended as `{"role": "system", "content": system}` in `messages` | Top-level `system=` kwarg, not in `messages` |
+| Tool call | `tools=[{"type": "function", "function": {...}}]`, `tool_choice={"type": "function", ...}` | `tools=[tool]` (schema is already canonical), `tool_choice={"type": "tool", "name": ...}` |
+| No tool | `response_format={"type": "json_object"}` | No `response_format`; prompt instructs JSON |
+| Result (no tool) | `choices[0].message.content` | First `text`-type content block |
+| Result (tool) | `json.loads(choices[0].message.tool_calls[0].function.arguments)` | First `tool_use`-type content block's `.input` |
+| Token counts | `usage.prompt_tokens`, `usage.completion_tokens` | `usage.input_tokens`, `usage.output_tokens` |
+
+## Usage
+
+```python
+from lcats.llm import anthropic_backend
+
+backend = anthropic_backend.AnthropicBackend()
+result = backend.complete(
+    system="You are a helpful assistant.",
+    messages=[{"role": "user", "content": "Summarize this story."}],
+    model="claude-opus-4-8",
+)
+print(result.text)
+```
+
+Callers construct one concrete backend and pass it down — `JSONPromptExtractor`,
+`extract_from_story`, and `assess_story` all take a `backend: LLMBackend`
+parameter rather than constructing a provider client internally.
+
+## See also
+
+- [`project/design/unified-llm-backend-design.md`](../../project/design/unified-llm-backend-design.md) — full design rationale, provider translation tables, and migration sequence (`WI-LLM-0007` through `WI-LLM-0010`, all resolved).
+- [`docs/how-to/run-assess.md`](../how-to/run-assess.md) — using `lcats assess`, which is built on this abstraction.

--- a/lcats/docs/reference/llm-backend.md
+++ b/lcats/docs/reference/llm-backend.md
@@ -13,12 +13,17 @@ argument, not a code change. Derived from
 
 ```
 lcats/lcats/llm/
-├── __init__.py           re-exports all public names
+├── __init__.py           module docstring only; no re-exports
 ├── backend.py             LLMBackend Protocol + BackendResponse dataclass
 ├── openai_backend.py       OpenAIBackend
 ├── anthropic_backend.py    AnthropicBackend
 └── fake_backend.py         FakeBackend (test double)
 ```
+
+`lcats.llm.__init__` does not re-export any of these names. Import the
+submodule directly, e.g. `from lcats.llm import anthropic_backend` then
+`anthropic_backend.AnthropicBackend(...)` — `from lcats.llm import
+LLMBackend` or `BackendResponse` will fail.
 
 ## `LLMBackend` Protocol
 
@@ -61,7 +66,7 @@ class BackendResponse:
     model: str
     input_tokens: int
     output_tokens: int
-    raw: Any = field(repr=False)
+    raw: Any = field(repr=False, default=None)
 ```
 
 | Field | Description |

--- a/lcats/lcats/analysis/corpus/README.md
+++ b/lcats/lcats/analysis/corpus/README.md
@@ -228,58 +228,7 @@ and make human overrides explicit.
 ## 9. Story Assessment (`lcats assess`)
 
 `lcats assess` is the LLM-powered curation layer that sits on top of the
-detector pipeline. It calls the Claude API with a structured tool schema,
-runs pre-flight QA via `run_preflight`, and returns an `AssessmentResult`
-with verdict, genre detection, and quality annotations.
-
-### Modes
-
-| Mode | Command | When to use |
-|---|---|---|
-| Detect | `lcats assess <files> --format human` | Unknown/mixed corpus — model identifies genre independently |
-| Lens | `lcats assess <files> --genre horror --format human` | Curation run — model detects genre then evaluates the claimed genre |
-
-Both modes always return `detected_genre` and `detected_genre_confidence`.
-Lens mode additionally returns `genre_verdict` in `[confirmed, disputed, wrong]`
-(detect mode sets it to `detected`).
-
-### Manual prompt validation
-
-Before running a full corpus assessment with new or modified system prompts,
-spot-check on 2–3 representative stories per mode:
-
-```bash
-# Detect mode — pick one story you know well
-lcats assess data/path/to/story.json --format human
-
-# Lens mode — same story with its expected genre
-lcats assess data/path/to/story.json --genre "science fiction" --format human
-```
-
-**What to verify:**
-
-- `detected_genre` matches your expectation for the story.
-- `detected_genre_confidence` is high (≥0.8) for clear cases and lower for
-  genuinely borderline ones.
-- `genre_verdict` in lens mode is `confirmed` for a clear match, `disputed`
-  for a borderline match, `wrong` for a clear mismatch.
-- `verdict` (`include`/`exclude`/`review`) aligns with your curation judgment.
-  In lens mode: `disputed` should produce `review`, not `include`.
-- `summary` accurately describes the story in one or two sentences.
-- `issues` lists any pre-flight QA findings you would also flag by hand.
-
-A good spot-check set includes: one story that clearly belongs to the target
-genre, one that belongs to a different target genre, and one that is
-borderline or mixed. If the model misclassifies the clear case or returns
-implausible confidence scores, the system prompt needs adjustment before a
-bulk run.
-
-### Dry run
-
-Use `--dry-run` to verify file discovery and pre-flight QA without making
-API calls:
-
-```bash
-lcats assess data/ --dry-run                     # detect mode
-lcats assess data/ --genre western --dry-run     # lens mode
-```
+detector pipeline. See [`docs/how-to/run-assess.md`](../../../docs/how-to/run-assess.md)
+for modes, manual prompt validation, and dry-run usage, and
+[`docs/reference/cli-commands.md`](../../../docs/reference/cli-commands.md)
+for the full flag reference.

--- a/lcats/project/executions/AD_HOC/2026_07_20_00_39_47_WI_DOCS_0014_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_20_00_39_47_WI_DOCS_0014_REVIEW.md
@@ -1,0 +1,60 @@
+---
+execution_id: 2026_07_20_00_39_47_WI_DOCS_0014_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_DOCS_0014_REVIEW)[2026-07-20T00:36:17-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_20_00_31_05_WI_DOCS_0014
+pr: https://github.com/xenotaur/LCATS/pull/135
+commit: eac3d86
+created_at: 2026-07-20T00:39:47-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/135
+session_transcript: pending
+---
+
+# Summary
+
+Addressed 11 open review comments on PR #135 (`WI-DOCS-0014` implementation), from
+`chatgpt-codex-connector` and `copilot-pull-request-reviewer`, grouped into 4 root causes.
+
+# Result
+
+All 11 comments were valid (presence + validity + feasibility checks passed) and fixed:
+
+1. **`lcats.llm.__init__` re-export claim** (2 comments) — `llm-backend.md`'s package-layout
+   diagram claimed `__init__.py` "re-exports all public names," copied uncritically from the
+   design doc's aspirational layout. Actual `__init__.py` has only a module docstring. Fixed the
+   diagram and added an explicit note that callers must import the submodule directly (the
+   `Usage` example already did this correctly — only the stated claim was wrong).
+2. **`BackendResponse.raw` snippet mismatch** (1 comment) — the documented dataclass field was
+   `raw: Any = field(repr=False)`; actual code is `dataclasses.field(repr=False, default=None)`.
+   Fixed.
+3. **`lcats clean`'s default scope understated** (1 comment) — documented as "defaults to every
+   gatherer," copied from the `--help` text, which itself undersells the behavior. Read
+   `clean_cli.py._clean_data` directly: with no gatherer names, it calls
+   `clear_directory_contents(env.data_root())`, wholesale-clearing everything under `data/`,
+   including any custom/unregistered directories — not scoped to known gatherers at all. Rewrote
+   the table entry with the accurate, more safety-relevant description.
+4. **"Flag" table header misleading where a positional argument is also listed** (7 comments) —
+   `gather`, `survey`, `assess`, `stats`, `repair-specials`, `promote`, `clean` tables all mix a
+   positional arg (`gatherers`/`directories`/`files`/`collections`) under a "Flag"-only header.
+   Renamed to "Argument / Flag" in all 7 (matching the header already used correctly in `help`
+   and `meta register`).
+
+No comments were skipped.
+
+# Validation
+
+- Only Markdown files changed (`git status --short` showed 2 modified `.md` files, no Python) —
+  `scripts/format`, `scripts/lint`, `scripts/test` not applicable.
+- Re-verified `lcats.llm.__init__`'s content and `clean_cli.py`'s `_clean_data` implementation
+  directly (not from memory or the design doc) before writing the fixes.
+- `lrh validate` — 0 errors, 26 pre-existing warnings (unchanged from before this PR).
+
+# Follow-up
+
+- `session_transcript` is `pending` — update to `claude-app:<session-id>` after this session ends.
+- After PR #135 merges: run `/lrh-closeout` — set both this record and the primary
+  `2026_07_20_00_31_05_WI_DOCS_0014` record to `landed`, resolve `WI-DOCS-0014`. As noted on the
+  primary record, `WI-DOCS-0013`'s closeout was missed for 10 days last time — don't assume this
+  one happens automatically either.

--- a/lcats/project/executions/AD_HOC/2026_07_20_00_47_48_WI_DOCS_0014_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_20_00_47_48_WI_DOCS_0014_CONFIRM.md
@@ -1,0 +1,63 @@
+---
+execution_id: 2026_07_20_00_47_48_WI_DOCS_0014_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_DOCS_0014_CONFIRM)[2026-07-20T00:44:56-04:00]
+work_item: WI-DOCS-0014
+status: in_progress
+rerun_of: 2026_07_20_00_31_05_WI_DOCS_0014
+pr: https://github.com/xenotaur/LCATS/pull/135
+commit: ce26092
+created_at: 2026-07-20T00:47:48-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/135
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass on PR #135 (`WI-DOCS-0014`): independently confirmed the 3 remaining
+open review threads are resolved by the current diff, resolved them on GitHub, and re-checked CI.
+
+# Result
+
+**Thread listing** (`lrh github threads --mode raw --state all`, filtered to `isResolved == false`
+client-side — the authoritative live-state list, broader than `lrh request review_response`'s own
+`Nothing to resolve:` report, which uses a narrower filter that silently excludes
+outdated-but-unresolved threads): 3 of 11 total threads were still unresolved. The other 8 already
+showed `isResolved: true` on GitHub before this run (likely auto-resolved by Copilot's own bot
+after the `/lrh-review-response` push — not something this run did).
+
+**Fresh-eyes classification** — offered and used a cold subagent (session had authored the fixes
+being verified) with only the PR URL, comment bodies, and file paths to check; no session memory.
+All 3 classified **Clear-satisfied**, matching an inline check done before the offer:
+
+1. `chatgpt-codex-connector` (r3612049508) — re-export claim. `llm-backend.md` now explicitly
+   states `__init__.py` does not re-export names and instructs importing the submodule directly.
+2. `chatgpt-codex-connector` (r3612049511) — clean-all default. `cli-commands.md` now accurately
+   describes the wholesale-clear behavior, matching `clean_cli.py`'s actual `_clean_data` logic.
+3. `copilot-pull-request-reviewer` (r3612051392) — duplicate of #1, same fix resolves it.
+
+No Unaddressed / Partial / Ambiguous / Problematic threads found. Resolved all 3 via
+`resolveReviewThread` (each confirmed `isResolved: true` in the mutation response).
+
+**Thread-resolution verdict (Step 6): green** — every verifiable thread resolved, no exceptions
+remain open.
+
+# Validation
+
+- Provisional CI (Step 2, before this record's commit): `gh pr checks 135 --required` reported "no
+  required checks" — distinguished via the branch-rules lookup
+  (`gh api repos/xenotaur/LCATS/rules/branches/main`, `required_status_checks` count `0`) that this
+  means genuinely no required-check protection on `main`, not a reporting-timing race. Fell back to
+  the unfiltered `gh pr checks 135`: 4/4 checks green (`lint`, `coverage`, `test` ×2).
+- Post-push CI re-check against this record's own commit SHA: see Follow-up — Step 8 runs after
+  this record is committed and pushed.
+- `lrh validate` — run before commit; see below.
+
+# Follow-up
+
+- `session_transcript` is `pending` — update to `claude-app:<session-id>` after this session ends.
+- Step 8 (post-push CI re-check and final merge-readiness verdict) follows immediately after this
+  record is committed and pushed — see the session report for the actual verdict and `HEAD` SHA.
+- After PR #135 merges: run `/lrh-closeout` — update this record, the `_REVIEW` record
+  (`2026_07_20_00_39_47_WI_DOCS_0014_REVIEW`), and the primary record
+  (`2026_07_20_00_31_05_WI_DOCS_0014`) to `landed`, resolve `WI-DOCS-0014`.

--- a/lcats/project/executions/WI-DOCS-0014/2026_07_20_00_31_05_WI_DOCS_0014.md
+++ b/lcats/project/executions/WI-DOCS-0014/2026_07_20_00_31_05_WI_DOCS_0014.md
@@ -1,0 +1,66 @@
+---
+execution_id: 2026_07_20_00_31_05_WI_DOCS_0014
+prompt_id: PROMPT(WI-DOCS-0014:WI_DOCS_0014)[2026-07-19T14:52:06-04:00]
+work_item: WI-DOCS-0014
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/135
+commit: f49e224
+created_at: 2026-07-20T00:31:05-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-DOCS-0014.md
+session_transcript: pending
+---
+
+# Summary
+
+Implemented `WI-DOCS-0014` (Phase 3 of the 2026-07-07 docs audit): extracted the `lcats assess`
+how-to content into its own page, and added CLI-flags and `LLMBackend` reference docs.
+
+# Result
+
+- `lcats/docs/how-to/run-assess.md` (new): extracted Section 9 of
+  `lcats/lcats/analysis/corpus/README.md` (modes, manual prompt validation, dry run) verbatim —
+  copy-and-link, not a rewrite, per the audit's note that the content was already carefully
+  reviewed. Section 9 is now a one-line pointer to the new page.
+- `lcats/docs/reference/cli-commands.md` (new): flags/arguments for every `lcats` subcommand,
+  verified live against `lcats <command> --help` for each one before writing (not assumed from
+  `cli-status.md` or source).
+- `lcats/docs/reference/llm-backend.md` (new): the `LLMBackend` Protocol, `BackendResponse`,
+  `AnthropicBackend`/`OpenAIBackend`/`FakeBackend`, and the provider wire-format translation
+  table, derived from `project/design/unified-llm-backend-design.md` and cross-checked directly
+  against `lcats/llm/{backend,anthropic_backend,openai_backend,fake_backend}.py` — documented one
+  behavior (temperature suppression for newer Claude models, in `anthropic_backend.py`) that
+  exists in code but isn't in the original design doc.
+- `lcats/docs/index.md` and `lcats/docs/reference/README.md`: linked both new pages, without
+  disturbing entries other sessions had already added (`prepare-corpora-release.md`,
+  `corpus-promotion.md`, `secrets-setup.md`).
+
+**Disclosed scope addition** (flagged at the confirm gate, not silent): the CLI grew two commands
+(`promote`, `clean`) via unrelated work in the 10 days since this WI was written. Documented all
+15 current subcommands in `cli-commands.md` rather than the WI's original 13 — the WI's own
+"verify against actual `--help`, not assumed from source" principle would be defeated by shipping
+a reference page that's already wrong. Also added `promote`/`clean` to the older
+`docs/reference/cli-status.md` matrix so it doesn't sit stale immediately next to the new page.
+For `promote`, kept `cli-commands.md`'s entry brief with a pointer to the existing dedicated
+`corpus-promotion.md` rather than duplicating it.
+
+# Validation
+
+- Only Markdown files changed (`git status --short` showed 7 modified/new `.md` files, no
+  Python) — `scripts/format`, `scripts/lint`, `scripts/test` not applicable.
+- `scripts/version tools` — not present in this repository (no `scripts/version` script exists,
+  consistent with every prior session this workstream).
+- Verified every link added in this PR resolves on the filesystem (`docs/index.md`,
+  `docs/how-to/run-assess.md`, `docs/reference/{README,cli-commands,llm-backend,cli-status}.md`,
+  corpus `README.md`) via a small Python script, not by eye.
+- `lrh validate` — 0 errors, 26 pre-existing warnings (unchanged from before this PR).
+
+# Follow-up
+
+- `session_transcript` is `pending` — update to `claude-app:<session-id>` after this session ends.
+- After PR #135 merges: run `/lrh-closeout` — set this record's `status` to `landed`, record the
+  merge commit, move `WI-DOCS-0014` to `project/work_items/resolved/`. Given `WI-DOCS-0013`'s
+  closeout was missed for 10 days last time, don't assume this one will happen automatically.
+- `WI-DOCS-0015` (tutorial, Phase 4) is now unblocked — depends on both `WI-DOCS-0013` (resolved)
+  and this item.


### PR DESCRIPTION
## Summary
Implements `WI-DOCS-0014` (Phase 3 of the 2026-07-07 docs audit): normalize the CLI, LLM-backend, and `lcats assess` reference documentation.

- Extracted the `lcats assess` how-to content (modes, manual prompt validation, dry run) out of Section 9 of `lcats/lcats/analysis/corpus/README.md` into `docs/how-to/run-assess.md` — copy-and-link, not a rewrite, per the audit's note that the original content was carefully reviewed. Section 9 is now a one-line pointer.
- Added `docs/reference/cli-commands.md`: flags/arguments for every `lcats` subcommand, verified live against `lcats <command> --help` (not assumed from source).
- Added `docs/reference/llm-backend.md`: the `LLMBackend` Protocol, `AnthropicBackend`/`OpenAIBackend`/`FakeBackend`, and the provider wire-format translation table, derived from `project/design/unified-llm-backend-design.md` and cross-checked against the actual `lcats/llm/` implementation — including one behavior (temperature suppression for newer Claude models) that exists in code but isn't in the original design doc.
- Linked both new pages from `docs/index.md` and `docs/reference/README.md`.

## Scope note (flagged at the confirm gate, not silent)
The CLI grew two commands (`promote`, `clean`) via unrelated work in the 10 days since this WI was written. `cli-commands.md` documents all 15 current subcommands rather than the WI's original 13 — the WI's own principle is "verify against actual `--help` output, not assumed from source," and documenting only 13 today would make the new page wrong on arrival. Also added `promote`/`clean` to `docs/reference/cli-status.md` (the older Phase 2a status matrix) so it doesn't sit stale directly next to the new, more detailed page. For `promote`, kept the `cli-commands.md` entry brief with a pointer to the existing dedicated `corpus-promotion.md` rather than duplicating it.

Prompt ID: `PROMPT(WI-DOCS-0014:WI_DOCS_0014)[2026-07-19T14:52:06-04:00]`

## Test plan
- [x] Verified all 15 subcommands' `--help` output live before writing `cli-commands.md`
- [x] Cross-checked `llm-backend.md` against the actual `lcats/llm/{backend,anthropic_backend,openai_backend,fake_backend}.py` source, not just the design doc
- [x] Checked every link added in this PR resolves on the filesystem (`docs/index.md`, `docs/how-to/run-assess.md`, `docs/reference/{README,cli-commands,llm-backend,cli-status}.md`, corpus `README.md`)
- [x] Only Markdown changed — `scripts/format`/`lint`/`test` not applicable
- [x] `lrh validate`: 0 errors, 26 pre-existing warnings unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
