### PR TITLE
Add work item WI-META-0023: Remove LRH meta-registry duplication from LCATS codebase and docs

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_20_22_27_19_WI_META_0023_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_20_22_27_19_WI_META_0023_REVIEW.md
@@ -1,0 +1,66 @@
+---
+execution_id: 2026_07_20_22_27_19_WI_META_0023_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_META_0023_REVIEW)[2026-07-20T17:52:04-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/137
+commit: 87c71ea
+created_at: 2026-07-20T22:27:19-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/137
+session_transcript: pending
+---
+
+# Summary
+
+Addressed 6 open review comments on PR #137 (WI-META-0023, "Remove LRH
+meta-registry duplication from LCATS codebase and docs"): two reviewers
+flagged that the work item's `artifacts_expected` list used non-path
+annotations, that `Required Changes` baked in line numbers likely to drift,
+that the repo-root `README.md` CLI table was missing from scope, and that
+the manual work-item index (`lcats/project/work_items/README.md`) was not
+updated for the new proposed item or WI-META-0006's planned move to
+`abandoned/`.
+
+# Result
+
+All six comments were valid, present, and feasible to fix in-place on
+`project/work_items/proposed/WI-META-0023.md` (no code changes were
+required since this PR only adds the planning artifact):
+
+1. Removed the `(deleted)` annotations from `artifacts_expected`; entries
+   are now plain repo-relative paths.
+2. Reworded `Required Changes` items 2 (cli.py) to reference the symbol
+   (`meta_registry` import, `_handle_meta_register` handler, subparser
+   registration) instead of line numbers.
+3. Reworded the doc-file `Required Changes` items (README, roadmap,
+   cli-commands.md, cli-status.md) to reference sections/rows instead of
+   line numbers.
+4. Added the repo-root `README.md` CLI Commands table row to Scope,
+   Required Changes, `acceptance`/`artifacts_expected` frontmatter,
+   Acceptance Criteria, and the validation grep command.
+5. Added a Required Changes step and acceptance criterion to add
+   `WI-META-0023` under Proposed Items in `lcats/project/work_items/README.md`.
+6. Added a Required Changes step and acceptance criterion to remove
+   WI-META-0006 from Active Items and add an Abandoned Items
+   listing/bucket description in the same index file when it moves.
+
+# Validation
+
+- `scripts/format --check --diff` — 153 files unchanged, no diff.
+- `scripts/lint` — ruff and black checks passed.
+- `scripts/test` — 1346 tests, OK.
+- `lrh validate` — 0 errors, 28 pre-existing warnings (unrelated
+  `OWNER_ROLE_INSUFFICIENT` / `PLANNING_ORPHANED_ACTIVE_WORK_ITEM`,
+  unchanged by this commit).
+- `scripts/version tools` — not present in this repository; no equivalent
+  substituted (repo has no tool-version pinning script).
+
+# Follow-up
+
+- `session_transcript` is `pending`; update to `claude-app:<session-id>`
+  after this session ends.
+- The implementation PR for WI-META-0023 itself (the actual code/doc
+  removal) is still outstanding — this record only covers the review
+  response for the planning-artifact PR.

--- a/lcats/project/executions/AD_HOC/2026_07_20_22_38_31_WI_META_0023_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_20_22_38_31_WI_META_0023_CONFIRM.md
@@ -1,0 +1,75 @@
+---
+execution_id: 2026_07_20_22_38_31_WI_META_0023_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_META_0023_CONFIRM)[2026-07-20T22:35:37-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/137
+commit: 7cc5967
+created_at: 2026-07-20T22:38:31-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/137
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge fresh-eyes verification of PR #137 (WI-META-0023) after the
+`/lrh-review-response` round pushed fixes for all 6 original review
+comments. Independently re-read the live unresolved-thread state and the
+current `HEAD` diff (not the review-response execution record's claims)
+to decide which threads the diff actually satisfies.
+
+# Result
+
+`lrh github threads --mode raw --state all`, filtered client-side to
+`isResolved == false`, returned 5 unresolved threads (1 of the original 6 —
+the `artifacts_expected` "(deleted)" annotation comment — already showed
+`isResolved: true` on GitHub and needed no action). All 5 were classified
+Clear-satisfied against the current diff (inline classification, not
+subagent — user declined the subagent offer since the fixes, though
+authored in this session, were mechanically verifiable against the diff):
+
+1. copilot-pull-request-reviewer — cli.py line-number drift concern —
+   satisfied: Required Changes item 2 now names symbols, not line numbers.
+2. copilot-pull-request-reviewer — doc-file line-number drift concern —
+   satisfied: doc items now reference sections/rows, not line numbers.
+3. chatgpt-codex-connector — repo-root README.md missing from scope —
+   satisfied: item 4 now explicitly covers repo-root README.md; grep/
+   acceptance/artifacts updated to include it.
+4. chatgpt-codex-connector — WI-META-0023 missing from work-item index —
+   satisfied: item 10 requires adding it to Proposed Items.
+5. chatgpt-codex-connector — WI-META-0006 relocation not reflected in
+   index — satisfied: item 10 requires removing the Active entry and
+   adding an Abandoned Items listing.
+
+No Unaddressed / Partial / Ambiguous / Problematic threads. Thread-
+resolution verdict: **green** — all 5 resolved via `resolveReviewThread`,
+no exceptions remain open.
+
+No primary execution record was found for this branch (`find
+project/executions/ -name "*WI_META_0023*" | grep -vE
+"_(REVIEW|CONFIRM)\.md$"` returned nothing) — this is a planning-only PR
+created outside `/lrh-implement`, so `rerun_of` is left empty.
+
+# Validation
+
+- `gh pr checks 137 --required` — exited 1 ("no required checks reported");
+  distinguishing check (`gh api repos/xenotaur/LCATS/rules/branches/main
+  --jq '[.[] | select(.type=="required_status_checks")] | length'`) returned
+  `0`, confirming no required-check branch protection exists (not a timing
+  race) — safe to fall back to the unfiltered read.
+- `gh pr checks 137` (unfiltered, provisional read) — `test`, `coverage`,
+  `lint` all `SUCCESS`.
+- 5/5 `resolveReviewThread` mutations returned `isResolved: true`.
+- `lrh validate` — run below before commit.
+
+# Follow-up
+
+- `session_transcript` is `pending`; update to `claude-app:<session-id>`
+  after this session ends.
+- Final CI re-check against the post-push `HEAD` SHA (after this record is
+  committed) still needs to run before the merge-readiness verdict is
+  reported — see the confirm-fixes report in chat.
+- The implementation PR for WI-META-0023 itself (the actual code/doc
+  removal) is still outstanding.

--- a/lcats/project/work_items/proposed/WI-META-0023.md
+++ b/lcats/project/work_items/proposed/WI-META-0023.md
@@ -30,8 +30,9 @@ acceptance:
   - lcats/lcats/meta_registry.py no longer exists
   - lcats/lcats/cli.py has no `meta`/`meta register` subcommand, handler, or `meta_registry` import
   - lcats/tests/meta_registry_test.py is removed and lcats/tests/cli_test.py has no meta-register test cases
-  - lcats/README.md, lcats/project/roadmap/roadmap.md, lcats/docs/reference/cli-commands.md, and lcats/docs/reference/cli-status.md no longer document `lcats meta register` as an LCATS command
+  - README.md, lcats/README.md, lcats/project/roadmap/roadmap.md, lcats/docs/reference/cli-commands.md, and lcats/docs/reference/cli-status.md no longer document `lcats meta register` as an LCATS command
   - WI-META-0006 is moved to project/work_items/abandoned/ with status abandoned and a resolution note pointing to WI-META-0023 and `lrh meta register`
+  - lcats/project/work_items/README.md reflects WI-META-0023 under Proposed Items and WI-META-0006's move out of Active Items
   - lrh validate reports 0 errors
   - scripts/test passes
 required_evidence:
@@ -39,14 +40,16 @@ required_evidence:
   - lrh_validate
   - test_output
 artifacts_expected:
-  - lcats/lcats/meta_registry.py (deleted)
+  - lcats/lcats/meta_registry.py
   - lcats/lcats/cli.py
-  - lcats/tests/meta_registry_test.py (deleted)
+  - lcats/tests/meta_registry_test.py
   - lcats/tests/cli_test.py
+  - README.md
   - lcats/README.md
   - lcats/project/roadmap/roadmap.md
   - lcats/docs/reference/cli-commands.md
   - lcats/docs/reference/cli-status.md
+  - lcats/project/work_items/README.md
   - lcats/project/work_items/abandoned/WI-META-0006.md
 ---
 
@@ -61,18 +64,20 @@ Commits `009b0c0` and `9d36ad8` (2026-04-21) added a "workspace project registry
 ## Scope
 - Remove the `meta_registry` module and its CLI wiring from the `lcats` Python package.
 - Remove or update all tests referencing `meta register`/`meta_registry`.
-- Remove documentation of `lcats meta register` from README, roadmap, and `docs/reference/`.
-- Move WI-META-0006 to `abandoned/` with a resolution note.
+- Remove documentation of `lcats meta register` from the repo-root README, `lcats/README.md`, roadmap, and `docs/reference/`.
+- Move WI-META-0006 to `abandoned/` with a resolution note, and update the work-item index accordingly.
 
 ## Required Changes
 1. Delete `lcats/lcats/meta_registry.py`.
-2. In `lcats/lcats/cli.py`: remove `from lcats import meta_registry` (line 14), `_handle_meta_register` (line 66), the `meta`/`meta register` subparser wiring (around line 284), and the `meta_register_parser.set_defaults(handler=_handle_meta_register)` line.
+2. In `lcats/lcats/cli.py`: remove the `meta_registry` import, the `_handle_meta_register` handler function, and the `meta`/`meta register` subparser registration (including its `set_defaults(handler=_handle_meta_register)` wiring).
 3. Delete `lcats/tests/meta_registry_test.py`; remove the meta-register test cases from `lcats/tests/cli_test.py`.
-4. In `lcats/README.md`: remove the `lcats meta register <repo_locator>` line (line 39) from the Building section.
-5. In `lcats/project/roadmap/roadmap.md`: remove or rephrase the Phase 5 bullet "Deliver initial workspace meta registry slice (`meta register`)..." (line 52).
-6. In `lcats/docs/reference/cli-commands.md`: remove the `## meta register` section (line 218 onward).
-7. In `lcats/docs/reference/cli-status.md`: remove `meta register` from the Implemented commands list (line 18).
-8. Move `lcats/project/work_items/active/WI-META-0006.md` to `lcats/project/work_items/abandoned/WI-META-0006.md`, set `status: abandoned`, `resolution:` explaining it is superseded by native LRH functionality (`lrh meta register`) and reversed by WI-META-0023.
+4. In the repo-root `README.md`: remove the `lcats meta register <repo_locator>` row from the CLI Commands table.
+5. In `lcats/README.md`: remove the `lcats meta register <repo_locator>` line from the Building section.
+6. In `lcats/project/roadmap/roadmap.md`: remove or rephrase the Phase 5 bullet referencing delivery of the workspace meta registry slice (`meta register`).
+7. In `lcats/docs/reference/cli-commands.md`: remove the `## meta register` section.
+8. In `lcats/docs/reference/cli-status.md`: remove `meta register` from the Implemented commands list.
+9. Move `lcats/project/work_items/active/WI-META-0006.md` to `lcats/project/work_items/abandoned/WI-META-0006.md`, set `status: abandoned`, `resolution:` explaining it is superseded by native LRH functionality (`lrh meta register`) and reversed by WI-META-0023.
+10. In `lcats/project/work_items/README.md`: remove the `active/WI-META-0006.md` entry from Active Items, add an Abandoned Items section (or bucket description) listing `abandoned/WI-META-0006.md`, and add `proposed/WI-META-0023.md` to Proposed Items.
 
 ## Non-Goals
 - Do not implement or modify anything in the LRH repository (`logical_robotics_harness`) -- this item only removes the duplicate from LCATS.
@@ -81,7 +86,8 @@ Commits `009b0c0` and `9d36ad8` (2026-04-21) added a "workspace project registry
 
 ## Acceptance Criteria
 - `lcats meta register` no longer exists as a CLI command (`lcats --help` shows no `meta` subcommand).
-- `grep -rIl "meta_registry\|meta register" lcats/lcats lcats/tests lcats/README.md lcats/docs lcats/project/roadmap` returns no matches (excluding WI-META-0006/WI-META-0023 themselves).
+- `grep -rIl "meta_registry\|meta register" lcats/lcats lcats/tests README.md lcats/README.md lcats/docs lcats/project/roadmap` returns no matches (excluding WI-META-0006/WI-META-0023 themselves).
+- `lcats/project/work_items/README.md` lists WI-META-0023 under Proposed Items and no longer lists WI-META-0006 under Active Items.
 - `lrh validate` reports 0 errors.
 - `scripts/test` passes.
 
@@ -90,7 +96,7 @@ Commits `009b0c0` and `9d36ad8` (2026-04-21) added a "workspace project registry
 - `scripts/test`
 - `scripts/lint`
 - `lcats --help`
-- `grep -rIl "meta_registry\|meta register" lcats/lcats lcats/tests lcats/README.md lcats/docs lcats/project/roadmap`
+- `grep -rIl "meta_registry\|meta register" lcats/lcats lcats/tests README.md lcats/README.md lcats/docs lcats/project/roadmap`
 
 ## Risk Notes
 - `lcats/lcats/cli.py` mixes this handler with unrelated subcommands in one file; the removal diff must be scoped carefully to avoid touching other command wiring.

--- a/lcats/project/work_items/proposed/WI-META-0023.md
+++ b/lcats/project/work_items/proposed/WI-META-0023.md
@@ -1,0 +1,97 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-META-0023
+title: Remove LRH meta-registry duplication from LCATS codebase and docs
+type: operation
+status: proposed
+priority: medium
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus: []
+related_roadmap: []
+related_workstreams: []
+related_design: []
+depends_on: []
+blocked_by: []
+expected_actions:
+  - delete_file
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - modify_ci_pipeline
+  - run_lrh_agentic
+acceptance:
+  - lcats/lcats/meta_registry.py no longer exists
+  - lcats/lcats/cli.py has no `meta`/`meta register` subcommand, handler, or `meta_registry` import
+  - lcats/tests/meta_registry_test.py is removed and lcats/tests/cli_test.py has no meta-register test cases
+  - lcats/README.md, lcats/project/roadmap/roadmap.md, lcats/docs/reference/cli-commands.md, and lcats/docs/reference/cli-status.md no longer document `lcats meta register` as an LCATS command
+  - WI-META-0006 is moved to project/work_items/abandoned/ with status abandoned and a resolution note pointing to WI-META-0023 and `lrh meta register`
+  - lrh validate reports 0 errors
+  - scripts/test passes
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/lcats/meta_registry.py (deleted)
+  - lcats/lcats/cli.py
+  - lcats/tests/meta_registry_test.py (deleted)
+  - lcats/tests/cli_test.py
+  - lcats/README.md
+  - lcats/project/roadmap/roadmap.md
+  - lcats/docs/reference/cli-commands.md
+  - lcats/docs/reference/cli-status.md
+  - lcats/project/work_items/abandoned/WI-META-0006.md
+---
+
+# Work Item: WI-META-0023
+
+## Summary
+Remove the `lcats meta register` command and its `meta_registry.py` implementation from LCATS, along with all documentation that presents it as an LCATS feature, since it duplicates functionality that already exists natively in the LRH CLI (`lrh meta register`).
+
+## Problem / Context
+Commits `009b0c0` and `9d36ad8` (2026-04-21) added a "workspace project registry" slice (`lcats/lcats/meta_registry.py`, wired into the CLI as `lcats meta register`) under WI-META-0006. Investigation shows this duplicates LRH's own `meta` subsystem (`lrh meta {init,list,where,config,register,refresh,inspect,set,unset}`, ~2,929 lines in `src/lrh/meta/workspace.py` + `local_state_model.py`) almost field-for-field: `repo_locator`, `project_dir`, TOML registry records under `projects/`, duplicate-detection via `--force`. Nothing in the LCATS version touches LCATS's actual domain (corpora, texts, gathering, story analysis) -- it is pure workspace bookkeeping that belongs in LRH, which already implements it more completely. A broader repo sweep for other LRH-flavored fingerprints (`work_item`, `workstream`, `execution record`, `.lrh/config`, `LRH_WORKSPACE`, etc.) found no further contamination -- this is an isolated, self-contained slice from a single two-commit session.
+
+## Scope
+- Remove the `meta_registry` module and its CLI wiring from the `lcats` Python package.
+- Remove or update all tests referencing `meta register`/`meta_registry`.
+- Remove documentation of `lcats meta register` from README, roadmap, and `docs/reference/`.
+- Move WI-META-0006 to `abandoned/` with a resolution note.
+
+## Required Changes
+1. Delete `lcats/lcats/meta_registry.py`.
+2. In `lcats/lcats/cli.py`: remove `from lcats import meta_registry` (line 14), `_handle_meta_register` (line 66), the `meta`/`meta register` subparser wiring (around line 284), and the `meta_register_parser.set_defaults(handler=_handle_meta_register)` line.
+3. Delete `lcats/tests/meta_registry_test.py`; remove the meta-register test cases from `lcats/tests/cli_test.py`.
+4. In `lcats/README.md`: remove the `lcats meta register <repo_locator>` line (line 39) from the Building section.
+5. In `lcats/project/roadmap/roadmap.md`: remove or rephrase the Phase 5 bullet "Deliver initial workspace meta registry slice (`meta register`)..." (line 52).
+6. In `lcats/docs/reference/cli-commands.md`: remove the `## meta register` section (line 218 onward).
+7. In `lcats/docs/reference/cli-status.md`: remove `meta register` from the Implemented commands list (line 18).
+8. Move `lcats/project/work_items/active/WI-META-0006.md` to `lcats/project/work_items/abandoned/WI-META-0006.md`, set `status: abandoned`, `resolution:` explaining it is superseded by native LRH functionality (`lrh meta register`) and reversed by WI-META-0023.
+
+## Non-Goals
+- Do not implement or modify anything in the LRH repository (`logical_robotics_harness`) -- this item only removes the duplicate from LCATS.
+- Do not add a pointer/wrapper command in LCATS that shells out to `lrh meta register` -- users who need workspace registration should use `lrh` directly.
+- Do not re-audit for other contamination -- that sweep was already done in the conversation that produced this item and found nothing further.
+
+## Acceptance Criteria
+- `lcats meta register` no longer exists as a CLI command (`lcats --help` shows no `meta` subcommand).
+- `grep -rIl "meta_registry\|meta register" lcats/lcats lcats/tests lcats/README.md lcats/docs lcats/project/roadmap` returns no matches (excluding WI-META-0006/WI-META-0023 themselves).
+- `lrh validate` reports 0 errors.
+- `scripts/test` passes.
+
+## Validation
+- `lrh validate`
+- `scripts/test`
+- `scripts/lint`
+- `lcats --help`
+- `grep -rIl "meta_registry\|meta register" lcats/lcats lcats/tests lcats/README.md lcats/docs lcats/project/roadmap`
+
+## Risk Notes
+- `lcats/lcats/cli.py` mixes this handler with unrelated subcommands in one file; the removal diff must be scoped carefully to avoid touching other command wiring.
+- If any external doc or script (outside this repo) references `lcats meta register`, it will break -- none were found in this repo's sweep, but this wasn't checked outside LCATS.


### PR DESCRIPTION
## Summary
- Investigation found that `lcats/lcats/meta_registry.py` (`lcats meta register`, added under WI-META-0006) duplicates LRH's own `meta` subsystem (`lrh meta register`, backed by ~2,929 lines in `src/lrh/meta/`) -- workspace/project-registry bookkeeping that has nothing to do with LCATS's literary-corpus domain.
- Adds `WI-META-0023` to `project/work_items/proposed/` proposing removal of the duplicated code, tests, and docs (README, roadmap, `docs/reference/cli-*.md`), plus moving `WI-META-0006` to `abandoned/`.
- A repo-wide sweep for other LRH-flavored fingerprints found no further contamination -- this is isolated to the single two-commit session that added it.

## Test plan
- [x] `lrh validate` -- 0 errors (28 pre-existing `OWNER_ROLE_INSUFFICIENT`/`PLANNING_ORPHANED_ACTIVE_WORK_ITEM` warnings, unrelated to this change)
- [ ] Follow-up implementation PR performs the actual code/doc removal per this work item's Required Changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
