### PR TITLE
Add workstream WS-EVENT-ROLE-WORLD: SF Event-Role-World Extractor Implementation

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_22_13_58_27_WS_EVENT_ROLE_WORLD_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_22_13_58_27_WS_EVENT_ROLE_WORLD_REVIEW.md
@@ -1,0 +1,65 @@
+---
+execution_id: 2026_07_22_13_58_27_WS_EVENT_ROLE_WORLD_REVIEW
+prompt_id: PROMPT(AD_HOC:WS_EVENT_ROLE_WORLD_REVIEW)[2026-07-22T13:48:51-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/143
+commit: e2eb424
+created_at: 2026-07-22T13:58:27-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/143
+session_transcript: pending
+---
+
+# Summary
+
+Addressed 3 open review comments (chatgpt-codex-connector x1,
+copilot-pull-request-reviewer x2) on PR #143, which adds workstream
+WS-EVENT-ROLE-WORLD. `rerun_of` is left empty: no primary execution record
+exists for this PR's underlying change (the workstream was created directly
+via `/lrh-workstream`, not through a minted-prompt-id `/lrh-implement` flow).
+
+# Result
+
+- Reviewer 1 (codex) caught that the workstream's Scope/Work Items/exit
+  criteria referenced a "Proposed v0.1 deliverable" and "stage 0"/"stage 5"
+  that do not exist in the governing proposal
+  (`project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md`).
+  That language came from a separate ChatGPT-conversation synthesis that
+  was never committed to the repo and was mistakenly conflated with the
+  proposal's actual "Recommended staged pipeline" (stages 1-9, verified by
+  reading the committed file directly). Rewrote Scope, Work Items, and
+  exit criteria against the real pipeline, and explicitly labeled the
+  first-work-item phasing (stages 1-5, with 6-7 and 9 following, 8
+  remaining optional per the proposal itself) as a workstream-level scoping
+  decision the proposal does not itself prescribe.
+- Reviewer 2 (copilot) caught the H1 convention mismatch: this repo's
+  workstreams consistently use `# Workstream: <title>`
+  (`WS-SPECIALS-CLEANUP.md`, `WS-DOCS.md`), not `# WS-<ID>`. Fixed.
+- Reviewer 2 (copilot) caught that the duplication-search bullet was
+  inaccurate: the proposal's own architecture sketch names an
+  `EventRoleWorldProcessor` and an `event_role_world/` module layout
+  (`00_proposal.md:91`, `00_proposal.md:132`) — design sketches, not code,
+  but real references, contradicting the "no ... references anywhere"
+  claim. The bullet also cited a nonexistent `.claude/skills/` directory.
+  Corrected to distinguish "no implementation" (true, verified) from "no
+  references" (false), and dropped the `.claude/skills/` claim.
+
+All 3 comments were valid and addressed; none were skipped.
+
+# Validation
+
+- `scripts/format --check --diff` — 151 files unchanged
+- `scripts/lint` — ruff and black checks passed
+- `scripts/test` — 1337 tests OK
+- `lrh validate` — 0 errors, 27 pre-existing warnings unrelated to this file
+- `scripts/version tools` — script does not exist in this repo (not
+  applicable; change is documentation-only, no Python touched)
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Recommend `/lrh-confirm-fixes` on PR #143 before merge to verify these
+  fixes against the current diff and resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_22_14_10_29_WS_EVENT_ROLE_WORLD_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_22_14_10_29_WS_EVENT_ROLE_WORLD_CONFIRM.md
@@ -1,0 +1,78 @@
+---
+execution_id: 2026_07_22_14_10_29_WS_EVENT_ROLE_WORLD_CONFIRM
+prompt_id: PROMPT(AD_HOC:WS_EVENT_ROLE_WORLD_CONFIRM)[2026-07-22T14:05:30-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/143
+commit: 491f6fd
+created_at: 2026-07-22T14:10:29-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/143
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass on PR #143 (WS-EVENT-ROLE-WORLD review fixes).
+Verification was dispatched to a cold subagent (no session memory) at the
+user's request, since the fixes being verified were authored in this same
+session. `rerun_of` is left empty: no primary execution record exists for
+this PR's underlying change (the workstream was created directly via
+`/lrh-workstream`, not through a minted-prompt-id `/lrh-implement` flow).
+
+# Result
+
+`lrh request review_response` reported "Nothing to resolve" (its narrower
+filter excludes outdated threads), but `lrh github threads --mode raw
+--state all` filtered to `isResolved == false` showed 2 of the original 3
+threads were still genuinely unresolved. The third thread (H1 convention
+fix) was already `isResolved: true` on GitHub by the time this run started
+— no action needed on it.
+
+The remaining 2 threads were classified by a cold subagent given only the
+PR URL, the two comment bodies, and instructions to independently re-read
+the current `WS-EVENT-ROLE-WORLD.md` and `00_proposal.md` content (not any
+prior report):
+
+- `PRRT_kwDOKlhIbM6S1m0M` (chatgpt-codex-connector, bot) — "Align the first
+  work item with the governing pipeline" — subagent confirmed the
+  proposal's real stages 1-9 (stage 6 = Relation pass, stage 7 = Discourse/SF
+  tag pass) and confirmed the workstream now references those real stages
+  and explicitly reconciles a narrower first-work-item scope rather than
+  inventing terminology. **Clear-satisfied.**
+- `PRRT_kwDOKlhIbM6S1nLR` (copilot-pull-request-reviewer, bot) — duplication
+  search bullet accuracy — subagent confirmed `00_proposal.md:91` and `:132`
+  do contain `EventRoleWorldProcessor`/`event_role_world/`, confirmed
+  `.claude/skills/` does not exist in this repo, and confirmed the current
+  bullet now distinguishes "no implementation" from "no references" and
+  drops the false `.claude/skills/` claim. **Clear-satisfied.**
+
+Both threads were bot-authored, pre-selected, user-confirmed as a single
+batch, and resolved via `resolveReviewThread`. No exceptions surfaced (no
+Unaddressed, Partial, Ambiguous, or Problematic threads).
+
+Thread-resolution verdict: **green** — every unresolved thread resolved, no
+exceptions remain.
+
+# Validation
+
+- `lrh request review_response` — "Nothing to resolve" (narrower filter;
+  not treated as authoritative per protocol)
+- `lrh github threads --mode raw --state all` — 3 threads total; 1 already
+  resolved, 2 unresolved before this run
+- Cold-subagent fresh-eyes verification against current file content
+  (not the prior `_REVIEW` execution record) — both Clear-satisfied
+- `gh api graphql resolveReviewThread` — both threads now `isResolved: true`
+- Provisional CI (`gh pr checks --json name,state,bucket`, after confirming
+  0 `required_status_checks` rules via `rules/branches/main`): `coverage`,
+  `lint`, `test` x2 all `pass`
+- Re-checked CI against post-push `HEAD` in the readiness report below
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Final merge-readiness verdict and `gh pr merge` one-liner are reported to
+  the user after this record is pushed and CI is re-checked against the new
+  `HEAD`.

--- a/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
@@ -12,14 +12,15 @@ related_design:
   - project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
 work_items: []
 exit_criteria:
-  - v0.1 seed extractor implemented per the proposal's staged pipeline (paragraph indexing through per-segment semantic audit), reusing the existing segment/evidence substrate without reimplementing it
+  - The proposal's Recommended staged pipeline stages 1-7 and 9 (input contract, surface feature pass, entity participant pass, event-role pass, anchor pass, relation pass, discourse/SF tag pass, and validation/export) are implemented, reusing the existing segment/evidence substrate without reimplementing scene/sequel extraction
+  - The optional hypothesis pass (stage 8) is implemented, or explicitly deferred with a follow-up work item recorded
   - New Event-Role-World object schemas (Event, EntityMention, EventRelation, etc.) are called through the backend's existing tool= structured-output path, not json_object mode
   - Validation and metrics export (per-story JSON, JSONL/CSV analysis tables) implemented and passes the proposal's artifact-validation checks
   - Cost/baseline reporting (token counts, model, elapsed time per pass; fixed-chunk-vs-segment comparison) implemented per the proposal's Cost and baseline requirements section
   - All work items under this workstream resolved and lrh validate reports 0 errors
 ---
 
-# WS-EVENT-ROLE-WORLD
+# Workstream: SF Event-Role-World Extractor Implementation
 
 ## Purpose
 
@@ -33,10 +34,11 @@ that has already been through two rounds of reviewer feedback.
 
 ## Scope
 
-- Implement the v0.1 seed extractor described in the proposal's "Proposed
-  v0.1 deliverable" section: segment metadata, GACD/ERAC reuse, cohesion
-  fields, confidence/rationale, per-segment audit, validation report, and
-  optional SF feature tags.
+- Implement the proposal's Recommended staged pipeline (stages 1-9): input
+  contract, surface feature pass, entity participant pass, event-role pass,
+  anchor pass, relation pass, discourse/SF tag pass, optional hypothesis
+  pass, and validation/export — reusing the existing segment/evidence
+  substrate as the input contract rather than reimplementing it.
 - Wire new Event-Role-World object schemas through the backend's existing
   `tool=` structured-output path (per the proposal's Implementation
   prerequisites section) rather than the current scene/sequel prompts'
@@ -50,9 +52,12 @@ that has already been through two rounds of reviewer feedback.
 ## Prior Art Check
 
 ### Duplication search
-- In-repo: No existing implementation found (no `EventRoleWorld`/
-  `event_role_world` module or references anywhere in `lcats/` or
-  `.claude/skills/`).
+- In-repo: No existing implementation found in `lcats/lcats/`. The
+  governing proposal's own architecture sketch names an
+  `EventRoleWorldProcessor` and a suggested `event_role_world/` module
+  layout (`00_proposal.md:91`, `00_proposal.md:132`) — these are design
+  sketches, not code; no implementation exists under `lcats/lcats/`. (This
+  repo has no `.claude/skills/` directory to check.)
 - Sibling repos: None identified.
 - External libraries: None identified.
 - Recommendation: Proceed.
@@ -65,13 +70,22 @@ that has already been through two rounds of reviewer feedback.
 
 ## Work Items
 
-No work items exist yet. The recommended first work item covers the
-proposal's own "Proposed v0.1 deliverable" scope: stage 0 (story loading)
-through stage 5 (agreement and quality metrics), reusing the existing
-`make_annotated_segment_extractor` two-pass extractor, plus the backend
-`tool=` schema-wiring fix and the cost/baseline reporting requirements.
-Later annotator layers (relation, discourse/SF-tag, hypothesis passes) are
-expected as follow-up work items once v0.1 lands. To be created via
+No work items exist yet. The proposal's own Recommended staged pipeline
+(stages 1-9) does not define an early/late split — stages 1-7 and 9 are
+presented as the main pipeline, with only stage 8 (optional hypothesis
+pass) marked explicitly optional. The following phasing is a
+workstream-level scoping decision, not something the proposal itself
+prescribes:
+
+The recommended first work item covers stages 1-5 (input contract through
+anchor pass): reusing the existing segment/evidence substrate as input,
+extracting entities/participants/actant roles and events/semantic roles,
+and anchoring them temporally and spatially — plus the backend `tool=`
+schema-wiring fix and the cost/baseline reporting requirements. Stages 6-7
+(relation, discourse/SF tag) and stage 9 (validation/export) are expected
+as closely-following follow-up work items, since validation/export is
+required to check any of the earlier stages' output; stage 8 (hypothesis
+pass) remains optional per the proposal itself. To be created via
 `/lrh-work-item` after this workstream is confirmed.
 
 ## Exit Criteria

--- a/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
@@ -1,0 +1,94 @@
+---
+id: WS-EVENT-ROLE-WORLD
+kind: planning_node
+title: SF Event-Role-World Extractor Implementation
+status: proposed
+stage: designed
+origin: design_review
+summary: Implement the Science-Fiction Event-Role-World extractor proposed for the Worldcon "Shape of Science Fiction" paper, layered on the existing LCATS scene/sequel segment substrate.
+related_focus: []
+related_roadmap: []
+related_design:
+  - project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
+work_items: []
+exit_criteria:
+  - v0.1 seed extractor implemented per the proposal's staged pipeline (paragraph indexing through per-segment semantic audit), reusing the existing segment/evidence substrate without reimplementing it
+  - New Event-Role-World object schemas (Event, EntityMention, EventRelation, etc.) are called through the backend's existing tool= structured-output path, not json_object mode
+  - Validation and metrics export (per-story JSON, JSONL/CSV analysis tables) implemented and passes the proposal's artifact-validation checks
+  - Cost/baseline reporting (token counts, model, elapsed time per pass; fixed-chunk-vs-segment comparison) implemented per the proposal's Cost and baseline requirements section
+  - All work items under this workstream resolved and lrh validate reports 0 errors
+---
+
+# WS-EVENT-ROLE-WORLD
+
+## Purpose
+
+This workstream coordinates implementation of the Science-Fiction
+Event-Role-World extractor: entity/participant, event/semantic-role,
+temporal-spatial anchor, causal-relation, discourse, and SF world-model
+annotation layers built on top of LCATS's existing scene/sequel segment
+output. It exists to support the forthcoming Worldcon Academic paper "The
+Shape of Science Fiction," and follows a review-hardened design proposal
+that has already been through two rounds of reviewer feedback.
+
+## Scope
+
+- Implement the v0.1 seed extractor described in the proposal's "Proposed
+  v0.1 deliverable" section: segment metadata, GACD/ERAC reuse, cohesion
+  fields, confidence/rationale, per-segment audit, validation report, and
+  optional SF feature tags.
+- Wire new Event-Role-World object schemas through the backend's existing
+  `tool=` structured-output path (per the proposal's Implementation
+  prerequisites section) rather than the current scene/sequel prompts'
+  `json_object` mode.
+- Implement the cost/baseline reporting and metrics export required by the
+  proposal's Validation and metrics section.
+- Land associated work items through the standard LRH execution lifecycle
+  (`/lrh-implement` → `/lrh-review-response` → `/lrh-confirm-fixes` →
+  `/lrh-closeout`).
+
+## Prior Art Check
+
+### Duplication search
+- In-repo: No existing implementation found (no `EventRoleWorld`/
+  `event_role_world` module or references anywhere in `lcats/` or
+  `.claude/skills/`).
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found beyond the governing proposal itself.
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Work Items
+
+No work items exist yet. The recommended first work item covers the
+proposal's own "Proposed v0.1 deliverable" scope: stage 0 (story loading)
+through stage 5 (agreement and quality metrics), reusing the existing
+`make_annotated_segment_extractor` two-pass extractor, plus the backend
+`tool=` schema-wiring fix and the cost/baseline reporting requirements.
+Later annotator layers (relation, discourse/SF-tag, hypothesis passes) are
+expected as follow-up work items once v0.1 lands. To be created via
+`/lrh-work-item` after this workstream is confirmed.
+
+## Exit Criteria
+
+(see frontmatter `exit_criteria:` above)
+
+## Non-Goals
+
+- Does not reimplement scene/sequel extraction, GACD/ERAC classification,
+  or paragraph indexing/alignment — these are reused as-is from the existing
+  substrate.
+- Does not require a graph database or CBR/RAG adaptation in this workstream
+  — deferred per the proposal's own non-goals until the extracted data
+  justifies them.
+- Does not choose the Worldcon paper's final statistical method.
+- Does not require full Story Logic extraction.
+
+## Relationship to Design
+
+- Design proposal: `project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md`


### PR DESCRIPTION
## Summary

Adds `WS-EVENT-ROLE-WORLD`, the planning node coordinating implementation of the review-hardened [Event-Role-World extractor proposal](https://github.com/xenotaur/LCATS/blob/main/lcats/project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md) (`PROP-LCATS-EVENT-ROLE-WORLD-EXTRACTOR`), in support of the Worldcon "Shape of Science Fiction" paper.

- **Stage:** `designed` — the proposal has been through two review rounds (PR #142) and is review-hardened; approach is locked, not yet broken into a full roadmap/WI plan.
- **Scope:** v0.1 seed extractor (reusing the existing scene/sequel segment substrate), backend `tool=` schema wiring, and the cost/baseline reporting requirements added during review.
- **Prior art check:** no existing implementation, no overlapping work items or proposals — clean to proceed.
- **Work items:** none created yet. The recommended first WI (v0.1 seed extractor scope) is described in the `## Work Items` section for a follow-up `/lrh-work-item` pass.

## Test plan

- [x] `lrh validate`: 0 errors (27 pre-existing warnings unrelated to this file)
- [x] Filename stem matches `id` frontmatter field
- [x] `status: proposed` matches directory bucket (`workstreams/proposed/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
