### PR TITLE
Add team follow-up discussion to WI-EVENT-0025 NLP evaluation

### DIFF
--- a/lcats/project/design/event-role-world-surface-feature-nlp-evaluation.md
+++ b/lcats/project/design/event-role-world-surface-feature-nlp-evaluation.md
@@ -173,27 +173,43 @@ analysis above.
 corpus" (Candidates surveyed, above) and weighed its PyTorch dependency as
 a disproportionate cost on that basis. If a multilingual corpus is an
 actual near-term direction for LCATS rather than a distant possibility,
-that premise no longer holds: Stanza is the only one of the four
-candidates built around genuine multilingual support (80 languages via a
-uniform Universal Dependencies interface), while spaCy, NLTK, and UDPipe
-would each need separate per-language integration work. This is a
-legitimate reason to revisit which candidate is "best positioned" — the
-spaCy conclusion above was reasoned specifically for an English-only
-future.
+that premise no longer holds — but the choice is not narrowly "Stanza or
+nothing." UDPipe also provides genuine multilingual support: its
+Universal Dependencies 2.15 release covers 93 languages across 169 models,
+each exposing the same tokenizer/tagger/lemmatizer/parser interface, so
+adding a language is a model download, not a separate code integration —
+comparable in kind to Stanza's approach. spaCy and NLTK, by contrast,
+would each need real per-language integration work (spaCy ships
+per-language pipelines with varying feature completeness; NLTK has no
+comparable unified multilingual tagging/parsing interface). If
+multilingual support drives the decision, the live comparison is between
+Stanza and UDPipe on their respective merits (Stanza: PyTorch dependency,
+broader active development, arguably stronger accuracy; UDPipe: no heavy
+framework, smaller footprint, but the CC BY-NC-SA model-license question
+already raised above) — not a foregone conclusion in Stanza's favor.
+[UDPipe 2 models](https://ufal.mff.cuni.cz/udpipe/2/models)
 
 **PyTorch cost reconsideration.** The team's view is that the PyTorch
 dependency may be less disqualifying than this document originally
 treated it, on the expectation that LCATS may need something like PyTorch
 for other future work regardless of this decision. Checking the repo for
-supporting evidence: `lcats/lcats/datasets/torchdata.py:5` already
-imports `from torch.utils.data import Dataset`, but `torch` is not
-declared in `lcats/pyproject.toml`'s dependencies, and no other file in
-the codebase imports this module (`torchdata`) or anything from
-`lcats.datasets`. This is real evidence that PyTorch was reached for once
-in this project's history, but it is an unused, undeclared import today —
-not a currently active or working dependency. The "we'll need it anyway"
-argument is directionally supported by this precedent but remains a
-forecast, not something the repo currently demonstrates.
+supporting evidence: this document originally claimed
+`lcats/lcats/datasets/torchdata.py:5` (which imports `from
+torch.utils.data import Dataset`) was unused elsewhere in the repo — that
+claim was wrong. A broader search (beyond just the installable
+`lcats/lcats/` package) finds real consumers: `lcats/KMo/scenes.py:33` and
+`lcats/KMo/analyze.py:29` both import it directly
+(`from lcats.datasets import torchdata`), and four notebooks
+(`notebooks/03_datasets.ipynb`, `07_project_reboot.ipynb`,
+`08_cbr_rag_reboot.ipynb`, `09_scene_analysis.ipynb`) also use it. `torch`
+itself is still not declared in `lcats/pyproject.toml`'s dependencies, so
+these consumers depend on a manually-installed, undeclared package — but
+this is meaningfully stronger evidence for the team's point than the
+original single-unused-import framing: PyTorch has been reached for
+repeatedly across scripts and notebooks, not once. It remains true that no
+part of the installable `lcats` package itself depends on it today, and
+formalizing it as a declared dependency is still a decision to make, not
+something already done.
 
 **Team familiarity.** Separately, the team has more hands-on experience
 with NLTK than with spaCy. This does not change the factual concerns
@@ -203,18 +219,21 @@ risk — that the original evaluation did not weigh at all.
 
 **What this changes:** the core recommendation is unchanged — defer
 adoption until a stratified accuracy sample is run against LCATS's actual
-prose, since no candidate (including Stanza) has demonstrated accuracy on
-comparable text, and a multilingual direction raises the bar for that
-validation rather than lowering it. What changes is the "if adoption is
-justified later, spaCy is best" sub-recommendation: it now depends on
-whether the multilingual direction is near-term (favors reconsidering
-Stanza, with its dependency cost weighed against the team's other
-anticipated PyTorch needs) or remains a longer-term possibility (favors
-the original English-only reasoning, in which case NLTK's team familiarity
-is a legitimate tie-breaking factor against spaCy alongside the
-accuracy question). This document does not resolve which branch applies —
-that is a corpus-roadmap decision for the team to make, not one this
-evaluation is positioned to make on its own.
+prose, since no candidate (including Stanza and UDPipe) has demonstrated
+accuracy on comparable text, and a multilingual direction raises the bar
+for that validation rather than lowering it. What changes is the "if
+adoption is justified later, spaCy is best" sub-recommendation: it now
+depends on whether the multilingual direction is near-term (favors
+reconsidering Stanza and UDPipe against each other, with Stanza's
+dependency cost weighed against the team's other anticipated PyTorch
+needs and UDPipe's model-license question) or remains a longer-term
+possibility (favors the original English-only reasoning, in which case
+NLTK's team familiarity is a legitimate tie-breaking factor against spaCy
+alongside the accuracy question). This document does not resolve which
+branch applies, nor does it pick a winner between Stanza and UDPipe for
+the multilingual case — those are corpus-roadmap and further-evaluation
+decisions for the team to make, not ones this document is positioned to
+make on its own.
 
 ## Tension with WI-EVENT-0024's acceptance criteria
 
@@ -238,10 +257,14 @@ complete:
    and structural features the heuristic approach actually produces,
    explicitly deferring "syntactic, morphological" to a future work item
    contingent on this document's adoption conditions being met; or
-2. **Adopt a lightweight library now** (spaCy, per the recommendation
-   above) rather than deferring, accepting the unverified-accuracy risk on
-   this corpus in exchange for satisfying the literal acceptance criterion
-   today.
+2. **Adopt a library now** rather than deferring, accepting the
+   unverified-accuracy risk on this corpus in exchange for satisfying the
+   literal acceptance criterion today. Which library depends on the
+   corpus-roadmap decision raised in the Follow-up discussion above
+   (spaCy for an English-only future; Stanza or UDPipe if multilingual
+   support is near-term) — this is no longer a settled choice, and the
+   implementer should not default to spaCy without first checking whether
+   that roadmap decision has been made.
 
 This document's own recommendation (defer) implies option 1 is the
 consistent path, but that is `WI-EVENT-0024`'s decision to make, not one

--- a/lcats/project/design/event-role-world-surface-feature-nlp-evaluation.md
+++ b/lcats/project/design/event-role-world-surface-feature-nlp-evaluation.md
@@ -149,15 +149,72 @@ NLTK's standard tagger is trained on a narrow, dated news corpus with no
 demonstrated advantage over the alternatives for this project's text.
 
 **If adoption becomes justified later, spaCy is the best-positioned
-candidate**: MIT-licensed (matches LCATS), a footprint comparable to NLTK's
-and UDPipe's — not categorically smaller, per the table above — no heavy
-ML framework requirement, and the most actively maintained, feature-rich
-API of the three lightweight options (tokenization, POS tagging,
-dependency parsing, and lemmatization in one package). Adoption should not
-proceed, however, without first running a small stratified accuracy sample
-against this corpus's actual prose — the governing proposal's own
-validation principle (span-grounded, evidence-backed claims) applies as
-much to a tooling decision as to an extraction result.
+candidate under an English-only assumption**: MIT-licensed (matches
+LCATS), a footprint comparable to NLTK's and UDPipe's — not categorically
+smaller, per the table above — no heavy ML framework requirement, and the
+most actively maintained, feature-rich API of the three lightweight
+options (tokenization, POS tagging, dependency parsing, and lemmatization
+in one package). Adoption should not proceed, however, without first
+running a small stratified accuracy sample against this corpus's actual
+prose — the governing proposal's own validation principle (span-grounded,
+evidence-backed claims) applies as much to a tooling decision as to an
+extraction result. **This "best-positioned" judgment assumes the corpus
+stays English-only — see the follow-up discussion below, which reopens
+that assumption.**
+
+## Follow-up discussion: multilingual direction and dependency cost
+
+After this document's initial recommendation, the team discussed it
+further and raised two points that revise — without overturning — the
+analysis above.
+
+**Multilingual direction.** The original Stanza assessment reasoned that
+"the multilingual breadth is not a requirement for LCATS's English-only
+corpus" (Candidates surveyed, above) and weighed its PyTorch dependency as
+a disproportionate cost on that basis. If a multilingual corpus is an
+actual near-term direction for LCATS rather than a distant possibility,
+that premise no longer holds: Stanza is the only one of the four
+candidates built around genuine multilingual support (80 languages via a
+uniform Universal Dependencies interface), while spaCy, NLTK, and UDPipe
+would each need separate per-language integration work. This is a
+legitimate reason to revisit which candidate is "best positioned" — the
+spaCy conclusion above was reasoned specifically for an English-only
+future.
+
+**PyTorch cost reconsideration.** The team's view is that the PyTorch
+dependency may be less disqualifying than this document originally
+treated it, on the expectation that LCATS may need something like PyTorch
+for other future work regardless of this decision. Checking the repo for
+supporting evidence: `lcats/lcats/datasets/torchdata.py:5` already
+imports `from torch.utils.data import Dataset`, but `torch` is not
+declared in `lcats/pyproject.toml`'s dependencies, and no other file in
+the codebase imports this module (`torchdata`) or anything from
+`lcats.datasets`. This is real evidence that PyTorch was reached for once
+in this project's history, but it is an unused, undeclared import today —
+not a currently active or working dependency. The "we'll need it anyway"
+argument is directionally supported by this precedent but remains a
+forecast, not something the repo currently demonstrates.
+
+**Team familiarity.** Separately, the team has more hands-on experience
+with NLTK than with spaCy. This does not change the factual concerns
+raised above about NLTK's tagger (Penn Treebank training domain, dated
+API) but is a legitimate practical factor — implementation speed and
+risk — that the original evaluation did not weigh at all.
+
+**What this changes:** the core recommendation is unchanged — defer
+adoption until a stratified accuracy sample is run against LCATS's actual
+prose, since no candidate (including Stanza) has demonstrated accuracy on
+comparable text, and a multilingual direction raises the bar for that
+validation rather than lowering it. What changes is the "if adoption is
+justified later, spaCy is best" sub-recommendation: it now depends on
+whether the multilingual direction is near-term (favors reconsidering
+Stanza, with its dependency cost weighed against the team's other
+anticipated PyTorch needs) or remains a longer-term possibility (favors
+the original English-only reasoning, in which case NLTK's team familiarity
+is a legitimate tie-breaking factor against spaCy alongside the
+accuracy question). This document does not resolve which branch applies —
+that is a corpus-roadmap decision for the team to make, not one this
+evaluation is positioned to make on its own.
 
 ## Tension with WI-EVENT-0024's acceptance criteria
 

--- a/lcats/project/executions/AD_HOC/2026_07_23_13_39_09_WI_EVENT_0025_FOLLOWUP_DISCUSSION_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_23_13_39_09_WI_EVENT_0025_FOLLOWUP_DISCUSSION_REVIEW.md
@@ -1,0 +1,69 @@
+---
+execution_id: 2026_07_23_13_39_09_WI_EVENT_0025_FOLLOWUP_DISCUSSION_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0025_FOLLOWUP_DISCUSSION_REVIEW)[2026-07-23T13:33:38-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/147
+commit: 1fc4783
+created_at: 2026-07-23T13:39:09-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/147
+session_transcript: pending
+---
+
+# Summary
+
+Addressed all 4 open review comments (chatgpt-codex-connector x3,
+copilot-pull-request-reviewer x1) on PR #147, which adds a team follow-up
+discussion to the already-resolved `WI-EVENT-0025` NLP evaluation.
+`rerun_of` is left empty: this PR was a direct user-directed content
+update (no `/lrh-work-item` or `/lrh-implement` flow), so no primary
+execution record was minted for this specific branch/slug.
+
+# Result
+
+- Comment (codex + copilot, 2 instances): the claim that
+  `lcats/lcats/datasets/torchdata.py` was unused elsewhere in the repo was
+  factually wrong — my original search only covered the installable
+  `lcats/lcats/` package. Verified a broader search finds real consumers:
+  `lcats/KMo/scenes.py:33`, `lcats/KMo/analyze.py:29`, and four notebooks
+  (`03_datasets`, `07_project_reboot`, `08_cbr_rag_reboot`,
+  `09_scene_analysis`). Corrected the claim — PyTorch has been reached for
+  repeatedly across scripts and notebooks, stronger evidence for the
+  team's "we'll need it anyway" point than originally stated. `torch`
+  remains undeclared in `pyproject.toml` and unused by the installable
+  package itself, so that part of the original framing still holds.
+- Comment (codex): characterizing Stanza as the only genuinely
+  multilingual candidate was wrong — verified via research that UDPipe's
+  UD 2.15 release covers 93 languages/169 models through the same
+  tokenizer/tagger/parser interface, comparable in kind to Stanza's
+  per-language approach (a model download, not separate integration).
+  Rewrote the multilingual-direction paragraph so the live comparison, if
+  multilingual support drives the decision, is Stanza vs. UDPipe on their
+  merits, not a foregone conclusion for Stanza.
+- Comment (codex): the "Tension with WI-EVENT-0024's acceptance criteria"
+  section's option 2 still told the implementer to "adopt spaCy, per the
+  recommendation above," contradicting the new roadmap-dependent framing —
+  verified the stale text was still present. Reworded to point at the
+  corpus-roadmap decision instead of naming a settled library.
+
+Also updated the "What this changes" summary paragraph to reflect UDPipe
+as a live multilingual candidate alongside Stanza. All 4 comments were
+valid and addressed; none were skipped.
+
+# Validation
+
+- `lrh validate` — 0 errors, 31 pre-existing warnings unrelated to this
+  file
+- `scripts/format`/`scripts/lint`/`scripts/test` not applicable — no
+  Python code touched (documentation-only change)
+- New factual claims (torchdata consumers, UDPipe language coverage)
+  verified via repo grep and web search respectively before being written
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Recommend `/lrh-confirm-fixes` on PR #147 before merge to verify these
+  fixes against the current diff and resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_23_15_38_22_WI_EVENT_0025_FOLLOWUP_DISCUSSION_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_23_15_38_22_WI_EVENT_0025_FOLLOWUP_DISCUSSION_CONFIRM.md
@@ -1,0 +1,72 @@
+---
+execution_id: 2026_07_23_15_38_22_WI_EVENT_0025_FOLLOWUP_DISCUSSION_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0025_FOLLOWUP_DISCUSSION_CONFIRM)[2026-07-23T15:31:08-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/147
+commit: 5a4469e
+created_at: 2026-07-23T15:38:22-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/147
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass on PR #147 (follow-up discussion review
+fixes). Verification was classified inline (user declined the offered
+cold-subagent pass). `rerun_of` is left empty: this PR was a direct
+user-directed content update, not a `/lrh-work-item`/`/lrh-implement`
+flow, so no primary execution record was minted for this specific
+branch/slug.
+
+# Result
+
+`lrh github threads --mode raw --state all` filtered to `isResolved ==
+false` showed all 4 original threads were still unresolved before this
+run (none auto-resolved by a bot this round).
+
+All 4 verified against the current `HEAD` diff and file content (not the
+prior `_REVIEW` execution record's claims):
+
+- `PRRT_kwDOKlhIbM6TVE7K` (chatgpt-codex-connector, bot) — torchdata
+  consumers — confirmed the current text acknowledges `KMo/scenes.py`,
+  `KMo/analyze.py`, and the notebooks as real consumers, no longer claims
+  the module is unused. **Clear-satisfied.**
+- `PRRT_kwDOKlhIbM6TVE7Q` (chatgpt-codex-connector, bot) — UDPipe
+  multilingual comparison — confirmed UDPipe's 93-language/169-model UD
+  2.15 coverage is now included, no longer framed as Stanza-only.
+  **Clear-satisfied.**
+- `PRRT_kwDOKlhIbM6TVE7R` (chatgpt-codex-connector, bot) — downstream
+  spaCy instruction — confirmed option 2 in the "Tension" section now
+  points to the roadmap decision (spaCy/Stanza/UDPipe depending on
+  direction) instead of naming spaCy as settled. **Clear-satisfied.**
+- `PRRT_kwDOKlhIbM6TVFms` (copilot-pull-request-reviewer, bot) — same
+  torchdata-consumers issue as the first thread — confirmed fixed.
+  **Clear-satisfied.**
+
+All 4 were bot-authored, pre-selected, user-confirmed as a single batch,
+and resolved via `resolveReviewThread`. No exceptions surfaced.
+
+Thread-resolution verdict: **green** — every unresolved thread resolved, no
+exceptions remain.
+
+# Validation
+
+- `lrh github threads --mode raw --state all` — 4 threads, all
+  `isResolved: false` before this run
+- Fresh-eyes diff/file read against each comment — all 4 Clear-satisfied
+- `gh api graphql resolveReviewThread` — all 4 threads now `isResolved: true`
+- Provisional CI (`gh pr checks --json name,state,bucket`, after confirming
+  0 `required_status_checks` rules via `rules/branches/main`): `coverage`,
+  `lint`, `test` x2 all `pass`
+- Re-checked CI against post-push `HEAD` in the readiness report below
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Final merge-readiness verdict and `gh pr merge` one-liner are reported to
+  the user after this record is pushed and CI is re-checked against the new
+  `HEAD`.


### PR DESCRIPTION
## Summary

Adds a "Follow-up discussion: multilingual direction and dependency cost" section to [`project/design/event-role-world-surface-feature-nlp-evaluation.md`](lcats/project/design/event-role-world-surface-feature-nlp-evaluation.md), recording team discussion after `WI-EVENT-0025`'s original recommendation landed (PR #146).

Two points reopen premises in the original evaluation:

- **Multilingual direction**: the original Stanza assessment dismissed its multilingual support as irrelevant to an "English-only corpus." If a multilingual direction is a real near-term goal, that premise doesn't hold, and Stanza is the only candidate of the four built around genuine multilingual support.
- **PyTorch dependency cost**: the team's view is that this may be less disqualifying if PyTorch is needed for other future work regardless. Grounded this against the repo: `lcats/lcats/datasets/torchdata.py:5` already imports `torch`, but it's undeclared in `pyproject.toml` and unused elsewhere — real precedent, not an active dependency.

Also notes team NLTK familiarity as a practical factor the original evaluation didn't weigh.

**What's unchanged**: the core recommendation (defer adoption, require a stratified accuracy sample before adopting anything) still holds — no candidate has demonstrated accuracy on this corpus, and going multilingual raises that bar rather than lowering it. **What's revised**: the "spaCy is best-positioned" sub-recommendation is now explicitly scoped to the English-only case, with the multilingual/PyTorch tradeoff left as an open branch for the team's corpus-roadmap decision.

## Test plan

- [x] `lrh validate`: 0 errors (no new warnings — this file carries no frontmatter, same as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
