### PR TITLE
Add work item WI-EVENT-0024 (planning artifact only): Event-Role-World extractor stages 1-5

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_22_22_03_42_WI_EVENT_0024_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_22_22_03_42_WI_EVENT_0024_REVIEW.md
@@ -1,0 +1,71 @@
+---
+execution_id: 2026_07_22_22_03_42_WI_EVENT_0024_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0024_REVIEW)[2026-07-22T22:00:02-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/144
+commit: f7dc4d9
+created_at: 2026-07-22T22:03:42-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/144
+session_transcript: pending
+---
+
+# Summary
+
+Addressed 5 of 6 open review comments (chatgpt-codex-connector x2,
+copilot-pull-request-reviewer x3, one already resolved) on PR #144, which
+adds work item WI-EVENT-0024. `rerun_of` is left empty: no primary
+execution record exists for this PR's underlying change (the work item was
+created directly via `/lrh-work-item`, not through a minted-prompt-id
+`/lrh-implement` flow).
+
+# Result
+
+- Comment (copilot): missing `priority:` field — verified 24 of 44 existing
+  work items set `priority: high` or `medium`. Added `priority: medium`.
+- Comment (copilot): workstream still showed `work_items: []` — verified
+  against the current branch and found this was **already fixed** by the
+  prior commit (`0dd48c1`, pushed before this review round landed); the
+  comment was generated against an earlier commit. Skipped — presence
+  check fails, issue not present on current branch.
+- Comment (copilot): PR title/description implies the extractor is
+  implemented, but the diff only adds the WI markdown — valid, the title
+  "Add work item WI-EVENT-0024: Implement Event-Role-World extractor
+  stages 1-5" was ambiguous. Edited the PR title to
+  "Add work item WI-EVENT-0024 (planning artifact only): Event-Role-World
+  extractor stages 1-5" and added an explicit first-line disclaimer to the
+  PR body.
+- Comment (codex): acceptance criteria omitted the fixed-chunk-vs-segment
+  baseline comparison that `WS-EVENT-ROLE-WORLD`'s own first-work-item
+  scope and the proposal's Cost and baseline requirements section both
+  require — verified against the WI's current acceptance list. Added it to
+  Scope, Required Changes, acceptance (frontmatter + prose), and
+  `artifacts_expected` (new `baseline.py`).
+- Comment (codex): acceptance never required stage-2 surface-feature
+  output, so an implementation could close the item while skipping one of
+  the five advertised stages — verified. Added surface-feature output to
+  the acceptance frontmatter list and prose section, and added
+  `surface_feature_extractor.py` to Required Changes/artifacts_expected.
+- Comment (codex): `scripts/version tools` in the Validation section
+  references a nonexistent command — verified `scripts/` has no `version`
+  file. Removed it from the Validation section.
+
+# Validation
+
+- `scripts/format --check --diff` — 151 files unchanged
+- `scripts/lint` — ruff and black checks passed
+- `scripts/test` — 1337 tests OK
+- `lrh validate` — 0 errors, 29 pre-existing warnings unrelated to this
+  change (owner: unassigned pattern shared by every other work item)
+- `scripts/version tools` — script does not exist in this repo; this is
+  exactly what comment 6 above flagged, and the fix was to remove the
+  command from the WI's own Validation section rather than run it
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Recommend `/lrh-confirm-fixes` on PR #144 before merge to verify these
+  fixes against the current diff and resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_23_01_40_33_WI_EVENT_0024_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_23_01_40_33_WI_EVENT_0024_CONFIRM.md
@@ -1,0 +1,78 @@
+---
+execution_id: 2026_07_23_01_40_33_WI_EVENT_0024_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0024_CONFIRM)[2026-07-22T22:19:29-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/144
+commit: 9f9c3e6
+created_at: 2026-07-23T01:40:33-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/144
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass on PR #144 (WI-EVENT-0024 review fixes).
+Verification was classified inline (user declined the offered cold-subagent
+pass, since these were narrow, factual, file-content fixes). `rerun_of` is
+left empty: no primary execution record exists for this PR's underlying
+change (the work item was created directly via `/lrh-work-item`, not
+through a minted-prompt-id `/lrh-implement` flow).
+
+# Result
+
+`lrh github threads --mode raw --state all` filtered to `isResolved ==
+false` showed 5 of the original 6 threads still genuinely unresolved. The
+6th (`priority:` field) was already `isResolved: true` on GitHub by the
+time this run started — no action needed on it.
+
+All 5 remaining threads verified against the current `HEAD` diff and live
+PR title/body (not the prior `_REVIEW` execution record's claims):
+
+- `PRRT_kwDOKlhIbM6THj3-` (copilot-pull-request-reviewer, bot) — workstream
+  `work_items: []` — confirmed `WS-EVENT-ROLE-WORLD.md` now has
+  `work_items: [WI-EVENT-0024]`. **Clear-satisfied.**
+- `PRRT_kwDOKlhIbM6THj4F` (copilot-pull-request-reviewer, bot) — PR
+  title/description overclaim — confirmed via `gh pr view --json
+  title,body` that the title now reads "(planning artifact only)" and the
+  body opens with an explicit disclaimer. **Clear-satisfied.**
+- `PRRT_kwDOKlhIbM6THkrr` (chatgpt-codex-connector, bot) — fixed-chunk
+  baseline missing from scope — confirmed the acceptance list, Required
+  Changes, and `artifacts_expected` (new `baseline.py`) all now include it.
+  **Clear-satisfied.**
+- `PRRT_kwDOKlhIbM6THkru` (chatgpt-codex-connector, bot) — surface-feature
+  acceptance gap — confirmed both the frontmatter `acceptance:` list and
+  prose Acceptance Criteria section now explicitly require it.
+  **Clear-satisfied.**
+- `PRRT_kwDOKlhIbM6THkrw` (chatgpt-codex-connector, bot) — nonexistent
+  `scripts/version tools` — confirmed the Validation section no longer
+  lists it. **Clear-satisfied.**
+
+All 5 were bot-authored, pre-selected, user-confirmed as a single batch,
+and resolved via `resolveReviewThread`. No exceptions surfaced (no
+Unaddressed, Partial, Ambiguous, or Problematic threads).
+
+Thread-resolution verdict: **green** — every unresolved thread resolved, no
+exceptions remain.
+
+# Validation
+
+- `lrh github threads --mode raw --state all` — 6 threads total; 1 already
+  resolved, 5 unresolved before this run
+- Fresh-eyes diff/file/PR-metadata read against each comment — all 5
+  Clear-satisfied
+- `gh api graphql resolveReviewThread` — all 5 threads now `isResolved: true`
+- Provisional CI (`gh pr checks --json name,state,bucket`, after confirming
+  0 `required_status_checks` rules via `rules/branches/main`): `lint`,
+  `coverage`, `test` x2 all `pass`
+- Re-checked CI against post-push `HEAD` in the readiness report below
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Final merge-readiness verdict and `gh pr merge` one-liner are reported to
+  the user after this record is pushed and CI is re-checked against the new
+  `HEAD`.

--- a/lcats/project/work_items/proposed/WI-EVENT-0024.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0024.md
@@ -6,6 +6,7 @@ id: WI-EVENT-0024
 title: Implement Event-Role-World extractor stages 1-5 (input contract through anchor pass)
 type: deliverable
 status: proposed
+priority: medium
 owner: unassigned
 contributors: []
 assigned_agents: []
@@ -34,8 +35,9 @@ forbidden_actions:
 acceptance:
   - New Event-Role-World object schemas (EvidenceSpan, EntityMention, Entity, SemanticRole, Event, TemporalAnchor, SpatialAnchor) are defined and validated
   - Extraction calls for these schemas use the backend's existing tool= structured-output path, not json_object mode
-  - Given existing LCATS story JSON plus segments, the extractor produces entity/participant, event/semantic-role, and temporal/spatial anchor annotations per segment
+  - Given existing LCATS story JSON plus segments, the extractor produces surface-feature (lexical, syntactic, morphological), entity/participant, event/semantic-role, and temporal/spatial anchor annotations per segment
   - Per-pass LLM-backed calls record token counts, model, and elapsed time (not just call counts)
+  - A fixed-chunk-vs-segment comparison is produced by running the same extractor over both scene/sequel segments and fixed-token chunks, per the proposal's Cost and baseline requirements section
   - lrh validate reports 0 errors and scripts/test passes after all files are written
 required_evidence:
   - lrh_validate
@@ -45,8 +47,10 @@ artifacts_expected:
   - lcats/lcats/analysis/event_role_world/__init__.py
   - lcats/lcats/analysis/event_role_world/schema.py
   - lcats/lcats/analysis/event_role_world/processor.py
+  - lcats/lcats/analysis/event_role_world/surface_feature_extractor.py
   - lcats/lcats/analysis/event_role_world/entity_extractor.py
   - lcats/lcats/analysis/event_role_world/event_extractor.py
+  - lcats/lcats/analysis/event_role_world/baseline.py
   - lcats/tests/analysis_tests/event_role_world_test.py
 ---
 
@@ -99,17 +103,20 @@ whenever the workstream chooses to pick it up.
   (`lcats/lcats/llm/openai_backend.py`, `lcats/lcats/llm/anthropic_backend.py`),
   not `json_object` mode.
 - Cost/baseline reporting: record token counts, model, and elapsed time per
-  LLM-backed pass, per the proposal's "Cost and baseline requirements"
+  LLM-backed pass, and produce a fixed-chunk-vs-segment comparison by
+  running the same extractor over both scene/sequel segments and
+  fixed-token chunks, per the proposal's "Cost and baseline requirements"
   section.
 
 ## Required Changes
 
 1. Create `lcats/lcats/analysis/event_role_world/` package (`__init__.py`,
    `schema.py` for the object definitions, `processor.py` for pipeline
-   orchestration, `entity_extractor.py` for stages 2-3,
-   `event_extractor.py` for stages 4-5) — following the proposal's
-   "Suggested downstream module layout" as a starting point, not a
-   requirement (the proposal itself notes this is "a future LCATS
+   orchestration, `surface_feature_extractor.py` for stage 2,
+   `entity_extractor.py` for stage 3, `event_extractor.py` for stages 4-5,
+   `baseline.py` for the fixed-chunk-vs-segment comparison) — following the
+   proposal's "Suggested downstream module layout" as a starting point, not
+   a requirement (the proposal itself notes this is "a future LCATS
    implementation sketch, not an LRH implementation requirement").
 2. Wire extraction calls through the backend's existing `tool=` parameter
    with a JSON Schema per object type, per `00_proposal.md`'s
@@ -122,9 +129,12 @@ whenever the workstream chooses to pick it up.
    `lcats/lcats/analysis/text_segmenter.py`) as the stage-1 input contract
    — do not reimplement segmentation, paragraph indexing, or GACD/ERAC
    classification.
-5. Add `lcats/tests/analysis_tests/event_role_world_test.py` covering
-   schema validation and each extraction pass.
-6. Add `WI-EVENT-0024` to `WS-EVENT-ROLE-WORLD`'s `work_items:` list.
+5. Implement the fixed-chunk-vs-segment baseline comparison required by the
+   proposal's "Cost and baseline requirements" section.
+6. Add `lcats/tests/analysis_tests/event_role_world_test.py` covering
+   schema validation and each extraction pass, including surface features
+   and the baseline comparison.
+7. Add `WI-EVENT-0024` to `WS-EVENT-ROLE-WORLD`'s `work_items:` list.
 
 ## Non-Goals
 
@@ -145,16 +155,20 @@ whenever the workstream chooses to pick it up.
 - Extraction calls for these schemas use the backend's existing `tool=`
   structured-output path, not `json_object` mode.
 - Given existing LCATS story JSON plus segments, the extractor produces
-  entity/participant, event/semantic-role, and temporal/spatial anchor
-  annotations per segment.
+  surface-feature (lexical, syntactic, morphological), entity/participant,
+  event/semantic-role, and temporal/spatial anchor annotations per segment
+  — an implementation that skips stage 2 (surface features) does not
+  satisfy this item.
 - Per-pass LLM-backed calls record token counts, model, and elapsed time
   (not just call counts).
+- A fixed-chunk-vs-segment comparison is produced by running the same
+  extractor over both scene/sequel segments and fixed-token chunks, per the
+  proposal's Cost and baseline requirements section.
 - `lrh validate` reports 0 errors and `scripts/test` passes after all files
   are written.
 
 ## Validation
 
-- `scripts/version tools`
 - `scripts/format --check --diff`
 - `scripts/lint`
 - `scripts/test`

--- a/lcats/project/work_items/proposed/WI-EVENT-0024.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0024.md
@@ -1,0 +1,175 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EVENT-0024
+title: Implement Event-Role-World extractor stages 1-5 (input contract through anchor pass)
+type: deliverable
+status: proposed
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap:
+  - ROADMAP-CORE
+related_workstreams:
+  - WS-EVENT-ROLE-WORLD
+related_design:
+  - project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - create_file
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - implement_relation_pass
+  - implement_discourse_sf_tag_pass
+  - implement_hypothesis_pass
+  - implement_graph_database
+  - force_push
+  - delete_branch
+acceptance:
+  - New Event-Role-World object schemas (EvidenceSpan, EntityMention, Entity, SemanticRole, Event, TemporalAnchor, SpatialAnchor) are defined and validated
+  - Extraction calls for these schemas use the backend's existing tool= structured-output path, not json_object mode
+  - Given existing LCATS story JSON plus segments, the extractor produces entity/participant, event/semantic-role, and temporal/spatial anchor annotations per segment
+  - Per-pass LLM-backed calls record token counts, model, and elapsed time (not just call counts)
+  - lrh validate reports 0 errors and scripts/test passes after all files are written
+required_evidence:
+  - lrh_validate
+  - test_output
+  - manual_review
+artifacts_expected:
+  - lcats/lcats/analysis/event_role_world/__init__.py
+  - lcats/lcats/analysis/event_role_world/schema.py
+  - lcats/lcats/analysis/event_role_world/processor.py
+  - lcats/lcats/analysis/event_role_world/entity_extractor.py
+  - lcats/lcats/analysis/event_role_world/event_extractor.py
+  - lcats/tests/analysis_tests/event_role_world_test.py
+---
+
+## Summary
+
+Implement the first five stages of the Event-Role-World extractor's
+Recommended staged pipeline — input contract, surface feature pass, entity
+participant pass, event-role pass, and anchor pass — producing
+entity/participant, event/semantic-role, and temporal/spatial anchor
+annotations for each existing LCATS segment.
+
+## Problem / Context
+
+`WS-EVENT-ROLE-WORLD` coordinates implementation of the Science-Fiction
+Event-Role-World extractor proposed in
+`project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md`,
+in support of the Worldcon "Shape of Science Fiction" paper
+(`FOCUS-WORLDCON-2026`). The proposal's own "Recommended staged pipeline"
+(`00_proposal.md`, stages 1-9) does not define an early/late split; this
+work item implements stages 1-5 as the workstream's chosen first phase,
+deferring stages 6-7 (relation, discourse/SF tag) and 9 (validation/export)
+to a closely-following work item, and stage 8 (optional hypothesis pass) to
+whenever the workstream chooses to pick it up.
+
+### Duplication search
+- In-repo: No existing implementation found. No `EntityParticipantAnnotator`,
+  `EventRoleAnnotator`, `AnchorAnnotator`, or `SurfaceFeatureAnnotator`
+  anywhere in `lcats/`. The proposal's own architecture sketch
+  (`00_proposal.md:91`) names these as a design sketch, not code.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found beyond the governing proposal itself.
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Scope
+
+- Extraction passes for stages 1-5: input contract (reuse existing segment
+  JSON), surface feature pass, entity participant pass, event-role pass,
+  and anchor pass.
+- Schema definitions for `EvidenceSpan`, `EntityMention`, `Entity`,
+  `SemanticRole`, `Event`, `TemporalAnchor`, and `SpatialAnchor` per the
+  proposal's "Core schema sketch".
+- Backend `tool=` schema wiring: new extraction calls use
+  `OpenAIBackend`/`AnthropicBackend`'s existing tool/function-calling path
+  (`lcats/lcats/llm/openai_backend.py`, `lcats/lcats/llm/anthropic_backend.py`),
+  not `json_object` mode.
+- Cost/baseline reporting: record token counts, model, and elapsed time per
+  LLM-backed pass, per the proposal's "Cost and baseline requirements"
+  section.
+
+## Required Changes
+
+1. Create `lcats/lcats/analysis/event_role_world/` package (`__init__.py`,
+   `schema.py` for the object definitions, `processor.py` for pipeline
+   orchestration, `entity_extractor.py` for stages 2-3,
+   `event_extractor.py` for stages 4-5) — following the proposal's
+   "Suggested downstream module layout" as a starting point, not a
+   requirement (the proposal itself notes this is "a future LCATS
+   implementation sketch, not an LRH implementation requirement").
+2. Wire extraction calls through the backend's existing `tool=` parameter
+   with a JSON Schema per object type, per `00_proposal.md`'s
+   "Implementation prerequisites" section.
+3. Add token/model/elapsed-time capture to each LLM-backed pass, using the
+   `input_tokens`/`output_tokens`/`model` fields already returned by
+   `BackendResponse` (`lcats/lcats/llm/backend.py`).
+4. Reuse the existing segment/evidence substrate
+   (`lcats/lcats/analysis/story_processors.py`,
+   `lcats/lcats/analysis/text_segmenter.py`) as the stage-1 input contract
+   — do not reimplement segmentation, paragraph indexing, or GACD/ERAC
+   classification.
+5. Add `lcats/tests/analysis_tests/event_role_world_test.py` covering
+   schema validation and each extraction pass.
+6. Add `WI-EVENT-0024` to `WS-EVENT-ROLE-WORLD`'s `work_items:` list.
+
+## Non-Goals
+
+- Does not implement stages 6-7 (relation pass, discourse/SF tag pass) or
+  stage 9 (validation/export) — deferred to a follow-up work item.
+- Does not implement stage 8 (optional hypothesis pass) — optional per the
+  proposal itself.
+- Does not require a graph database or CBR/RAG adaptation.
+- Does not reimplement scene/sequel extraction, GACD/ERAC classification,
+  or paragraph indexing/alignment.
+- Does not choose the Worldcon paper's final statistical method.
+
+## Acceptance Criteria
+
+- New Event-Role-World object schemas (`EvidenceSpan`, `EntityMention`,
+  `Entity`, `SemanticRole`, `Event`, `TemporalAnchor`, `SpatialAnchor`) are
+  defined and validated.
+- Extraction calls for these schemas use the backend's existing `tool=`
+  structured-output path, not `json_object` mode.
+- Given existing LCATS story JSON plus segments, the extractor produces
+  entity/participant, event/semantic-role, and temporal/spatial anchor
+  annotations per segment.
+- Per-pass LLM-backed calls record token counts, model, and elapsed time
+  (not just call counts).
+- `lrh validate` reports 0 errors and `scripts/test` passes after all files
+  are written.
+
+## Validation
+
+- `scripts/version tools`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `lrh validate`
+
+## Risk Notes
+
+- Automatic entity/coreference extraction is known to struggle on older
+  literary prose (epithets, pronouns, nested narration) per the proposal's
+  own risk table — expect lower precision on the corpus's pre-1950 material.
+- The backend `tool=` path has not previously been exercised for this many
+  distinct object schemas in one pipeline; watch for schema-size or
+  tool-choice-forcing limits during implementation.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md`
+- Design: `project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md`

--- a/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
@@ -10,7 +10,8 @@ related_focus: []
 related_roadmap: []
 related_design:
   - project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
-work_items: []
+work_items:
+  - WI-EVENT-0024
 exit_criteria:
   - The proposal's Recommended staged pipeline stages 1-7 and 9 (input contract, surface feature pass, entity participant pass, event-role pass, anchor pass, relation pass, discourse/SF tag pass, and validation/export) are implemented, reusing the existing segment/evidence substrate without reimplementing scene/sequel extraction
   - The optional hypothesis pass (stage 8) is implemented, or explicitly deferred with a follow-up work item recorded
@@ -70,23 +71,23 @@ that has already been through two rounds of reviewer feedback.
 
 ## Work Items
 
-No work items exist yet. The proposal's own Recommended staged pipeline
-(stages 1-9) does not define an early/late split — stages 1-7 and 9 are
-presented as the main pipeline, with only stage 8 (optional hypothesis
-pass) marked explicitly optional. The following phasing is a
-workstream-level scoping decision, not something the proposal itself
-prescribes:
+The proposal's own Recommended staged pipeline (stages 1-9) does not define
+an early/late split — stages 1-7 and 9 are presented as the main pipeline,
+with only stage 8 (optional hypothesis pass) marked explicitly optional.
+The following phasing is a workstream-level scoping decision, not something
+the proposal itself prescribes:
 
-The recommended first work item covers stages 1-5 (input contract through
-anchor pass): reusing the existing segment/evidence substrate as input,
-extracting entities/participants/actant roles and events/semantic roles,
-and anchoring them temporally and spatially — plus the backend `tool=`
-schema-wiring fix and the cost/baseline reporting requirements. Stages 6-7
-(relation, discourse/SF tag) and stage 9 (validation/export) are expected
-as closely-following follow-up work items, since validation/export is
-required to check any of the earlier stages' output; stage 8 (hypothesis
+- **WI-EVENT-0024** — covers stages 1-5 (input contract through anchor
+  pass): reusing the existing segment/evidence substrate as input,
+  extracting entities/participants/actant roles and events/semantic roles,
+  and anchoring them temporally and spatially — plus the backend `tool=`
+  schema-wiring fix and the cost/baseline reporting requirements.
+
+Stages 6-7 (relation, discourse/SF tag) and stage 9 (validation/export) are
+expected as closely-following follow-up work items, since validation/export
+is required to check any of the earlier stages' output; stage 8 (hypothesis
 pass) remains optional per the proposal itself. To be created via
-`/lrh-work-item` after this workstream is confirmed.
+`/lrh-work-item` once WI-EVENT-0024 is underway.
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary

**This PR creates a planning artifact only — it does not implement the Event-Role-World extractor.** It adds `WI-EVENT-0024`, the first work item under `WS-EVENT-ROLE-WORLD`, scoping the future implementation of stages 1-5 of the [Event-Role-World extractor proposal](https://github.com/xenotaur/LCATS/blob/main/lcats/project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md)'s "Recommended staged pipeline" (input contract through anchor pass), plus the backend `tool=` schema-wiring fix and cost/baseline reporting added during the proposal's review rounds. No extractor code, package, or tests exist yet — those are the deliverables of a future implementation PR against this work item.

- **Type:** `deliverable`
- **Related workstream:** `WS-EVENT-ROLE-WORLD` (updated to list this WI)
- **Prior art check:** no existing implementation, no overlapping work items or proposals — clean to proceed.
- **Scope:** entity/participant, event/semantic-role, temporal/spatial anchor, and surface-feature extraction, plus a fixed-chunk-vs-segment cost/baseline comparison — explicitly deferring relation, discourse/SF-tag, and hypothesis passes (stages 6-8) and validation/export (stage 9) to a follow-up work item.

## Test plan

- [x] `lrh validate`: 0 errors (2 `owner: unassigned` warnings, consistent with the repo-wide pattern already present on every other work item)
- [x] Filename stem matches `id` frontmatter field
- [x] `status: proposed` matches directory bucket (`work_items/proposed/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
