### PR TITLE
Close backend and cost/baseline gaps in event-role-world extractor proposal

### DIFF
--- a/lcats/project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
+++ b/lcats/project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
@@ -63,16 +63,21 @@ This proposal does not:
 
 ## Implementation prerequisites
 
-Design principle 5 (strict schemas over unconstrained JSON) is not yet
-supported by the current LLM backend. `OpenAIBackend.complete` only ever
-requests `{"type": "json_object"}` mode, which guarantees valid JSON but not
-conformance to any particular schema; it does not yet request JSON Schema or
-tool/function-based structured output. Before any Event-Role-World object
-(`Event`, `EntityMention`, `EventRelation`, etc.) is treated as schema-valid
-rather than best-effort-parsed, the implementation must add JSON Schema or
-tool-based structured-output support to the backend. This is a stage-0
-blocking task for the first implementation work item, not an optional later
-upgrade.
+`OpenAIBackend.complete` and `AnthropicBackend.complete` already support
+tool/function-based structured output: when a caller passes `tool`, both
+backends convert `tool["input_schema"]` into the provider's function/tool
+schema, force the model to call that tool, and return parsed, schema-checked
+arguments (`OpenAIBackend.complete`, `AnthropicBackend.complete`). Only the
+no-`tool` path falls back to unconstrained `{"type": "json_object"}` mode.
+No backend engineering is required as a stage-0 blocker.
+
+The actual requirement for design principle 5 (strict schemas over
+unconstrained JSON) is narrower: the Event-Role-World extractor implementation
+must define a JSON Schema for each output object (`Event`, `EntityMention`,
+`EventRelation`, etc.) and call the backend through the existing `tool=`
+path instead of the current scene/sequel prompts' unconstrained
+`json_object` mode. This is extractor-side schema and call-site work, not a
+backend capability gap.
 
 ## High-level architecture
 
@@ -243,14 +248,24 @@ coverage so genre comparisons remain auditable.
 
 ### Cost and baseline requirements
 
-- Each annotator pass must document whether it is LLM-backed or NLP-only, and
-  the pipeline must report total LLM calls per segment and per story so cost
-  and latency at corpus scale are visible before a full run is committed to.
-- A fixed-chunk baseline and a segment-only (no event/relation/SF-tag)
-  baseline must be run and exported alongside every SF-vs-other-genre
-  comparison metric. Genre-comparison claims are not reportable in the paper
-  without an accompanying baseline showing the effect is not an artifact of
-  chunking or story length.
+- Each annotator pass must document whether it is LLM-backed or NLP-only. For
+  LLM-backed passes, the pipeline must record input/output token counts,
+  model, and elapsed time per pass, not just a call count, since segments and
+  annotators vary enough in output volume that call counts alone do not make
+  cost or latency visible before a full run is committed to. The backend
+  already returns token counts and model per call (`BackendResponse`), so
+  this is a reporting requirement, not new backend capability.
+- Every SF-vs-other-genre comparison metric must be accompanied by a
+  fixed-chunk-vs-segment comparison: run the same full Event-Role-World
+  extractor over both scene/sequel segments and fixed-token chunks,
+  controlling for segment/story length, so genre differences are not
+  confounded with the chunking strategy. A segment-only baseline (scene/sequel
+  labels without event/relation/SF-tag enrichment) is a separate, narrower
+  control and only applies to metrics it can compute directly from segment
+  structure (segment-type distribution, segment length, coverage) — it cannot
+  be used for metrics that require the event/relation/SF-tag layers (event-type
+  distributions, causal-link density, SF-tag counts), since those layers are
+  exactly what the segment-only baseline omits.
 - A stratified sample across genres, eras, and extraction-confidence bands
   must receive human review before any comparison metric is treated as
   publication-quality.
@@ -266,7 +281,7 @@ coverage so genre comparisons remain auditable.
 | Graph-extraction overreach | Keep JSON canonical, validate IDs first, and defer graph-database adoption. |
 | Confusing interpretive hypotheses with extractive facts | Separate hypothesis fields, certainty, and confidence; exclude optional hypotheses from primary quantitative claims unless validated. |
 | Duplicating prior scene/sequel work | Make existing segments the input contract and retain the stated non-goals. |
-| LLM cost/latency at corpus scale from up to seven annotator passes per segment | Report LLM calls per segment/story; identify which annotators can run as NLP-only; gate a full-corpus run behind a cost estimate from the pilot sample. |
+| LLM cost/latency at corpus scale from up to seven annotator passes per segment | Report token counts, model, and elapsed time per pass (not just call counts); identify which annotators can run as NLP-only; gate a full-corpus run behind a cost estimate from the pilot sample. |
 
 ## Resulting scientific claim
 

--- a/lcats/project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
+++ b/lcats/project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
@@ -61,6 +61,19 @@ This proposal does not:
 7. Defer graph databases and deep case-based-reasoning adaptation until the
    extracted data justifies them.
 
+## Implementation prerequisites
+
+Design principle 5 (strict schemas over unconstrained JSON) is not yet
+supported by the current LLM backend. `OpenAIBackend.complete` only ever
+requests `{"type": "json_object"}` mode, which guarantees valid JSON but not
+conformance to any particular schema; it does not yet request JSON Schema or
+tool/function-based structured output. Before any Event-Role-World object
+(`Event`, `EntityMention`, `EventRelation`, etc.) is treated as schema-valid
+rather than best-effort-parsed, the implementation must add JSON Schema or
+tool-based structured-output support to the backend. This is a stage-0
+blocking task for the first implementation work item, not an optional later
+upgrade.
+
 ## High-level architecture
 
 ```text
@@ -228,6 +241,20 @@ resolve aliases and cross-segment references without losing segment evidence.
 Metrics must report relevant denominators, extraction versions, and validation
 coverage so genre comparisons remain auditable.
 
+### Cost and baseline requirements
+
+- Each annotator pass must document whether it is LLM-backed or NLP-only, and
+  the pipeline must report total LLM calls per segment and per story so cost
+  and latency at corpus scale are visible before a full run is committed to.
+- A fixed-chunk baseline and a segment-only (no event/relation/SF-tag)
+  baseline must be run and exported alongside every SF-vs-other-genre
+  comparison metric. Genre-comparison claims are not reportable in the paper
+  without an accompanying baseline showing the effect is not an artifact of
+  chunking or story length.
+- A stratified sample across genres, eras, and extraction-confidence bands
+  must receive human review before any comparison metric is treated as
+  publication-quality.
+
 ## Risks and mitigations
 
 | Risk | Mitigation |
@@ -239,10 +266,7 @@ coverage so genre comparisons remain auditable.
 | Graph-extraction overreach | Keep JSON canonical, validate IDs first, and defer graph-database adoption. |
 | Confusing interpretive hypotheses with extractive facts | Separate hypothesis fields, certainty, and confidence; exclude optional hypotheses from primary quantitative claims unless validated. |
 | Duplicating prior scene/sequel work | Make existing segments the input contract and retain the stated non-goals. |
-
-Lexical and segment-only baselines should accompany evaluation. A stratified
-sample across genres, eras, and extraction-confidence bands should receive
-human review.
+| LLM cost/latency at corpus scale from up to seven annotator passes per segment | Report LLM calls per segment/story; identify which annotators can run as NLP-only; gate a full-corpus run behind a cost estimate from the pilot sample. |
 
 ## Resulting scientific claim
 

--- a/lcats/project/executions/AD_HOC/2026_07_21_21_55_00_LCATS_EXTRACTOR_DESIGN_REVIEW_DB3C01_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_21_21_55_00_LCATS_EXTRACTOR_DESIGN_REVIEW_DB3C01_REVIEW.md
@@ -1,0 +1,60 @@
+---
+execution_id: 2026_07_21_21_55_00_LCATS_EXTRACTOR_DESIGN_REVIEW_DB3C01_REVIEW
+prompt_id: PROMPT(AD_HOC:LCATS_EXTRACTOR_DESIGN_REVIEW_DB3C01_REVIEW)[2026-07-21T17:21:07-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/142
+commit: f67780c
+created_at: 2026-07-21T21:55:00-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/142
+session_transcript: pending
+---
+
+# Summary
+
+Addressed 4 open review comments (chatgpt-codex-connector x3,
+copilot-pull-request-reviewer x1) on PR #142, which revises the
+Event-Role-World extractor proposal. `rerun_of` is left empty: no primary
+execution record exists for this PR's underlying change (it originated from
+an ad hoc chat design review, not `/lrh-implement`).
+
+# Result
+
+- Two reviewers flagged that the "Implementation prerequisites" section
+  misstated backend capability, claiming `OpenAIBackend` needed new
+  structured-output support as a stage-0 blocker. Verified against
+  `lcats/lcats/llm/openai_backend.py:47-76` and `anthropic_backend.py:53-105`
+  that both backends already support schema-checked tool/function-based
+  output via the `tool=` parameter. Rewrote the section to describe the
+  existing path and narrow the real requirement to per-object JSON Schemas
+  plus using that path from the extractor.
+- Fixed the cost-reporting bullet to require token counts, model, and
+  elapsed time per LLM-backed pass, not just call counts, since the backend
+  already returns this data (`BackendResponse`).
+- Replaced the segment-only baseline requirement (which excluded exactly the
+  fields — event/relation/SF-tag — needed to compute the metrics it was
+  meant to validate) with a computable fixed-chunk-vs-segment comparison
+  using the same full extractor, scoping the segment-only control to only
+  the metrics it can actually produce.
+- Updated the matching risk-table mitigation to match the expanded cost
+  bullet.
+
+All 4 comments were valid and addressed; none were skipped.
+
+# Validation
+
+- `scripts/format --check --diff` — 153 files unchanged
+- `scripts/lint` — ruff and black checks passed
+- `scripts/test` — 1346 tests OK
+- `lrh validate` — 0 errors, 28 pre-existing warnings unrelated to this file
+- `scripts/version tools` — script does not exist in this repo (not
+  applicable; change is documentation-only, no Python touched)
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Recommend `/lrh-confirm-fixes` on PR #142 before merge to verify these
+  fixes against the current diff and resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_21_23_02_36_LCATS_EXTRACTOR_DESIGN_REVIEW_DB3C01_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_21_23_02_36_LCATS_EXTRACTOR_DESIGN_REVIEW_DB3C01_CONFIRM.md
@@ -1,0 +1,77 @@
+---
+execution_id: 2026_07_21_23_02_36_LCATS_EXTRACTOR_DESIGN_REVIEW_DB3C01_CONFIRM
+prompt_id: PROMPT(AD_HOC:LCATS_EXTRACTOR_DESIGN_REVIEW_DB3C01_CONFIRM)[2026-07-21T23:01:44-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/142
+commit: 032e4f4
+created_at: 2026-07-21T23:02:36-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/142
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass on PR #142 (Event-Role-World proposal review
+fixes). Independently re-checked the 4 open review threads against the
+current `HEAD` diff (032e4f4), not against the prior `_REVIEW` record's own
+claims. `rerun_of` is left empty: no primary execution record exists for
+this PR's underlying change (it originated from an ad hoc chat design
+review, not `/lrh-implement`).
+
+# Result
+
+`lrh request review_response` reported "Nothing to resolve" (its narrower
+`state="unresolved"` filter excludes outdated threads), but
+`lrh github threads --mode raw --state all` filtered to `isResolved ==
+false` showed all 4 threads were still genuinely unresolved
+(`isOutdated: true`, `isResolved: false` each) — the authoritative
+outdated-but-unresolved case this skill exists to catch.
+
+All 4 threads classified Clear-satisfied on fresh read of the diff:
+
+- `PRRT_kwDOKlhIbM6Ss2Tb` (chatgpt-codex-connector, bot) — "Use the backend's
+  existing tool-schema path" — the rewritten "Implementation prerequisites"
+  section now states the tool-schema path already exists and drops the
+  stage-0-blocker framing.
+- `PRRT_kwDOKlhIbM6Ss2Tf` (chatgpt-codex-connector, bot) — "Record token and
+  timing usage" — the cost bullet now requires token counts, model, and
+  elapsed time per pass.
+- `PRRT_kwDOKlhIbM6Ss2Tj` (chatgpt-codex-connector, bot) — "Define a baseline
+  that can produce the compared metrics" — replaced with a computable
+  fixed-chunk-vs-segment comparison, scoping the segment-only baseline to
+  only the metrics it can compute.
+- `PRRT_kwDOKlhIbM6Ss2YD` (copilot-pull-request-reviewer, bot) — duplicate of
+  `Ss2Tb`'s concern — fixed by the same rewrite.
+
+All 4 were bot-authored, pre-selected, user-confirmed as a single batch, and
+resolved via `resolveReviewThread`. No exceptions surfaced (no Unaddressed,
+Partial, Ambiguous, or Problematic threads).
+
+Thread-resolution verdict: **green** — every unresolved thread resolved, no
+exceptions remain.
+
+# Validation
+
+- `lrh request review_response` — "Nothing to resolve" (narrower filter;
+  not treated as authoritative per protocol)
+- `lrh github threads --mode raw --state all` — 4 threads, all
+  `isResolved: false` before this run
+- Fresh-eyes diff read (`gh pr diff`) against each comment — all 4
+  Clear-satisfied
+- `gh api graphql resolveReviewThread` — all 4 threads now `isResolved: true`
+- Provisional CI (`gh pr checks --json name,state,bucket`, after confirming
+  no required-status-check branch protection via
+  `rules/branches/main` = 0 `required_status_checks` rules): `coverage`,
+  `lint`, `test` x2 all `pass`
+- Re-checked CI against post-push `HEAD` in the readiness report below
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Final merge-readiness verdict and `gh pr merge` one-liner are reported to
+  the user after this record is pushed and CI is re-checked against the new
+  `HEAD`.


### PR DESCRIPTION
## Summary

A best-practices design review of the [Event-Role-World extractor proposal](lcats/project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md), grounded against the current repo state, surfaced two gaps between the proposal's stated principles and the codebase as it exists today. Since the proposal is still `status: proposed` / `implementation_status: not_started`, these are addressed as direct revisions to the design doc rather than a separate work item.

- **Backend prerequisite**: design principle 5 ("prefer strict schemas over unconstrained JSON") isn't enforceable yet — `OpenAIBackend.complete` only requests `{"type": "json_object"}` mode (valid JSON, not schema-conformant). Added an "Implementation prerequisites" section calling out the JSON Schema / tool-based structured-output upgrade as a stage-0 blocking task for the first implementation work item.
- **Cost and baseline gate**: the proposal's cost risk (up to 7 annotator passes per segment) wasn't tracked, and baseline comparisons were phrased as a "should" recommendation rather than a required gate for the paper's genre-comparison claims. Added a "Cost and baseline requirements" subsection and a corresponding risk-table row requiring per-segment LLM-call reporting and mandatory fixed-chunk/segment-only baselines before any comparison metric counts as publication-quality.

## Test plan

- [x] `lrh validate` from the `lcats/project` root: 0 errors (28 pre-existing warnings unrelated to this file)
- [x] Reviewed diff — changes are additive, confined to the one proposal doc, no frontmatter/status changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
