### PR TITLE
WI-EVENT-0024: Implement Event-Role-World extractor stages 1-5 with swappable Stanza/spaCy backend

### DIFF
--- a/lcats/lcats/analysis/event_role_world/__init__.py
+++ b/lcats/lcats/analysis/event_role_world/__init__.py
@@ -1,0 +1,9 @@
+"""Event-Role-World extractor: stages 1-5 of the staged pipeline.
+
+See project/design/proposals/proposed/lcats-event-role-world-extractor/
+00_proposal.md for the governing design, and
+project/work_items/proposed/WI-EVENT-0024.md for this work item's scope
+(input contract, surface features, entity/participant, event/semantic-role,
+and temporal/spatial anchor extraction). Relation, discourse/SF-tag,
+hypothesis, and validation/export passes (stages 6-9) are out of scope.
+"""

--- a/lcats/lcats/analysis/event_role_world/baseline.py
+++ b/lcats/lcats/analysis/event_role_world/baseline.py
@@ -1,0 +1,136 @@
+"""Fixed-chunk-vs-segment baseline comparison.
+
+Per the governing proposal's "Cost and baseline requirements" section: a
+genre-comparison claim built on scene/sequel segments is not publishable
+without a control showing the effect is not an artifact of chunking
+strategy. This module produces fixed-token chunks over the same story text
+and lets the same extractor pipeline run over both, so callers can compare
+normalized rates (entities/1000 words, events/1000 words, ...) between the
+two chunking strategies.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from lcats.analysis import story_analysis
+from lcats.analysis.event_role_world import schema
+
+
+def make_fixed_token_chunks(
+    text: str, chunk_size_tokens: int = 500
+) -> List[Dict[str, Any]]:
+    """Split `text` into contiguous, non-overlapping fixed-token chunks.
+
+    Args:
+        text: Full story text to chunk.
+        chunk_size_tokens: Target token count per chunk (final chunk may be
+            shorter).
+
+    Returns:
+        A list of dicts shaped like scene/sequel segments (segment_id,
+        segment_type, start_char, end_char) so the same pipeline machinery
+        can consume either. segment_type is always "fixed_chunk".
+    """
+    if not text:
+        return []
+
+    encoder = story_analysis.get_encoder()
+    tokens = encoder.encode(text)
+    chunks: List[Dict[str, Any]] = []
+
+    chunk_id = 1
+    for token_start in range(0, len(tokens), chunk_size_tokens):
+        token_end = min(token_start + chunk_size_tokens, len(tokens))
+        chunk_tokens = tokens[token_start:token_end]
+        chunk_text = encoder.decode(chunk_tokens)
+
+        # Locate this decoded chunk's char span within the original text.
+        # tiktoken decode/encode round-trips are not always byte-identical
+        # to a naive substring search, so anchor on the first token's
+        # decoded text (short and reliably findable) rather than the full
+        # chunk, then extend by the chunk's decoded length.
+        anchor = encoder.decode(chunk_tokens[:1]) if chunk_tokens else ""
+        search_from = chunks[-1]["end_char"] if chunks else 0
+        start_char = text.find(anchor, search_from) if anchor else search_from
+        if start_char < 0:
+            start_char = search_from
+        end_char = min(len(text), start_char + len(chunk_text))
+
+        chunks.append(
+            {
+                "segment_id": chunk_id,
+                "segment_type": "fixed_chunk",
+                "start_char": start_char,
+                "end_char": end_char,
+            }
+        )
+        chunk_id += 1
+
+    return chunks
+
+
+def _rate_per_1000_words(count: int, word_count: int) -> float:
+    """Normalize a raw count to a per-1000-word rate."""
+    if word_count <= 0:
+        return 0.0
+    return (count / word_count) * 1000.0
+
+
+def summarize_annotations(
+    annotations: List[schema.SegmentWorldAnnotation],
+) -> Dict[str, Any]:
+    """Compute normalized rates for a list of segment/chunk annotations.
+
+    Args:
+        annotations: SegmentWorldAnnotation instances produced by running
+            the pipeline over either scene/sequel segments or fixed chunks.
+
+    Returns:
+        A dict with unit_count, total_word_count, and per-1000-word rates
+        for entities, events, temporal_anchors, and spatial_anchors.
+    """
+    total_words = sum(
+        (a.surface_features.word_count if a.surface_features else 0)
+        for a in annotations
+    )
+    total_entities = sum(len(a.entities) for a in annotations)
+    total_events = sum(len(a.events) for a in annotations)
+    total_temporal = sum(len(a.temporal_anchors) for a in annotations)
+    total_spatial = sum(len(a.spatial_anchors) for a in annotations)
+
+    return {
+        "unit_count": len(annotations),
+        "total_word_count": total_words,
+        "entities_per_1000_words": _rate_per_1000_words(total_entities, total_words),
+        "events_per_1000_words": _rate_per_1000_words(total_events, total_words),
+        "temporal_anchors_per_1000_words": _rate_per_1000_words(
+            total_temporal, total_words
+        ),
+        "spatial_anchors_per_1000_words": _rate_per_1000_words(
+            total_spatial, total_words
+        ),
+    }
+
+
+def compare_chunking_strategies(
+    segment_annotations: List[schema.SegmentWorldAnnotation],
+    chunk_annotations: List[schema.SegmentWorldAnnotation],
+) -> Dict[str, Any]:
+    """Compare normalized rates between segment-based and fixed-chunk runs.
+
+    Args:
+        segment_annotations: Annotations from running the pipeline over
+            scene/sequel segments.
+        chunk_annotations: Annotations from running the same pipeline over
+            fixed-token chunks of the same story.
+
+    Returns:
+        A dict with "segment" and "fixed_chunk" summaries (see
+        summarize_annotations) so a caller can see whether entity/event/
+        anchor rates diverge between chunking strategies.
+    """
+    return {
+        "segment": summarize_annotations(segment_annotations),
+        "fixed_chunk": summarize_annotations(chunk_annotations),
+    }

--- a/lcats/lcats/analysis/event_role_world/baseline.py
+++ b/lcats/lcats/analysis/event_role_world/baseline.py
@@ -39,23 +39,30 @@ def make_fixed_token_chunks(
     tokens = encoder.encode(text)
     chunks: List[Dict[str, Any]] = []
 
+    # Char offsets are derived by decoding a token-index prefix starting
+    # from token 0 (not per-chunk anchor search): decode(tokens[:0]) == "",
+    # and decode(tokens[:len(tokens)]) round-trips to `text` exactly, since
+    # `tokens` was produced by encoding `text` itself. Anchoring every
+    # offset at index 0 this way keeps offsets correct even when a token
+    # boundary falls in the middle of a multi-byte Unicode character —
+    # decoding a prefix that ends mid-character resolves the same way each
+    # time it's computed, so consecutive chunks' start/end stay consistent
+    # with each other rather than drifting from an independent per-chunk
+    # anchor search.
+    prefix_char_len_cache: Dict[int, int] = {0: 0}
+
+    def _char_len_of_prefix(token_index: int) -> int:
+        if token_index not in prefix_char_len_cache:
+            prefix_char_len_cache[token_index] = len(
+                encoder.decode(tokens[:token_index])
+            )
+        return prefix_char_len_cache[token_index]
+
     chunk_id = 1
     for token_start in range(0, len(tokens), chunk_size_tokens):
         token_end = min(token_start + chunk_size_tokens, len(tokens))
-        chunk_tokens = tokens[token_start:token_end]
-        chunk_text = encoder.decode(chunk_tokens)
-
-        # Locate this decoded chunk's char span within the original text.
-        # tiktoken decode/encode round-trips are not always byte-identical
-        # to a naive substring search, so anchor on the first token's
-        # decoded text (short and reliably findable) rather than the full
-        # chunk, then extend by the chunk's decoded length.
-        anchor = encoder.decode(chunk_tokens[:1]) if chunk_tokens else ""
-        search_from = chunks[-1]["end_char"] if chunks else 0
-        start_char = text.find(anchor, search_from) if anchor else search_from
-        if start_char < 0:
-            start_char = search_from
-        end_char = min(len(text), start_char + len(chunk_text))
+        start_char = _char_len_of_prefix(token_start)
+        end_char = _char_len_of_prefix(token_end)
 
         chunks.append(
             {

--- a/lcats/lcats/analysis/event_role_world/entity_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/entity_extractor.py
@@ -1,0 +1,166 @@
+"""Stage 3: entity/participant extraction via the backend's tool= path.
+
+Uses lcats.analysis.llm_extractor.JSONPromptExtractor's tool_schema
+parameter (schema-checked structured output) rather than json_object mode,
+per the governing proposal's Implementation prerequisites section.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from lcats.analysis import llm_extractor
+from lcats.analysis.event_role_world import schema
+
+ENTITY_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "extract_entities",
+    "description": (
+        "Extract salient entities, participants, and aliases from a story "
+        "segment, with actant roles and quoted evidence for each mention."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "entities": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "entity_id": {"type": "string"},
+                        "canonical_name": {"type": "string"},
+                        "entity_type": {
+                            "type": "string",
+                            "description": (
+                                "e.g. human, nonhuman_animal, alien, "
+                                "machine_or_artifact, institution, "
+                                "environment, abstract_force"
+                            ),
+                        },
+                        "aliases": {"type": "array", "items": {"type": "string"}},
+                        "actant_roles": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "e.g. protagonist, opponent, helper, "
+                                "instrument, victim, observer"
+                            ),
+                        },
+                        "confidence": {"type": "number"},
+                        "mentions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "mention_id": {"type": "string"},
+                                    "text": {"type": "string"},
+                                    "quote": {
+                                        "type": "string",
+                                        "description": (
+                                            "Exact substring of the segment "
+                                            "text this mention refers to."
+                                        ),
+                                    },
+                                    "mention_form": {"type": "string"},
+                                    "grammatical_role": {"type": "string"},
+                                },
+                                "required": ["mention_id", "text", "quote"],
+                            },
+                        },
+                    },
+                    "required": [
+                        "entity_id",
+                        "canonical_name",
+                        "entity_type",
+                        "mentions",
+                    ],
+                },
+            }
+        },
+        "required": ["entities"],
+    },
+}
+
+ENTITY_SYSTEM_PROMPT = """You are extracting entities and participants from a
+segment of a story for structured narrative analysis. Identify every salient
+entity: people, nonhuman animals, aliens, machines/artifacts, institutions,
+environments, or abstract forces that act or are acted upon. For each entity,
+list every surface mention with the exact quoted text from the segment. Use
+only the provided segment text as evidence; do not infer entities not
+mentioned in it."""
+
+ENTITY_USER_PROMPT_TEMPLATE = """Segment text:
+---
+{story_text}
+---
+
+Extract entities and their mentions per the extract_entities tool schema."""
+
+
+def make_entity_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
+    """Create a JSONPromptExtractor configured for stage-3 entity extraction.
+
+    Args:
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
+
+    Returns:
+        Configured JSONPromptExtractor using the tool= structured-output path.
+    """
+    return llm_extractor.JSONPromptExtractor(
+        backend,
+        system_prompt=ENTITY_SYSTEM_PROMPT,
+        user_prompt_template=ENTITY_USER_PROMPT_TEMPLATE,
+        default_model="gpt-4o",
+        temperature=0.2,
+        tool_schema=ENTITY_TOOL_SCHEMA,
+    )
+
+
+def build_entities(
+    tool_result: Dict[str, Any], segment_text: str
+) -> Tuple[List[schema.Entity], List[schema.EntityMention]]:
+    """Convert a raw extract_entities tool result into schema objects.
+
+    Args:
+        tool_result: The dict returned by the extract_entities tool call
+            (JSONPromptExtractor.extract(...)['extracted_output']).
+        segment_text: The segment text mention quotes are resolved against.
+
+    Returns:
+        (entities, mentions) — mentions whose quote cannot be located in
+        `segment_text` are dropped (not fabricated with a guessed span).
+    """
+    entities: List[schema.Entity] = []
+    mentions: List[schema.EntityMention] = []
+
+    for raw_entity in tool_result.get("entities") or []:
+        mention_ids: List[str] = []
+        for raw_mention in raw_entity.get("mentions") or []:
+            evidence = schema.resolve_evidence(
+                raw_mention.get("quote", ""), segment_text
+            )
+            if evidence is None:
+                continue
+            mention = schema.EntityMention(
+                mention_id=raw_mention["mention_id"],
+                entity_id=raw_entity["entity_id"],
+                text=raw_mention.get("text", raw_mention.get("quote", "")),
+                evidence=evidence,
+                mention_form=raw_mention.get("mention_form"),
+                grammatical_role=raw_mention.get("grammatical_role"),
+            )
+            mentions.append(mention)
+            mention_ids.append(mention.mention_id)
+
+        entities.append(
+            schema.Entity(
+                entity_id=raw_entity["entity_id"],
+                canonical_name=raw_entity["canonical_name"],
+                entity_type=raw_entity.get("entity_type", "other"),
+                aliases=raw_entity.get("aliases") or [],
+                mention_ids=mention_ids,
+                actant_roles=raw_entity.get("actant_roles") or [],
+                confidence=raw_entity.get("confidence", 1.0),
+            )
+        )
+
+    return entities, mentions

--- a/lcats/lcats/analysis/event_role_world/entity_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/entity_extractor.py
@@ -128,16 +128,21 @@ def build_entities(
     Returns:
         (entities, mentions) — mentions whose quote cannot be located in
         `segment_text` are dropped (not fabricated with a guessed span).
+        An entity whose every mention was dropped this way is itself
+        dropped: an entity with zero grounded mentions is ungrounded and
+        would otherwise inflate entity-rate metrics for output the
+        evidence check already rejected. Repeated identical quotes within
+        one entity's mentions resolve to successive occurrences via a
+        per-segment EvidenceCursor, not all onto the first match.
     """
     entities: List[schema.Entity] = []
     mentions: List[schema.EntityMention] = []
+    cursor = schema.EvidenceCursor()
 
     for raw_entity in tool_result.get("entities") or []:
         mention_ids: List[str] = []
         for raw_mention in raw_entity.get("mentions") or []:
-            evidence = schema.resolve_evidence(
-                raw_mention.get("quote", ""), segment_text
-            )
+            evidence = cursor.resolve(raw_mention.get("quote", ""), segment_text)
             if evidence is None:
                 continue
             mention = schema.EntityMention(
@@ -150,6 +155,12 @@ def build_entities(
             )
             mentions.append(mention)
             mention_ids.append(mention.mention_id)
+
+        if not mention_ids:
+            # Every mention's quote was unresolvable: this entity has no
+            # grounded evidence at all. Drop it rather than keep an
+            # ungrounded entity that would inflate entity-rate metrics.
+            continue
 
         entities.append(
             schema.Entity(

--- a/lcats/lcats/analysis/event_role_world/event_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/event_extractor.py
@@ -1,0 +1,253 @@
+"""Stages 4-5: event/semantic-role and temporal/spatial anchor extraction.
+
+Uses lcats.analysis.llm_extractor.JSONPromptExtractor's tool_schema
+parameter (schema-checked structured output) rather than json_object mode,
+per the governing proposal's Implementation prerequisites section. Events
+and anchors are extracted in one call since events reference anchor IDs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from lcats.analysis import llm_extractor
+from lcats.analysis.event_role_world import schema
+
+EVENT_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "extract_events_and_anchors",
+    "description": (
+        "Extract salient events with semantic roles, and the temporal/"
+        "spatial anchors those events occur within, from a story segment."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "temporal_anchors": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "anchor_id": {"type": "string"},
+                        "text": {"type": "string"},
+                        "quote": {"type": "string"},
+                        "normalized": {"type": "string"},
+                        "granularity": {"type": "string"},
+                        "relative_or_absolute": {
+                            "type": "string",
+                            "enum": ["relative", "absolute"],
+                        },
+                        "scale": {"type": "string"},
+                        "confidence": {"type": "number"},
+                    },
+                    "required": ["anchor_id", "text", "quote"],
+                },
+            },
+            "spatial_anchors": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "anchor_id": {"type": "string"},
+                        "text": {"type": "string"},
+                        "quote": {"type": "string"},
+                        "linked_entity_id": {"type": "string"},
+                        "containment_or_scale": {"type": "string"},
+                        "confidence": {"type": "number"},
+                    },
+                    "required": ["anchor_id", "text", "quote"],
+                },
+            },
+            "events": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "event_id": {"type": "string"},
+                        "predicate": {"type": "string"},
+                        "lemma": {"type": "string"},
+                        "event_type": {"type": "string"},
+                        "quote": {
+                            "type": "string",
+                            "description": (
+                                "Exact substring of the segment text this "
+                                "event's predicate occurs in."
+                            ),
+                        },
+                        "modality": {
+                            "type": "string",
+                            "enum": [
+                                "actual",
+                                "hypothetical",
+                                "negated",
+                                "future",
+                                "counterfactual",
+                            ],
+                        },
+                        "confidence": {"type": "number"},
+                        "temporal_anchor_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "spatial_anchor_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "semantic_roles": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "description": (
+                                            "e.g. agent, patient, theme, "
+                                            "experiencer, instrument, "
+                                            "source, goal, location, "
+                                            "cause, result"
+                                        ),
+                                    },
+                                    "filler_entity_id": {"type": "string"},
+                                    "filler_text": {"type": "string"},
+                                    "quote": {"type": "string"},
+                                    "confidence": {"type": "number"},
+                                },
+                                "required": ["role", "quote"],
+                            },
+                        },
+                    },
+                    "required": ["event_id", "predicate", "event_type", "quote"],
+                },
+            },
+        },
+        "required": ["events"],
+    },
+}
+
+EVENT_SYSTEM_PROMPT = """You are extracting events, semantic roles, and
+temporal/spatial anchors from a segment of a story for structured narrative
+analysis. Identify every salient predicate/event, its participants' semantic
+roles (agent, patient, instrument, etc.), and the times/places it occurs
+within. Use only the provided segment text and previously-extracted entity
+IDs as evidence; quote exact segment text for every claim."""
+
+EVENT_USER_PROMPT_TEMPLATE = """Segment text:
+---
+{story_text}
+---
+
+Known entity IDs for this segment: {entity_ids}
+
+Extract events, semantic roles, and temporal/spatial anchors per the
+extract_events_and_anchors tool schema. Use the known entity IDs for
+filler_entity_id where a semantic role's filler is one of them."""
+
+
+def make_event_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
+    """Create a JSONPromptExtractor configured for stage-4/5 extraction.
+
+    Args:
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
+
+    Returns:
+        Configured JSONPromptExtractor using the tool= structured-output path.
+    """
+    return llm_extractor.JSONPromptExtractor(
+        backend,
+        system_prompt=EVENT_SYSTEM_PROMPT,
+        user_prompt_template=EVENT_USER_PROMPT_TEMPLATE,
+        default_model="gpt-4o",
+        temperature=0.2,
+        tool_schema=EVENT_TOOL_SCHEMA,
+    )
+
+
+def build_events_and_anchors(
+    tool_result: Dict[str, Any], segment_text: str
+) -> Tuple[List[schema.Event], List[schema.TemporalAnchor], List[schema.SpatialAnchor]]:
+    """Convert a raw extract_events_and_anchors tool result into schema objects.
+
+    Args:
+        tool_result: The dict returned by the extract_events_and_anchors
+            tool call.
+        segment_text: The segment text quotes are resolved against.
+
+    Returns:
+        (events, temporal_anchors, spatial_anchors). Events, semantic roles,
+        and anchors whose quote cannot be located in `segment_text` are
+        dropped (not fabricated with a guessed span).
+    """
+    temporal_anchors: List[schema.TemporalAnchor] = []
+    for raw in tool_result.get("temporal_anchors") or []:
+        evidence = schema.resolve_evidence(raw.get("quote", ""), segment_text)
+        if evidence is None:
+            continue
+        temporal_anchors.append(
+            schema.TemporalAnchor(
+                anchor_id=raw["anchor_id"],
+                text=raw.get("text", raw.get("quote", "")),
+                evidence=evidence,
+                normalized=raw.get("normalized"),
+                granularity=raw.get("granularity"),
+                relative_or_absolute=raw.get("relative_or_absolute", "relative"),
+                scale=raw.get("scale"),
+                confidence=raw.get("confidence", 1.0),
+            )
+        )
+
+    spatial_anchors: List[schema.SpatialAnchor] = []
+    for raw in tool_result.get("spatial_anchors") or []:
+        evidence = schema.resolve_evidence(raw.get("quote", ""), segment_text)
+        if evidence is None:
+            continue
+        spatial_anchors.append(
+            schema.SpatialAnchor(
+                anchor_id=raw["anchor_id"],
+                text=raw.get("text", raw.get("quote", "")),
+                evidence=evidence,
+                linked_entity_id=raw.get("linked_entity_id"),
+                containment_or_scale=raw.get("containment_or_scale"),
+                confidence=raw.get("confidence", 1.0),
+            )
+        )
+
+    events: List[schema.Event] = []
+    for raw_event in tool_result.get("events") or []:
+        event_evidence = schema.resolve_evidence(
+            raw_event.get("quote", ""), segment_text
+        )
+        if event_evidence is None:
+            continue
+
+        semantic_roles: List[schema.SemanticRole] = []
+        for raw_role in raw_event.get("semantic_roles") or []:
+            role_evidence = schema.resolve_evidence(
+                raw_role.get("quote", ""), segment_text
+            )
+            if role_evidence is None:
+                continue
+            semantic_roles.append(
+                schema.SemanticRole(
+                    role=raw_role["role"],
+                    evidence=role_evidence,
+                    filler_entity_id=raw_role.get("filler_entity_id"),
+                    filler_text=raw_role.get("filler_text"),
+                    confidence=raw_role.get("confidence", 1.0),
+                )
+            )
+
+        events.append(
+            schema.Event(
+                event_id=raw_event["event_id"],
+                predicate=raw_event["predicate"],
+                event_type=raw_event.get("event_type", "other"),
+                evidence=event_evidence,
+                lemma=raw_event.get("lemma"),
+                semantic_roles=semantic_roles,
+                temporal_anchor_ids=raw_event.get("temporal_anchor_ids") or [],
+                spatial_anchor_ids=raw_event.get("spatial_anchor_ids") or [],
+                modality=raw_event.get("modality", "actual"),
+                confidence=raw_event.get("confidence", 1.0),
+            )
+        )
+
+    return events, temporal_anchors, spatial_anchors

--- a/lcats/lcats/analysis/event_role_world/event_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/event_extractor.py
@@ -174,11 +174,16 @@ def build_events_and_anchors(
     Returns:
         (events, temporal_anchors, spatial_anchors). Events, semantic roles,
         and anchors whose quote cannot be located in `segment_text` are
-        dropped (not fabricated with a guessed span).
+        dropped (not fabricated with a guessed span). Repeated identical
+        quotes across anchors/events/roles resolve to successive
+        occurrences via a per-segment EvidenceCursor shared across all
+        three, not all onto the first match.
     """
+    cursor = schema.EvidenceCursor()
+
     temporal_anchors: List[schema.TemporalAnchor] = []
     for raw in tool_result.get("temporal_anchors") or []:
-        evidence = schema.resolve_evidence(raw.get("quote", ""), segment_text)
+        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
         temporal_anchors.append(
@@ -196,7 +201,7 @@ def build_events_and_anchors(
 
     spatial_anchors: List[schema.SpatialAnchor] = []
     for raw in tool_result.get("spatial_anchors") or []:
-        evidence = schema.resolve_evidence(raw.get("quote", ""), segment_text)
+        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
         spatial_anchors.append(
@@ -212,17 +217,13 @@ def build_events_and_anchors(
 
     events: List[schema.Event] = []
     for raw_event in tool_result.get("events") or []:
-        event_evidence = schema.resolve_evidence(
-            raw_event.get("quote", ""), segment_text
-        )
+        event_evidence = cursor.resolve(raw_event.get("quote", ""), segment_text)
         if event_evidence is None:
             continue
 
         semantic_roles: List[schema.SemanticRole] = []
         for raw_role in raw_event.get("semantic_roles") or []:
-            role_evidence = schema.resolve_evidence(
-                raw_role.get("quote", ""), segment_text
-            )
+            role_evidence = cursor.resolve(raw_role.get("quote", ""), segment_text)
             if role_evidence is None:
                 continue
             semantic_roles.append(

--- a/lcats/lcats/analysis/event_role_world/nlp_backend.py
+++ b/lcats/lcats/analysis/event_role_world/nlp_backend.py
@@ -1,0 +1,179 @@
+"""NLPBackend Protocol and implementations for surface-feature extraction.
+
+Mirrors lcats.llm.backend.LLMBackend: a structural Protocol lets callers
+swap the underlying NLP toolkit (spaCy, Stanza, ...) without touching
+extractor or pipeline code. Both spaCy and Stanza converge on token-level
+fields defined by the Universal Dependencies / CoNLL-U schema (UPOS, XPOS,
+FEATS, HEAD, DEPREL) even though their native object shapes differ, so a
+single normalized token record is sufficient to represent either.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+
+@dataclasses.dataclass
+class TokenRecord:
+    """One normalized token, aligned with the CoNLL-U column set.
+
+    Attributes:
+        text: Surface form.
+        lemma: Dictionary form.
+        upos: Universal part-of-speech tag (e.g. "NOUN").
+        xpos: Fine-grained/treebank-specific POS tag, if available.
+        feats: Morphological features as a UD-style string
+            (e.g. "Number=Sing|Person=3"), empty string if none.
+        head_index: 1-based index of the syntactic head word within the
+            sentence, or 0 for root. Normalizes spaCy's object-reference
+            `Token.head` and Stanza's integer `Word.head` to the same shape.
+        deprel: Universal dependency relation to the head.
+    """
+
+    text: str
+    lemma: str
+    upos: str
+    xpos: str
+    feats: str
+    head_index: int
+    deprel: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class SentenceRecord:
+    """One sentence's worth of normalized tokens."""
+
+    tokens: List[TokenRecord]
+
+
+@runtime_checkable
+class NLPBackend(Protocol):
+    """Structural protocol for a surface-feature (syntax/morphology) backend.
+
+    Implementations adapt a specific NLP toolkit to this normalized call
+    shape so callers can switch toolkits by swapping the backend instance,
+    without touching extractor or schema code.
+    """
+
+    def analyze(self, text: str) -> List[SentenceRecord]:
+        """Tokenize, tag, and parse `text`.
+
+        Args:
+            text: Segment text to analyze.
+
+        Returns:
+            A list of SentenceRecord, one per detected sentence.
+        """
+        ...
+
+
+class StanzaBackend:
+    """NLPBackend implementation backed by Stanford's Stanza toolkit."""
+
+    def __init__(
+        self, lang: str = "en", processors: str = "tokenize,pos,lemma,depparse"
+    ):
+        """Construct a Stanza-backed NLPBackend.
+
+        Args:
+            lang: Stanza language code.
+            processors: Comma-separated Stanza processor list.
+
+        Raises:
+            ImportError: If the `stanza` package is not installed.
+            Exception: If the requested language model has not been
+                downloaded (`stanza.download(lang)`).
+        """
+        import stanza
+
+        self._pipeline = stanza.Pipeline(
+            lang=lang, processors=processors, download_method=None
+        )
+
+    def analyze(self, text: str) -> List[SentenceRecord]:
+        """See NLPBackend.analyze."""
+        doc = self._pipeline(text)
+        sentences: List[SentenceRecord] = []
+        for sentence in doc.sentences:
+            tokens = [
+                TokenRecord(
+                    text=word.text,
+                    lemma=word.lemma or "",
+                    upos=word.upos or "",
+                    xpos=word.xpos or "",
+                    feats=word.feats or "",
+                    head_index=word.head or 0,
+                    deprel=word.deprel or "",
+                )
+                for word in sentence.words
+            ]
+            sentences.append(SentenceRecord(tokens=tokens))
+        return sentences
+
+
+class SpacyBackend:
+    """NLPBackend implementation backed by spaCy."""
+
+    def __init__(self, model_name: str = "en_core_web_sm"):
+        """Construct a spaCy-backed NLPBackend.
+
+        Args:
+            model_name: Name of an installed spaCy pipeline package.
+
+        Raises:
+            ImportError: If the `spacy` package is not installed.
+            OSError: If `model_name` has not been downloaded
+                (`python -m spacy download <model_name>`).
+        """
+        import spacy
+
+        self._nlp = spacy.load(model_name)
+
+    def analyze(self, text: str) -> List[SentenceRecord]:
+        """See NLPBackend.analyze."""
+        doc = self._nlp(text)
+        sentences: List[SentenceRecord] = []
+        for sent in doc.sents:
+            # spaCy's Token.head is an object reference; head_index is the
+            # head's 1-based position within the sentence (0 = root), to
+            # match Stanza's integer-index convention.
+            sent_tokens = list(sent)
+            index_in_sent = {tok.i: pos + 1 for pos, tok in enumerate(sent_tokens)}
+            tokens = [
+                TokenRecord(
+                    text=tok.text,
+                    lemma=tok.lemma_,
+                    upos=tok.pos_,
+                    xpos=tok.tag_,
+                    feats=str(tok.morph),
+                    head_index=(
+                        0 if tok.head.i == tok.i else index_in_sent.get(tok.head.i, 0)
+                    ),
+                    deprel=tok.dep_,
+                )
+                for tok in sent_tokens
+            ]
+            sentences.append(SentenceRecord(tokens=tokens))
+        return sentences
+
+
+class FakeNLPBackend:
+    """Deterministic NLPBackend test double.
+
+    Records every call in `self.calls` and always returns a fixed set of
+    SentenceRecord built from the constructor arguments.
+    """
+
+    def __init__(self, sentences: Optional[List[SentenceRecord]] = None):
+        self.sentences = sentences if sentences is not None else []
+        self.calls: List[str] = []
+
+    def analyze(self, text: str) -> List[SentenceRecord]:
+        """Record the call and return the fixed sentences."""
+        self.calls.append(text)
+        return self.sentences

--- a/lcats/lcats/analysis/event_role_world/processor.py
+++ b/lcats/lcats/analysis/event_role_world/processor.py
@@ -1,0 +1,242 @@
+"""Pipeline orchestration for Event-Role-World extractor stages 1-5.
+
+Stage 1 (input contract) reuses the existing segment/evidence substrate
+(lcats.analysis.story_processors, lcats.analysis.text_segmenter) rather than
+reimplementing segmentation — this module accepts already-produced segments
+(scene/sequel, or fixed_chunk from baseline.py) and runs stages 2-5 over
+each one's sliced text.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+
+from typing import Any, Dict, List
+
+from lcats.analysis.event_role_world import entity_extractor as entity_extractor_module
+from lcats.analysis.event_role_world import event_extractor as event_extractor_module
+from lcats.analysis.event_role_world import nlp_backend as nlp_backend_module
+from lcats.analysis.event_role_world import schema
+from lcats.analysis.event_role_world import surface_feature_extractor
+
+
+@dataclasses.dataclass
+class PassUsage:
+    """Cost/usage record for one annotator pass on one segment.
+
+    Per the governing proposal's Cost and baseline requirements: call
+    counts alone do not make cost/latency visible, so this records token
+    counts, model, and elapsed time for every LLM-backed pass, and marks
+    NLP-only passes explicitly so they are not miscounted as free.
+    """
+
+    segment_id: Any
+    pass_name: str
+    is_llm_backed: bool
+    model: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    elapsed_seconds: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def process_segment(
+    segment_id: Any,
+    segment_text: str,
+    *,
+    nlp_backend: nlp_backend_module.NLPBackend,
+    nlp_backend_name: str,
+    entity_llm_extractor: Any,
+    event_llm_extractor: Any,
+) -> "tuple[schema.SegmentWorldAnnotation, List[PassUsage]]":
+    """Run stages 2-5 over one segment's text.
+
+    Args:
+        segment_id: The segment's ID, carried through to the annotation.
+        segment_text: The exact text of this segment (story_text sliced by
+            the segment's start_char/end_char).
+        nlp_backend: NLPBackend for stage 2 (surface features).
+        nlp_backend_name: Label recorded on the SurfaceFeatures result and
+            usage records (e.g. "stanza", "spacy").
+        entity_llm_extractor: A JSONPromptExtractor configured via
+            entity_extractor.make_entity_extractor.
+        event_llm_extractor: A JSONPromptExtractor configured via
+            event_extractor.make_event_extractor.
+
+    Returns:
+        (annotation, usage_records) — annotation.validation_errors is
+        populated by schema.validate_segment_annotation before returning.
+    """
+    usage_records: List[PassUsage] = []
+
+    # Stage 2: surface features (NLP-only, not LLM-backed).
+    t0 = time.monotonic()
+    surface_features = surface_feature_extractor.extract_surface_features(
+        segment_text, nlp_backend, backend_name=nlp_backend_name
+    )
+    usage_records.append(
+        PassUsage(
+            segment_id=segment_id,
+            pass_name="surface_feature",
+            is_llm_backed=False,
+            model=nlp_backend_name,
+            elapsed_seconds=time.monotonic() - t0,
+        )
+    )
+
+    # Stage 3: entities/participants (LLM-backed).
+    t0 = time.monotonic()
+    entity_result = entity_llm_extractor.extract(segment_text)
+    usage_records.append(
+        _pass_usage_from_extraction(segment_id, "entity", entity_result, t0)
+    )
+    entities, mentions = entity_extractor_module.build_entities(
+        entity_result.get("extracted_output") or {}, segment_text
+    )
+
+    # Stages 4-5: events/semantic-roles + temporal/spatial anchors (LLM-backed).
+    # JSONPromptExtractor.extract() only substitutes {story_text}/
+    # {indexed_story_text}; entity IDs are interpolated via a dedicated
+    # helper rather than extract() itself, so this makes exactly one
+    # backend call, not two.
+    entity_ids = [e.entity_id for e in entities]
+    t0 = time.monotonic()
+    event_result = _extract_events_with_entity_ids(
+        event_llm_extractor, segment_text, entity_ids
+    )
+    usage_records.append(
+        _pass_usage_from_extraction(segment_id, "event_anchor", event_result, t0)
+    )
+    events, temporal_anchors, spatial_anchors = (
+        event_extractor_module.build_events_and_anchors(
+            event_result.get("extracted_output") or {}, segment_text
+        )
+    )
+
+    annotation = schema.SegmentWorldAnnotation(
+        segment_id=segment_id,
+        surface_features=surface_features,
+        entities=entities,
+        mentions=mentions,
+        events=events,
+        temporal_anchors=temporal_anchors,
+        spatial_anchors=spatial_anchors,
+    )
+    annotation.validation_errors = schema.validate_segment_annotation(
+        annotation, segment_text
+    )
+
+    return annotation, usage_records
+
+
+def _pass_usage_from_extraction(
+    segment_id: Any, pass_name: str, extraction_result: Dict[str, Any], t0: float
+) -> PassUsage:
+    """Build a PassUsage record from a JSONPromptExtractor.extract() result."""
+    usage = extraction_result.get("usage") or {}
+    return PassUsage(
+        segment_id=segment_id,
+        pass_name=pass_name,
+        is_llm_backed=True,
+        model=extraction_result.get("model_name", ""),
+        input_tokens=usage.get("input_tokens", 0),
+        output_tokens=usage.get("output_tokens", 0),
+        elapsed_seconds=time.monotonic() - t0,
+    )
+
+
+def _extract_events_with_entity_ids(
+    event_llm_extractor: Any, segment_text: str, entity_ids: List[str]
+) -> Dict[str, Any]:
+    """Run the event extractor with entity IDs interpolated into the prompt.
+
+    JSONPromptExtractor.extract() only substitutes {story_text}/
+    {indexed_story_text} into user_prompt_template; {entity_ids} is
+    resolved here by temporarily formatting the template with both story
+    text and entity IDs, then calling the backend directly with the
+    resulting content — bypassing extract()'s own template formatting for
+    this one extra placeholder.
+    """
+    content = event_llm_extractor.user_prompt_template.format(
+        story_text=segment_text,
+        indexed_story_text=segment_text,
+        entity_ids=", ".join(entity_ids) if entity_ids else "(none known yet)",
+    )
+    messages = [
+        {"role": "system", "content": event_llm_extractor.system_prompt},
+        {"role": "user", "content": content},
+    ]
+    event_llm_extractor.last_messages = messages
+    backend_response = event_llm_extractor.backend.complete(
+        system=event_llm_extractor.system_prompt,
+        messages=[{"role": "user", "content": content}],
+        model=event_llm_extractor.default_model,
+        temperature=event_llm_extractor.temperature,
+        max_tokens=event_llm_extractor.max_tokens,
+        tool=event_llm_extractor.tool_schema,
+    )
+    event_llm_extractor.last_response = backend_response
+    return {
+        "extracted_output": backend_response.tool_result,
+        "model_name": backend_response.model,
+        "usage": {
+            "input_tokens": backend_response.input_tokens,
+            "output_tokens": backend_response.output_tokens,
+        },
+    }
+
+
+def process_segments(
+    story_text: str,
+    segments: List[Dict[str, Any]],
+    *,
+    nlp_backend_name: str,
+    llm_backend: Any,
+) -> Dict[str, Any]:
+    """Run stages 2-5 over every segment in `segments`.
+
+    Args:
+        story_text: Full story text; segments are sliced from this by
+            start_char/end_char (the stage-1 input contract).
+        segments: Segment dicts with segment_id, start_char, end_char (as
+            produced by story_processors.make_annotated_segment_extractor,
+            or baseline.make_fixed_token_chunks).
+        nlp_backend_name: "stanza" or "spacy".
+        llm_backend: LLMBackend for the entity/event extraction passes.
+
+    Returns:
+        {"segments": [SegmentWorldAnnotation.to_dict(), ...],
+         "usage": [PassUsage.to_dict(), ...]}
+    """
+    nlp_backend = surface_feature_extractor.make_nlp_backend(nlp_backend_name)
+    entity_llm_extractor = entity_extractor_module.make_entity_extractor(llm_backend)
+    event_llm_extractor = event_extractor_module.make_event_extractor(llm_backend)
+
+    annotations: List[schema.SegmentWorldAnnotation] = []
+    all_usage: List[PassUsage] = []
+
+    for segment in segments:
+        start_char = segment.get("start_char")
+        end_char = segment.get("end_char")
+        if start_char is None or end_char is None:
+            continue
+        segment_text = story_text[start_char:end_char]
+
+        annotation, usage_records = process_segment(
+            segment.get("segment_id"),
+            segment_text,
+            nlp_backend=nlp_backend,
+            nlp_backend_name=nlp_backend_name,
+            entity_llm_extractor=entity_llm_extractor,
+            event_llm_extractor=event_llm_extractor,
+        )
+        annotations.append(annotation)
+        all_usage.extend(usage_records)
+
+    return {
+        "segments": [a.to_dict() for a in annotations],
+        "usage": [u.to_dict() for u in all_usage],
+    }

--- a/lcats/lcats/analysis/event_role_world/processor.py
+++ b/lcats/lcats/analysis/event_role_world/processor.py
@@ -87,12 +87,22 @@ def process_segment(
         )
     )
 
+    extraction_errors: List[str] = []
+
     # Stage 3: entities/participants (LLM-backed).
     t0 = time.monotonic()
     entity_result = entity_llm_extractor.extract(segment_text)
     usage_records.append(
         _pass_usage_from_extraction(segment_id, "entity", entity_result, t0)
     )
+    entity_error = entity_result.get("api_error") or entity_result.get(
+        "extraction_error"
+    )
+    if entity_error:
+        # A failed entity pass must not silently read as "zero entities
+        # found" — an empty result here is meaningfully different from an
+        # extraction that never ran/succeeded.
+        extraction_errors.append(f"entity extraction failed: {entity_error}")
     entities, mentions = entity_extractor_module.build_entities(
         entity_result.get("extracted_output") or {}, segment_text
     )
@@ -100,8 +110,11 @@ def process_segment(
     # Stages 4-5: events/semantic-roles + temporal/spatial anchors (LLM-backed).
     # JSONPromptExtractor.extract() only substitutes {story_text}/
     # {indexed_story_text}; entity IDs are interpolated via a dedicated
-    # helper rather than extract() itself, so this makes exactly one
-    # backend call, not two.
+    # helper that still routes through extract() (see
+    # _extract_events_with_entity_ids), so this makes exactly one backend
+    # call, not two, and keeps extract()'s exception/api_error handling
+    # intact rather than letting a transient failure abort process_segments
+    # for every remaining segment.
     entity_ids = [e.entity_id for e in entities]
     t0 = time.monotonic()
     event_result = _extract_events_with_entity_ids(
@@ -110,6 +123,9 @@ def process_segment(
     usage_records.append(
         _pass_usage_from_extraction(segment_id, "event_anchor", event_result, t0)
     )
+    event_error = event_result.get("api_error") or event_result.get("extraction_error")
+    if event_error:
+        extraction_errors.append(f"event/anchor extraction failed: {event_error}")
     events, temporal_anchors, spatial_anchors = (
         event_extractor_module.build_events_and_anchors(
             event_result.get("extracted_output") or {}, segment_text
@@ -124,6 +140,7 @@ def process_segment(
         events=events,
         temporal_anchors=temporal_anchors,
         spatial_anchors=spatial_anchors,
+        extraction_errors=extraction_errors,
     )
     annotation.validation_errors = schema.validate_segment_annotation(
         annotation, segment_text
@@ -154,39 +171,25 @@ def _extract_events_with_entity_ids(
     """Run the event extractor with entity IDs interpolated into the prompt.
 
     JSONPromptExtractor.extract() only substitutes {story_text}/
-    {indexed_story_text} into user_prompt_template; {entity_ids} is
-    resolved here by temporarily formatting the template with both story
-    text and entity IDs, then calling the backend directly with the
-    resulting content — bypassing extract()'s own template formatting for
-    this one extra placeholder.
+    {indexed_story_text} into user_prompt_template. {entity_ids} is
+    resolved by temporarily replacing that one placeholder in the template
+    with a literal string (leaving {story_text}/{indexed_story_text}
+    intact for extract() to fill in as usual), then calling
+    extract() itself — not the backend directly — so a transient provider
+    failure or missing tool_result produces the same normalized
+    api_error/extraction_error result extract() gives every other call,
+    instead of an uncaught exception that would abort process_segments()
+    for every remaining segment.
     """
-    content = event_llm_extractor.user_prompt_template.format(
-        story_text=segment_text,
-        indexed_story_text=segment_text,
-        entity_ids=", ".join(entity_ids) if entity_ids else "(none known yet)",
+    original_template = event_llm_extractor.user_prompt_template
+    entity_ids_text = ", ".join(entity_ids) if entity_ids else "(none known yet)"
+    event_llm_extractor.user_prompt_template = original_template.replace(
+        "{entity_ids}", entity_ids_text
     )
-    messages = [
-        {"role": "system", "content": event_llm_extractor.system_prompt},
-        {"role": "user", "content": content},
-    ]
-    event_llm_extractor.last_messages = messages
-    backend_response = event_llm_extractor.backend.complete(
-        system=event_llm_extractor.system_prompt,
-        messages=[{"role": "user", "content": content}],
-        model=event_llm_extractor.default_model,
-        temperature=event_llm_extractor.temperature,
-        max_tokens=event_llm_extractor.max_tokens,
-        tool=event_llm_extractor.tool_schema,
-    )
-    event_llm_extractor.last_response = backend_response
-    return {
-        "extracted_output": backend_response.tool_result,
-        "model_name": backend_response.model,
-        "usage": {
-            "input_tokens": backend_response.input_tokens,
-            "output_tokens": backend_response.output_tokens,
-        },
-    }
+    try:
+        return event_llm_extractor.extract(segment_text)
+    finally:
+        event_llm_extractor.user_prompt_template = original_template
 
 
 def process_segments(

--- a/lcats/lcats/analysis/event_role_world/schema.py
+++ b/lcats/lcats/analysis/event_role_world/schema.py
@@ -1,0 +1,339 @@
+"""Event-Role-World object schemas for extractor stages 1-5.
+
+Implements the object responsibilities sketched in the governing proposal's
+"Core schema sketch" (project/design/proposals/proposed/
+lcats-event-role-world-extractor/00_proposal.md), scoped to the stages this
+work item covers: entities/participants, events/semantic roles, and
+temporal/spatial anchors. Relation, discourse, SF-tag, and hypothesis
+objects are out of scope (WI-EVENT-0024 forbidden_actions).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from typing import Any, Dict, List, Optional
+
+
+@dataclasses.dataclass
+class EvidenceSpan:
+    """Grounds a claim with a character span and quoted text.
+
+    Attributes:
+        start_char: 0-based start offset into the segment text.
+        end_char: 0-based end offset (exclusive) into the segment text.
+        quote: The exact substring the span points to.
+        source: One of "story", "segment", "model_pass", "external_annotation".
+        paragraph_ids: Optional paragraph IDs the span falls within.
+    """
+
+    start_char: int
+    end_char: int
+    quote: str
+    source: str = "segment"
+    paragraph_ids: Optional[List[int]] = None
+
+    def validate(self, text: str) -> Optional[str]:
+        """Return an error string if this span is invalid against `text`."""
+        if self.start_char < 0 or self.end_char > len(text):
+            return (
+                f"evidence span [{self.start_char}:{self.end_char}] out of "
+                f"bounds for text of length {len(text)}"
+            )
+        if self.start_char >= self.end_char:
+            return f"evidence span [{self.start_char}:{self.end_char}] is empty or inverted"
+        actual = text[self.start_char : self.end_char]
+        if self.quote and actual != self.quote:
+            return f"evidence span text mismatch: expected {self.quote!r}, found {actual!r}"
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class EntityMention:
+    """A surface mention of an entity within a segment."""
+
+    mention_id: str
+    entity_id: str
+    text: str
+    evidence: EvidenceSpan
+    mention_form: Optional[str] = None
+    grammatical_role: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "mention_id": self.mention_id,
+            "entity_id": self.entity_id,
+            "text": self.text,
+            "evidence": self.evidence.to_dict(),
+            "mention_form": self.mention_form,
+            "grammatical_role": self.grammatical_role,
+        }
+
+
+@dataclasses.dataclass
+class Entity:
+    """Reconciles participant mentions into a canonical entity."""
+
+    entity_id: str
+    canonical_name: str
+    entity_type: str
+    aliases: List[str] = dataclasses.field(default_factory=list)
+    mention_ids: List[str] = dataclasses.field(default_factory=list)
+    actant_roles: List[str] = dataclasses.field(default_factory=list)
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class SemanticRole:
+    """Binds an event to an entity or literal filler with a controlled role."""
+
+    role: str
+    evidence: EvidenceSpan
+    filler_entity_id: Optional[str] = None
+    filler_text: Optional[str] = None
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "role": self.role,
+            "evidence": self.evidence.to_dict(),
+            "filler_entity_id": self.filler_entity_id,
+            "filler_text": self.filler_text,
+            "confidence": self.confidence,
+        }
+
+
+@dataclasses.dataclass
+class Event:
+    """A salient predicate with semantic roles and anchors."""
+
+    event_id: str
+    predicate: str
+    event_type: str
+    evidence: EvidenceSpan
+    lemma: Optional[str] = None
+    semantic_roles: List[SemanticRole] = dataclasses.field(default_factory=list)
+    temporal_anchor_ids: List[str] = dataclasses.field(default_factory=list)
+    spatial_anchor_ids: List[str] = dataclasses.field(default_factory=list)
+    modality: str = "actual"
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "predicate": self.predicate,
+            "event_type": self.event_type,
+            "evidence": self.evidence.to_dict(),
+            "lemma": self.lemma,
+            "semantic_roles": [r.to_dict() for r in self.semantic_roles],
+            "temporal_anchor_ids": self.temporal_anchor_ids,
+            "spatial_anchor_ids": self.spatial_anchor_ids,
+            "modality": self.modality,
+            "confidence": self.confidence,
+        }
+
+
+@dataclasses.dataclass
+class TemporalAnchor:
+    """Records a normalized or textual time reference."""
+
+    anchor_id: str
+    text: str
+    evidence: EvidenceSpan
+    normalized: Optional[str] = None
+    granularity: Optional[str] = None
+    relative_or_absolute: str = "relative"
+    scale: Optional[str] = None
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "anchor_id": self.anchor_id,
+            "text": self.text,
+            "evidence": self.evidence.to_dict(),
+            "normalized": self.normalized,
+            "granularity": self.granularity,
+            "relative_or_absolute": self.relative_or_absolute,
+            "scale": self.scale,
+            "confidence": self.confidence,
+        }
+
+
+@dataclasses.dataclass
+class SpatialAnchor:
+    """Records a place or spatial frame."""
+
+    anchor_id: str
+    text: str
+    evidence: EvidenceSpan
+    linked_entity_id: Optional[str] = None
+    containment_or_scale: Optional[str] = None
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "anchor_id": self.anchor_id,
+            "text": self.text,
+            "evidence": self.evidence.to_dict(),
+            "linked_entity_id": self.linked_entity_id,
+            "containment_or_scale": self.containment_or_scale,
+            "confidence": self.confidence,
+        }
+
+
+@dataclasses.dataclass
+class SurfaceFeatures:
+    """Lexical, syntactic, and morphological features for a segment.
+
+    Not part of the governing proposal's "Core schema sketch" (which lists
+    no schema for the surface-feature pass) — this shape is this work
+    item's own design, populated by whichever NLPBackend produced it.
+
+    Attributes:
+        word_count: Number of tokens in the segment.
+        sentence_count: Number of sentences in the segment.
+        avg_sentence_length: Mean tokens per sentence.
+        avg_word_length: Mean characters per token.
+        tokens: Per-token records as produced by an NLPBackend: each dict
+            has keys text, lemma, upos, xpos, feats, head_index, deprel.
+        backend_name: Which NLPBackend produced `tokens` (e.g. "stanza",
+            "spacy").
+    """
+
+    word_count: int
+    sentence_count: int
+    avg_sentence_length: float
+    avg_word_length: float
+    tokens: List[Dict[str, Any]] = dataclasses.field(default_factory=list)
+    backend_name: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+@dataclasses.dataclass
+class SegmentWorldAnnotation:
+    """Collects all Event-Role-World annotations for one segment."""
+
+    segment_id: Any
+    surface_features: Optional[SurfaceFeatures] = None
+    entities: List[Entity] = dataclasses.field(default_factory=list)
+    mentions: List[EntityMention] = dataclasses.field(default_factory=list)
+    events: List[Event] = dataclasses.field(default_factory=list)
+    temporal_anchors: List[TemporalAnchor] = dataclasses.field(default_factory=list)
+    spatial_anchors: List[SpatialAnchor] = dataclasses.field(default_factory=list)
+    validation_errors: List[str] = dataclasses.field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "segment_id": self.segment_id,
+            "surface_features": (
+                self.surface_features.to_dict() if self.surface_features else None
+            ),
+            "entities": [e.to_dict() for e in self.entities],
+            "mentions": [m.to_dict() for m in self.mentions],
+            "events": [e.to_dict() for e in self.events],
+            "temporal_anchors": [a.to_dict() for a in self.temporal_anchors],
+            "spatial_anchors": [a.to_dict() for a in self.spatial_anchors],
+            "validation_errors": self.validation_errors,
+        }
+
+
+def resolve_evidence(
+    quote: str, segment_text: str, source: str = "segment"
+) -> Optional[EvidenceSpan]:
+    """Locate `quote` in `segment_text` and build an EvidenceSpan.
+
+    Args:
+        quote: Exact substring an LLM extraction claimed as evidence.
+        segment_text: The text to search within.
+        source: EvidenceSpan.source value.
+
+    Returns:
+        An EvidenceSpan if `quote` is found (first occurrence), else None.
+    """
+    if not quote:
+        return None
+    start = segment_text.find(quote)
+    if start < 0:
+        return None
+    return EvidenceSpan(
+        start_char=start, end_char=start + len(quote), quote=quote, source=source
+    )
+
+
+def validate_segment_annotation(
+    annotation: SegmentWorldAnnotation, segment_text: str
+) -> List[str]:
+    """Validate ID resolution and evidence-span alignment for one segment.
+
+    Args:
+        annotation: The annotation to validate.
+        segment_text: The exact segment text evidence spans are offset into.
+
+    Returns:
+        A list of human-readable error strings; empty if valid.
+    """
+    errors: List[str] = []
+
+    entity_ids = {e.entity_id for e in annotation.entities}
+    mention_ids = {m.mention_id for m in annotation.mentions}
+    anchor_ids = {a.anchor_id for a in annotation.temporal_anchors} | {
+        a.anchor_id for a in annotation.spatial_anchors
+    }
+
+    for mention in annotation.mentions:
+        if mention.entity_id not in entity_ids:
+            errors.append(
+                f"mention {mention.mention_id!r} references unknown entity "
+                f"{mention.entity_id!r}"
+            )
+        span_error = mention.evidence.validate(segment_text)
+        if span_error:
+            errors.append(f"mention {mention.mention_id!r}: {span_error}")
+
+    for entity in annotation.entities:
+        for mid in entity.mention_ids:
+            if mid not in mention_ids:
+                errors.append(
+                    f"entity {entity.entity_id!r} references unknown mention {mid!r}"
+                )
+
+    for event in annotation.events:
+        span_error = event.evidence.validate(segment_text)
+        if span_error:
+            errors.append(f"event {event.event_id!r}: {span_error}")
+        for role in event.semantic_roles:
+            if role.filler_entity_id and role.filler_entity_id not in entity_ids:
+                errors.append(
+                    f"event {event.event_id!r} role {role.role!r} references "
+                    f"unknown entity {role.filler_entity_id!r}"
+                )
+            role_span_error = role.evidence.validate(segment_text)
+            if role_span_error:
+                errors.append(
+                    f"event {event.event_id!r} role {role.role!r}: {role_span_error}"
+                )
+        for aid in event.temporal_anchor_ids + event.spatial_anchor_ids:
+            if aid not in anchor_ids:
+                errors.append(
+                    f"event {event.event_id!r} references unknown anchor {aid!r}"
+                )
+
+    for anchor in annotation.temporal_anchors:
+        span_error = anchor.evidence.validate(segment_text)
+        if span_error:
+            errors.append(f"temporal anchor {anchor.anchor_id!r}: {span_error}")
+
+    for anchor in annotation.spatial_anchors:
+        span_error = anchor.evidence.validate(segment_text)
+        if span_error:
+            errors.append(f"spatial anchor {anchor.anchor_id!r}: {span_error}")
+
+    return errors

--- a/lcats/lcats/analysis/event_role_world/schema.py
+++ b/lcats/lcats/analysis/event_role_world/schema.py
@@ -219,7 +219,19 @@ class SurfaceFeatures:
 
 @dataclasses.dataclass
 class SegmentWorldAnnotation:
-    """Collects all Event-Role-World annotations for one segment."""
+    """Collects all Event-Role-World annotations for one segment.
+
+    Attributes:
+        extraction_errors: Backend/API-level failures (e.g. a transient
+            provider error, an empty tool result) for any LLM-backed pass
+            on this segment. Distinct from validation_errors: an
+            extraction_error means a pass may not have run at all — its
+            "zero results" must not be read as "the pass ran and found
+            nothing."
+        validation_errors: ID-resolution and evidence-alignment failures
+            found by validate_segment_annotation, given whatever entities/
+            events/anchors were actually extracted.
+    """
 
     segment_id: Any
     surface_features: Optional[SurfaceFeatures] = None
@@ -228,6 +240,7 @@ class SegmentWorldAnnotation:
     events: List[Event] = dataclasses.field(default_factory=list)
     temporal_anchors: List[TemporalAnchor] = dataclasses.field(default_factory=list)
     spatial_anchors: List[SpatialAnchor] = dataclasses.field(default_factory=list)
+    extraction_errors: List[str] = dataclasses.field(default_factory=list)
     validation_errors: List[str] = dataclasses.field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -241,12 +254,16 @@ class SegmentWorldAnnotation:
             "events": [e.to_dict() for e in self.events],
             "temporal_anchors": [a.to_dict() for a in self.temporal_anchors],
             "spatial_anchors": [a.to_dict() for a in self.spatial_anchors],
+            "extraction_errors": self.extraction_errors,
             "validation_errors": self.validation_errors,
         }
 
 
 def resolve_evidence(
-    quote: str, segment_text: str, source: str = "segment"
+    quote: str,
+    segment_text: str,
+    source: str = "segment",
+    search_from: int = 0,
 ) -> Optional[EvidenceSpan]:
     """Locate `quote` in `segment_text` and build an EvidenceSpan.
 
@@ -254,18 +271,51 @@ def resolve_evidence(
         quote: Exact substring an LLM extraction claimed as evidence.
         segment_text: The text to search within.
         source: EvidenceSpan.source value.
+        search_from: Character offset to start searching from. When a
+            segment repeats the same quote (e.g. "he" mentioned several
+            times), passing the previous match's end_char here resolves
+            each successive claim to the next occurrence instead of
+            silently collapsing every claim onto occurrence 0. Callers
+            resolving multiple evidence spans for the same segment should
+            track a per-quote cursor (see EvidenceCursor).
 
     Returns:
-        An EvidenceSpan if `quote` is found (first occurrence), else None.
+        An EvidenceSpan if `quote` is found at or after `search_from`, else
+        None.
     """
     if not quote:
         return None
-    start = segment_text.find(quote)
+    start = segment_text.find(quote, search_from)
     if start < 0:
         return None
     return EvidenceSpan(
         start_char=start, end_char=start + len(quote), quote=quote, source=source
     )
+
+
+class EvidenceCursor:
+    """Tracks per-quote search positions so repeated quotes within one
+    segment resolve to successive occurrences rather than all collapsing
+    onto the first match.
+
+    Usage: construct one EvidenceCursor per segment (not shared across
+    segments — each segment's text is searched independently), and call
+    `.resolve(quote, segment_text)` for every evidence claim in that
+    segment, in the order the extraction produced them.
+    """
+
+    def __init__(self) -> None:
+        self._next_search_from: Dict[str, int] = {}
+
+    def resolve(
+        self, quote: str, segment_text: str, source: str = "segment"
+    ) -> Optional[EvidenceSpan]:
+        """Resolve `quote`, advancing this cursor's position for `quote`."""
+        search_from = self._next_search_from.get(quote, 0)
+        evidence = resolve_evidence(quote, segment_text, source, search_from)
+        if evidence is not None:
+            self._next_search_from[quote] = evidence.end_char
+        return evidence
 
 
 def validate_segment_annotation(

--- a/lcats/lcats/analysis/event_role_world/surface_feature_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/surface_feature_extractor.py
@@ -29,10 +29,17 @@ def extract_surface_features(
     sentences = backend.analyze(text) if text.strip() else []
 
     all_tokens = [tok for sent in sentences for tok in sent.tokens]
-    word_count = len(all_tokens)
+    # word_count and avg_word_length are word-rate denominators (used by
+    # baseline.py for entities/events-per-1000-words comparisons), so they
+    # must exclude punctuation tokens (upos == "PUNCT") — otherwise
+    # punctuation density skews the rate rather than word count driving it.
+    # `tokens`/token_count itself still includes punctuation: downstream
+    # consumers of the full token list need it for syntactic analysis.
+    word_tokens = [tok for tok in all_tokens if tok.upos != "PUNCT"]
+    word_count = len(word_tokens)
     sentence_count = len(sentences)
     avg_sentence_length = word_count / sentence_count if sentence_count else 0.0
-    total_word_chars = sum(len(tok.text) for tok in all_tokens)
+    total_word_chars = sum(len(tok.text) for tok in word_tokens)
     avg_word_length = total_word_chars / word_count if word_count else 0.0
 
     return schema.SurfaceFeatures(

--- a/lcats/lcats/analysis/event_role_world/surface_feature_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/surface_feature_extractor.py
@@ -1,0 +1,64 @@
+"""Stage 2: surface-feature (lexical, syntactic, morphological) extraction.
+
+Consumes an NLPBackend (see nlp_backend.py) — never imports spaCy or Stanza
+directly, so the underlying toolkit is swappable without touching this file.
+"""
+
+from __future__ import annotations
+
+from lcats.analysis.event_role_world import nlp_backend as nlp_backend_module
+from lcats.analysis.event_role_world import schema
+
+
+def extract_surface_features(
+    text: str,
+    backend: nlp_backend_module.NLPBackend,
+    backend_name: str = "",
+) -> schema.SurfaceFeatures:
+    """Run one NLPBackend pass and summarize lexical/syntactic features.
+
+    Args:
+        text: Segment text to analyze.
+        backend: An NLPBackend satisfying nlp_backend.NLPBackend.
+        backend_name: Label recorded on the result (e.g. "stanza", "spacy").
+
+    Returns:
+        A populated SurfaceFeatures instance. On empty input, counts are
+        zero and `tokens` is an empty list.
+    """
+    sentences = backend.analyze(text) if text.strip() else []
+
+    all_tokens = [tok for sent in sentences for tok in sent.tokens]
+    word_count = len(all_tokens)
+    sentence_count = len(sentences)
+    avg_sentence_length = word_count / sentence_count if sentence_count else 0.0
+    total_word_chars = sum(len(tok.text) for tok in all_tokens)
+    avg_word_length = total_word_chars / word_count if word_count else 0.0
+
+    return schema.SurfaceFeatures(
+        word_count=word_count,
+        sentence_count=sentence_count,
+        avg_sentence_length=avg_sentence_length,
+        avg_word_length=avg_word_length,
+        tokens=[tok.to_dict() for tok in all_tokens],
+        backend_name=backend_name,
+    )
+
+
+def make_nlp_backend(name: str) -> nlp_backend_module.NLPBackend:
+    """Construct an NLPBackend by name.
+
+    Args:
+        name: One of "stanza", "spacy".
+
+    Returns:
+        A constructed NLPBackend instance.
+
+    Raises:
+        ValueError: If `name` is not a recognized backend.
+    """
+    if name == "stanza":
+        return nlp_backend_module.StanzaBackend()
+    if name == "spacy":
+        return nlp_backend_module.SpacyBackend()
+    raise ValueError(f"Unknown NLP backend name: {name!r}")

--- a/lcats/lcats/analysis/llm_extractor.py
+++ b/lcats/lcats/analysis/llm_extractor.py
@@ -45,6 +45,14 @@ class JSONPromptExtractor:
         If provided, called to post-process the parsed JSON and fill canonical offsets.
     result_validator : Optional[Callable[[Dict[str, Any], str, Any], Dict[str, Any]]]
         If provided, runs AFTER alignment and attaches a 'validation_report' to the result.
+    tool_schema : Optional[Dict[str, Any]]
+        If provided, passed as `tool=` to the backend's `complete()` call
+        (see lcats.llm.backend.LLMBackend), forcing schema-checked
+        structured output instead of json_object mode. When set, the
+        backend's `tool_result` is used directly as both `parsed_output`
+        and `extracted_output` — `output_key`/text-JSON parsing are not
+        used. Callers still get alignment/validation hooks applied to the
+        tool result if `result_aligner`/`result_validator` are provided.
     """
 
     def __init__(
@@ -66,6 +74,7 @@ class JSONPromptExtractor:
         result_validator: Optional[
             Callable[[Dict[str, Any], str, Any], Dict[str, Any]]
         ] = None,
+        tool_schema: Optional[Dict[str, Any]] = None,
     ):
         if client is not _UNSET:
             if backend is not _UNSET:
@@ -103,6 +112,7 @@ class JSONPromptExtractor:
         self.text_indexer = text_indexer
         self.result_aligner = result_aligner
         self.result_validator = result_validator
+        self.tool_schema = tool_schema
 
         # Debug/inspection hooks
         self.last_messages: Optional[List[Dict[str, str]]] = None
@@ -301,16 +311,30 @@ class JSONPromptExtractor:
                 model=model,
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
+                tool=self.tool_schema,
             )
             self.last_response = backend_response
             raw_output = backend_response.text
 
-            if not raw_output:
+            if not raw_output and self.tool_schema is None:
                 api_error = {
                     "status": None,
                     "code": "empty_response",
                     "type": "client_or_server",
                     "message": "No content returned by backend.",
+                    "raw": repr(backend_response),
+                    "category": "unknown",
+                    "can_retry": True,
+                    "needs_smaller_request": False,
+                    "should_abort_batch": False,
+                    "suggested_action": "retry_with_backoff",
+                }
+            elif self.tool_schema is not None and backend_response.tool_result is None:
+                api_error = {
+                    "status": None,
+                    "code": "empty_tool_result",
+                    "type": "client_or_server",
+                    "message": "No tool_result returned by backend for tool_schema call.",
                     "raw": repr(backend_response),
                     "category": "unknown",
                     "can_retry": True,
@@ -342,6 +366,66 @@ class JSONPromptExtractor:
 
         self.last_raw_output = raw_output
 
+        extraction_error = None
+        alignment_error = None
+        validation_error = None
+        validation_report = None
+        extracted = None
+
+        if self.tool_schema is not None:
+            # Tool/function-calling path: the backend already validated the
+            # arguments against tool_schema, so there is no JSON-text parse
+            # step. `tool_result` stands in for both `parsed` and `extracted`.
+            parsing_error = None
+            parsed = backend_response.tool_result if backend_response else None
+            if api_error:
+                extraction_error = "api_error"
+            elif parsed is not None:
+                if self.result_aligner and index_meta is not None:
+                    try:
+                        parsed = self.result_aligner(parsed, story_text, index_meta)
+                    except Exception as exc:
+                        alignment_error = f"alignment failed: {exc!r}"
+                if self.result_validator and index_meta is not None:
+                    try:
+                        validation_report = self.result_validator(
+                            parsed, story_text, index_meta
+                        )
+                    except Exception as exc:
+                        validation_error = f"validation failed: {exc!r}"
+                self.last_validation_report = validation_report
+                extracted = parsed
+            else:
+                extraction_error = "No tool_result returned by backend."
+
+            return {
+                "story_text": story_text,
+                "model_name": (backend_response.model if backend_response else model),
+                "messages": messages,
+                "response": backend_response.raw if backend_response else None,
+                "response_id": getattr(
+                    backend_response.raw if backend_response else None, "id", None
+                ),
+                "usage": (
+                    {
+                        "input_tokens": backend_response.input_tokens,
+                        "output_tokens": backend_response.output_tokens,
+                    }
+                    if backend_response
+                    else None
+                ),
+                "raw_output": raw_output,
+                "parsed_output": parsed,
+                "extracted_output": extracted,
+                "parsing_error": parsing_error,
+                "extraction_error": extraction_error,
+                "alignment_error": alignment_error,
+                "index_meta": index_meta,
+                "validation_report": validation_report,
+                "validation_error": validation_error,
+                "api_error": api_error,
+            }
+
         # Parse (only if we got raw_output and no api_error)
         parsing_error = None
         try:
@@ -349,12 +433,6 @@ class JSONPromptExtractor:
         except json.JSONDecodeError as exc:
             parsed = None
             parsing_error = str(exc)
-
-        extraction_error = None
-        alignment_error = None
-        validation_error = None
-        validation_report = None
-        extracted = None
 
         if api_error:
             extraction_error = "api_error"

--- a/lcats/project/executions/AD_HOC/2026_07_23_18_25_20_WI_EVENT_0024_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_23_18_25_20_WI_EVENT_0024_REVIEW.md
@@ -1,0 +1,45 @@
+---
+execution_id: 2026_07_23_18_25_20_WI_EVENT_0024_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0024_REVIEW)[2026-07-23T18:00:20-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_23_17_26_52_WI_EVENT_0024
+pr: https://github.com/xenotaur/LCATS/pull/148
+commit: bb81b23
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/148
+session_transcript: pending
+created_at: 2026-07-23T18:25:20-04:00
+---
+
+# Summary
+
+Address 10 open review comments on PR #148 (WI-EVENT-0024, the Event-Role-World extractor implementation) via /lrh-review-response.
+
+# Result
+
+Fixed 9 of 10 comments (chatgpt-codex-connector: 4 P1 + 4 P2; copilot-pull-request-reviewer: 2, one overlapping a codex P1):
+
+1. (P1) Entity extraction failure silently read as "zero entities": processor.py now appends `entity extraction failed: <error>` to `annotation.extraction_errors` when `entity_result` carries an `api_error`/`extraction_error`, instead of discarding the failure.
+2. (P1, overlaps copilot #8) Event/anchor call bypassed `JSONPromptExtractor.extract()`'s error handling by calling `backend.complete()` directly, so an exception could abort `process_segments()` for every remaining segment: `_extract_events_with_entity_ids` rewritten to temporarily swap `user_prompt_template` and call `extract()` itself.
+3. (P1) `word_count` included punctuation tokens, skewing per-1000-word rates: `surface_feature_extractor.py` now filters `upos != "PUNCT"` before computing word_count/avg_word_length.
+4. (P1) `resolve_evidence()` always matched the first occurrence of a repeated quote: added `schema.EvidenceCursor`, used by both `entity_extractor.py` and `event_extractor.py` to advance per-quote search positions.
+5. (P2) Entities with zero surviving mentions were still appended as ungrounded "ghost" entities: `entity_extractor.build_entities` now skips entities with no resolved mentions.
+6. (P2) Fixed-chunk tests invoked the real `tiktoken` encoder (network risk in a clean environment, against the `tests/AGENTS.md` determinism convention): added `_CharEncoder`/`_ByteEncoder` test doubles and patched `story_analysis.get_encoder` in `TestMakeFixedTokenChunks`.
+7. (P2) Chunk char-offset derivation was not robust to multi-byte Unicode token-boundary splits: `baseline.make_fixed_token_chunks` now derives every offset via cumulative decode-from-index-0 instead of per-chunk anchor search, guaranteeing contiguity by construction.
+9. (copilot) `TestProcessSegments` was fully skipped without a real spaCy model, so `process_segments()` logic went unexercised in a clean CI checkout: removed the skip decorator and added a `setUp()` patching `make_nlp_backend` to return `nlp_backend.FakeNLPBackend()`.
+10. (copilot) `stanza`/`spacy` (pulling in PyTorch) were unconditional core dependencies, bloating every LCATS install: moved to a new `[project.optional-dependencies] nlp` extras group in `pyproject.toml`.
+
+Also updated `tests/analysis_tests/event_role_world_test.py::TestBuildEntities::test_drops_mention_with_unresolvable_quote`, which asserted the pre-fix "ghost entity" behavior, to assert the corrected drop-the-entity behavior from fix #5. Added two new regression tests to `TestProcessSegments`: `test_entity_extraction_failure_is_recorded_not_silently_empty` (fix #1) and `test_event_pass_failure_does_not_abort_remaining_segments` (fix #2).
+
+# Validation
+
+- `scripts/format --check --diff` — 2 files needed reformatting (processor.py, event_role_world_test.py); applied via `scripts/format`, re-verified clean.
+- `scripts/lint` — ruff and black both pass.
+- `scripts/test` — 1375 tests, all pass (0 failures after updating the one pre-fix-behavior assertion).
+- `lrh validate` (run from `lcats/`) — 0 errors, 31 warnings (all pre-existing `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS` warnings across the whole project, unrelated to this change).
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Run `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/148` before merge to verify the fixes against the current diff and resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_23_23_43_36_WI_EVENT_0024_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_23_23_43_36_WI_EVENT_0024_CONFIRM.md
@@ -1,0 +1,50 @@
+---
+execution_id: 2026_07_23_23_43_36_WI_EVENT_0024_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0024_CONFIRM)[2026-07-23T23:43:27-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_23_17_26_52_WI_EVENT_0024
+pr: https://github.com/xenotaur/LCATS/pull/148
+commit: 32d2757
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/148
+session_transcript: pending
+created_at: 2026-07-23T23:43:36-04:00
+---
+
+# Summary
+
+Pre-merge verification of the review fixes pushed to PR #148 (WI-EVENT-0024) via /lrh-confirm-fixes: independently re-check the current HEAD diff against each of the 10 open review threads, resolve the ones it plainly satisfies, and surface anything else.
+
+# Result
+
+Gathered all 10 unresolved threads on PR #148 via `lrh github threads --mode raw --state all` filtered to `isResolved == false` (all bot-authored: chatgpt-codex-connector x7, copilot-pull-request-reviewer x3, one copilot thread overlapping a codex thread on the same code path).
+
+Per the user's explicit choice, fresh-eyes classification (Step 3) was dispatched to a cold subagent (no session memory — only the PR URL, the 10 comment bodies, and instructions to read the live diff) rather than classified inline, since this session authored the fixes being verified. The subagent checked out the PR branch independently, traced each code path against the actual current diff, and additionally ran the test suite itself.
+
+Verdict: **10 of 10 Clear-satisfied** — every thread's concern is plainly resolved by the current diff. No Unaddressed, Partial, Ambiguous, or Problematic-resolution/Problematic-comment findings. One non-blocking caveat noted: the Unicode-boundary fix (comment #7) is a tested, contiguous, non-lossy improvement over the original bug but is not a mathematically perfect byte-boundary mapping for adversarial multi-byte splits — does not affect the verdict.
+
+User confirmed the full batch. All 10 threads resolved via `gh api graphql resolveReviewThread`:
+- discussion_r3641512185 (P1, entity extraction failure propagation)
+- discussion_r3641512188 (P1, event call bypassing extractor error handling)
+- discussion_r3641512191 (P1, punctuation in word-rate denominator)
+- discussion_r3641512194 (P1, repeated evidence quote disambiguation)
+- discussion_r3641512198 (P2, ungrounded ghost entities)
+- discussion_r3641512199 (P2, tokenizer stub in fixed-chunk tests)
+- discussion_r3641512203 (P2, Unicode boundary preservation in fixed-token chunks)
+- discussion_r3641515163 (copilot, same code path as discussion_r3641512188)
+- discussion_r3641515186 (copilot, NLP backend stub in end-to-end processor tests)
+- discussion_r3641515201 (copilot, stanza/spacy moved to optional extras)
+
+Thread-resolution verdict (Step 6): **green** — every verifiable thread resolved, no exceptions remain open.
+
+# Validation
+
+- Subagent independently ran `python -m pytest tests/analysis_tests/event_role_world_test.py -v` on the checked-out PR branch: 38 passed, 0 failed, 0 skipped (both spaCy and Stanza models happened to be installed in that environment).
+- Provisional CI (pre-confirm-commit, `gh pr checks 148 --json name,state,bucket`; this repo has no required-status-checks configured, per prior confirmation, so the unfiltered check list is authoritative): lint, test, coverage all SUCCESS.
+- `lrh validate` run from `lcats/` after this record was written: 0 errors (pre-existing owner-field warnings only, unrelated to this change).
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- CI must be re-checked against the post-push HEAD SHA (this record's own commit) before reporting final merge readiness — see the readiness report that follows this record's push.

--- a/lcats/project/executions/WI-EVENT-0024/2026_07_23_17_26_52_WI_EVENT_0024.md
+++ b/lcats/project/executions/WI-EVENT-0024/2026_07_23_17_26_52_WI_EVENT_0024.md
@@ -1,0 +1,98 @@
+---
+execution_id: 2026_07_23_17_26_52_WI_EVENT_0024
+prompt_id: PROMPT(WI-EVENT-0024:WI_EVENT_0024)[2026-07-23T16:20:26-04:00]
+work_item: WI-EVENT-0024
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/148
+commit: fae44ec
+created_at: 2026-07-23T17:26:52-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-EVENT-0024.md
+session_transcript: pending
+---
+
+# Summary
+
+Implemented `WI-EVENT-0024`: stages 1-5 of the Event-Role-World
+extractor's staged pipeline (input contract, surface features,
+entity/participant, event/semantic-role, temporal/spatial anchors),
+reusing the existing scene/sequel segment substrate as the stage-1 input
+contract. Before implementing, resolved a design ambiguity with the user
+(spaCy vs. Stanza API differences, and whether to hide them behind a
+swappable interface) and a scope-blocking acceptance-criteria tension
+(deferred NLP-library adoption vs. this WI's literal "syntactic,
+morphological" requirement) via explicit user decisions.
+
+# Result
+
+- Created `lcats/lcats/analysis/event_role_world/` package: `schema.py`
+  (7 dataclasses per the proposal's Core schema sketch, plus
+  `SurfaceFeatures`/`SegmentWorldAnnotation` and
+  `validate_segment_annotation`), `nlp_backend.py` (`NLPBackend` Protocol
+  mirroring `lcats.llm.backend.LLMBackend` — `StanzaBackend`,
+  `SpacyBackend`, `FakeNLPBackend` — normalizing both toolkits' differing
+  `head` representations (spaCy: `Token` object reference; Stanza:
+  integer index) to one CoNLL-U-aligned `TokenRecord` shape),
+  `surface_feature_extractor.py` (stage 2, consumes `NLPBackend` only),
+  `entity_extractor.py` (stage 3, LLM `tool=` call), `event_extractor.py`
+  (stages 4-5, LLM `tool=` call, entity IDs from stage 3 interpolated into
+  the prompt), `baseline.py` (fixed-token chunking via `tiktoken` +
+  per-1000-word rate comparison), `processor.py` (orchestrates all passes,
+  captures `PassUsage` — token counts, model, elapsed time — per pass, not
+  just call counts).
+- Extended `lcats.analysis.llm_extractor.JSONPromptExtractor` with an
+  optional `tool_schema` parameter (backward-compatible; all 75 existing
+  tests pass unmodified) rather than writing a separate extractor class,
+  per user decision.
+- Added `stanza` and `spacy` to `lcats/pyproject.toml`; installed both
+  packages plus the English models (`en_core_web_sm`, Stanza `en`
+  tokenize/pos/lemma/depparse) in this environment and verified both
+  backends produce correctly-normalized output against real text before
+  writing formal tests.
+- Fixed a real bug found during manual smoke-testing: an early draft of
+  `process_segment` made a wasted, discarded LLM call before the real
+  event-extraction call — removed before it reached tests or the PR.
+- Revised `WI-EVENT-0024.md` (Scope, Required Changes, acceptance criteria
+  frontmatter and body, Risk Notes) to reflect the swappable-backend
+  architecture, the adopted libraries, and the resolved acceptance-criteria
+  tension.
+- Encountered and fixed a `black` version-skew issue mid-session: local
+  `pip install stanza spacy` had upgraded `black` to 26.3.1 against the
+  repo's pinned 25.11.0, which caused `scripts/format` to also reformat an
+  unrelated pre-existing file (`lcats/gettenberg/metadata.py`). Reverted
+  that unrelated change and reinstalled the pinned `black` version before
+  re-running formatting — no unrelated files are in this PR's diff.
+
+# Validation
+
+- `scripts/format --check --diff` — 160 files unchanged
+- `scripts/lint` — ruff and black checks passed (after fixing one real
+  `F401` unused-import error in `surface_feature_extractor.py`)
+- `scripts/test` — 1372 tests OK (1337 pre-existing + 35 new); all
+  pre-existing tests pass unmodified, confirming the `JSONPromptExtractor`
+  extension is backward-compatible
+- `lrh validate` — 0 errors, 31 pre-existing warnings unrelated to this
+  change
+- Both `StanzaBackend` and `SpacyBackend` verified against real downloaded
+  models (`TestRealNLPBackends`), each independently skippable via
+  `@unittest.skipUnless` if its model isn't present in a clean checkout,
+  per LCATS's offline/no-network-CI constraint
+- Full pipeline manually smoke-tested end-to-end (real NLP backend + a
+  sequenced fake LLM backend) before the formal test suite was written,
+  surfacing the wasted-call bug above
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Neither Stanza's nor spaCy's accuracy on this corpus's older/translated
+  prose has been benchmarked — `WI-EVENT-0025`'s recommended stratified
+  accuracy sample was not part of this work item's scope and should be
+  run before treating extractor output as reliable for genre-comparison
+  claims.
+- Stages 6-7 (relation, discourse/SF tag), stage 8 (optional hypothesis
+  pass), and stage 9 (validation/export) remain out of scope, per this
+  WI's forbidden_actions and Non-Goals — expected as follow-up work items.
+- Recommend `/lrh-review-response` on PR #148 once reviewer comments
+  arrive.

--- a/lcats/project/work_items/proposed/WI-EVENT-0024.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0024.md
@@ -35,7 +35,7 @@ forbidden_actions:
 acceptance:
   - New Event-Role-World object schemas (EvidenceSpan, EntityMention, Entity, SemanticRole, Event, TemporalAnchor, SpatialAnchor) are defined and validated
   - Extraction calls for these schemas use the backend's existing tool= structured-output path, not json_object mode
-  - Given existing LCATS story JSON plus segments, the extractor produces surface-feature (lexical, syntactic, morphological), entity/participant, event/semantic-role, and temporal/spatial anchor annotations per segment
+  - Given existing LCATS story JSON plus segments, the extractor produces real syntactic/morphological surface features via a swappable NLPBackend (Stanza and spaCy both supported), plus entity/participant, event/semantic-role, and temporal/spatial anchor annotations per segment
   - Per-pass LLM-backed calls record token counts, model, and elapsed time (not just call counts)
   - A fixed-chunk-vs-segment comparison is produced by running the same extractor over both scene/sequel segments and fixed-token chunks, per the proposal's Cost and baseline requirements section
   - lrh validate reports 0 errors and scripts/test passes after all files are written
@@ -46,12 +46,15 @@ required_evidence:
 artifacts_expected:
   - lcats/lcats/analysis/event_role_world/__init__.py
   - lcats/lcats/analysis/event_role_world/schema.py
+  - lcats/lcats/analysis/event_role_world/nlp_backend.py
   - lcats/lcats/analysis/event_role_world/processor.py
   - lcats/lcats/analysis/event_role_world/surface_feature_extractor.py
   - lcats/lcats/analysis/event_role_world/entity_extractor.py
   - lcats/lcats/analysis/event_role_world/event_extractor.py
   - lcats/lcats/analysis/event_role_world/baseline.py
   - lcats/tests/analysis_tests/event_role_world_test.py
+  - lcats/lcats/analysis/llm_extractor.py (extended, not new)
+  - lcats/pyproject.toml (adds stanza, spacy dependencies)
 ---
 
 ## Summary
@@ -107,20 +110,39 @@ whenever the workstream chooses to pick it up.
   running the same extractor over both scene/sequel segments and
   fixed-token chunks, per the proposal's "Cost and baseline requirements"
   section.
+- **Stage 2 surface features (revised from the original scope):**
+  `WI-EVENT-0025`'s NLP-library evaluation
+  (`project/design/event-role-world-surface-feature-nlp-evaluation.md`)
+  recommended deferring library adoption, which created a real tension with
+  this WI's own literal acceptance criterion requiring "syntactic,
+  morphological" output — a dependency-free heuristic cannot produce that.
+  Per an explicit follow-up decision, this work item resolves that tension
+  by **adopting real NLP libraries now** (Stanza first, for near-term
+  multilingual direction; spaCy also supported) rather than narrowing the
+  acceptance criterion. Both libraries are hidden behind a swappable
+  `NLPBackend` Protocol (`nlp_backend.py`), mirroring
+  `lcats.llm.backend.LLMBackend`'s existing pattern
+  (`lcats/lcats/llm/backend.py:31-68`), so the library choice remains
+  swappable rather than locked in.
 
 ## Required Changes
 
 1. Create `lcats/lcats/analysis/event_role_world/` package (`__init__.py`,
-   `schema.py` for the object definitions, `processor.py` for pipeline
-   orchestration, `surface_feature_extractor.py` for stage 2,
-   `entity_extractor.py` for stage 3, `event_extractor.py` for stages 4-5,
-   `baseline.py` for the fixed-chunk-vs-segment comparison) — following the
-   proposal's "Suggested downstream module layout" as a starting point, not
-   a requirement (the proposal itself notes this is "a future LCATS
-   implementation sketch, not an LRH implementation requirement").
+   `schema.py` for the object definitions, `nlp_backend.py` for the
+   swappable NLP-toolkit Protocol (`StanzaBackend`, `SpacyBackend`,
+   `FakeNLPBackend`), `processor.py` for pipeline orchestration,
+   `surface_feature_extractor.py` for stage 2, `entity_extractor.py` for
+   stage 3, `event_extractor.py` for stages 4-5, `baseline.py` for the
+   fixed-chunk-vs-segment comparison) — following the proposal's "Suggested
+   downstream module layout" as a starting point, not a requirement (the
+   proposal itself notes this is "a future LCATS implementation sketch, not
+   an LRH implementation requirement").
 2. Wire extraction calls through the backend's existing `tool=` parameter
    with a JSON Schema per object type, per `00_proposal.md`'s
-   "Implementation prerequisites" section.
+   "Implementation prerequisites" section. Extends
+   `lcats.analysis.llm_extractor.JSONPromptExtractor` with an optional
+   `tool_schema` parameter (backward-compatible; existing callers unaffected)
+   rather than writing a separate extractor class, per design decision.
 3. Add token/model/elapsed-time capture to each LLM-backed pass, using the
    `input_tokens`/`output_tokens`/`model` fields already returned by
    `BackendResponse` (`lcats/lcats/llm/backend.py`).
@@ -132,9 +154,11 @@ whenever the workstream chooses to pick it up.
 5. Implement the fixed-chunk-vs-segment baseline comparison required by the
    proposal's "Cost and baseline requirements" section.
 6. Add `lcats/tests/analysis_tests/event_role_world_test.py` covering
-   schema validation and each extraction pass, including surface features
-   and the baseline comparison.
-7. Add `WI-EVENT-0024` to `WS-EVENT-ROLE-WORLD`'s `work_items:` list.
+   schema validation, each extraction pass, the baseline comparison, and
+   both real `NLPBackend` implementations (each skipped independently, not
+   failed, if its model isn't downloaded locally).
+7. Add `stanza` and `spacy` to `lcats/pyproject.toml` dependencies.
+8. Add `WI-EVENT-0024` to `WS-EVENT-ROLE-WORLD`'s `work_items:` list.
 
 ## Non-Goals
 
@@ -155,17 +179,21 @@ whenever the workstream chooses to pick it up.
 - Extraction calls for these schemas use the backend's existing `tool=`
   structured-output path, not `json_object` mode.
 - Given existing LCATS story JSON plus segments, the extractor produces
-  surface-feature (lexical, syntactic, morphological), entity/participant,
-  event/semantic-role, and temporal/spatial anchor annotations per segment
-  — an implementation that skips stage 2 (surface features) does not
-  satisfy this item.
+  real syntactic/morphological surface features (POS tags, dependency
+  relations, morphological features — not a lexical-only heuristic) via a
+  swappable `NLPBackend`, with both Stanza and spaCy implementations
+  available, plus entity/participant, event/semantic-role, and
+  temporal/spatial anchor annotations per segment — an implementation that
+  skips stage 2 (surface features) does not satisfy this item.
 - Per-pass LLM-backed calls record token counts, model, and elapsed time
   (not just call counts).
 - A fixed-chunk-vs-segment comparison is produced by running the same
   extractor over both scene/sequel segments and fixed-token chunks, per the
   proposal's Cost and baseline requirements section.
 - `lrh validate` reports 0 errors and `scripts/test` passes after all files
-  are written.
+  are written. Tests requiring a downloaded NLP model skip (not fail) when
+  the model isn't present, so `scripts/test` stays runnable in a clean
+  checkout per LCATS's offline/no-network-CI constraint.
 
 ## Validation
 
@@ -182,6 +210,13 @@ whenever the workstream chooses to pick it up.
 - The backend `tool=` path has not previously been exercised for this many
   distinct object schemas in one pipeline; watch for schema-size or
   tool-choice-forcing limits during implementation.
+- Adopting Stanza adds a real PyTorch dependency (not the hypothetical
+  discussed in `WI-EVENT-0025`'s evaluation), meaningfully increasing
+  install size and download time. Neither Stanza's nor spaCy's accuracy on
+  this corpus's older/translated prose has been benchmarked — the
+  evaluation's own recommendation to run a stratified accuracy sample
+  before treating the output as reliable still applies and was not part of
+  this work item's scope.
 
 ## Related Workstream and Designs
 

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
    "anthropic",
    "openai>=1.0.0",
    "python-dotenv",
+   "stanza",
+   "spacy",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/lcats/pyproject.toml
+++ b/lcats/pyproject.toml
@@ -26,8 +26,6 @@ dependencies = [
    "anthropic",
    "openai>=1.0.0",
    "python-dotenv",
-   "stanza",
-   "spacy",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -45,6 +43,10 @@ lcats = "lcats.cli:main"
 "lcats.analysis.corpus" = ["allowlists/*.json"]
 
 [project.optional-dependencies]
+nlp = [
+    "stanza",
+    "spacy",
+]
 test = [
     "ruff",
     "black==25.11.0",

--- a/lcats/tests/analysis_tests/event_role_world_test.py
+++ b/lcats/tests/analysis_tests/event_role_world_test.py
@@ -1,0 +1,646 @@
+"""Unit tests for lcats.analysis.event_role_world."""
+
+import unittest
+
+from lcats.llm import backend as llm_backend
+from lcats.analysis.event_role_world import baseline
+from lcats.analysis.event_role_world import entity_extractor
+from lcats.analysis.event_role_world import event_extractor
+from lcats.analysis.event_role_world import nlp_backend
+from lcats.analysis.event_role_world import processor
+from lcats.analysis.event_role_world import schema
+from lcats.analysis.event_role_world import surface_feature_extractor
+
+
+def _spacy_model_available() -> bool:
+    """Return True iff the "en_core_web_sm" spaCy model is installed.
+
+    Per the LCATS-specific offline/no-network-CI constraint recorded in
+    project/design/event-role-world-surface-feature-nlp-evaluation.md, tests
+    that require a downloaded NLP model must skip (not fail) in a clean
+    checkout where the model hasn't been fetched.
+    """
+    try:
+        import spacy
+
+        spacy.load("en_core_web_sm")
+        return True
+    except Exception:  # noqa: BLE001 - any load failure means "unavailable"
+        return False
+
+
+_SPACY_AVAILABLE = _spacy_model_available()
+
+
+class _SequencedFakeBackend:
+    """LLMBackend test double returning a fixed sequence of tool results.
+
+    Unlike lcats.llm.fake_backend.FakeBackend (one fixed response for every
+    call), this returns a different tool_result per call in order — needed
+    to test a pipeline that makes multiple distinct LLM-backed passes.
+    """
+
+    def __init__(self, tool_results):
+        self._results = list(tool_results)
+        self.calls = []
+
+    def complete(self, **kwargs):
+        self.calls.append(kwargs)
+        result = self._results.pop(0)
+        return llm_backend.BackendResponse(
+            text="",
+            tool_result=result,
+            model="fake-1.0",
+            input_tokens=10,
+            output_tokens=5,
+            raw=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: schema
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceSpan(unittest.TestCase):
+    def test_validate_accepts_matching_span(self):
+        text = "The machine hummed."
+        span = schema.EvidenceSpan(start_char=4, end_char=11, quote="machine")
+        self.assertIsNone(span.validate(text))
+
+    def test_validate_rejects_out_of_bounds(self):
+        text = "short"
+        span = schema.EvidenceSpan(start_char=0, end_char=100, quote="short")
+        self.assertIsNotNone(span.validate(text))
+
+    def test_validate_rejects_text_mismatch(self):
+        text = "The machine hummed."
+        span = schema.EvidenceSpan(start_char=4, end_char=11, quote="wrong text here")
+        error = span.validate(text)
+        self.assertIsNotNone(error)
+        self.assertIn("mismatch", error)
+
+    def test_validate_rejects_empty_span(self):
+        span = schema.EvidenceSpan(start_char=5, end_char=5, quote="")
+        self.assertIsNotNone(span.validate("some text"))
+
+
+class TestResolveEvidence(unittest.TestCase):
+    def test_finds_quote(self):
+        text = "The old machine hummed."
+        evidence = schema.resolve_evidence("machine", text)
+        self.assertIsNotNone(evidence)
+        self.assertEqual(evidence.quote, "machine")
+        self.assertEqual(text[evidence.start_char : evidence.end_char], "machine")
+
+    def test_returns_none_for_missing_quote(self):
+        self.assertIsNone(schema.resolve_evidence("not present", "The machine hummed."))
+
+    def test_returns_none_for_empty_quote(self):
+        self.assertIsNone(schema.resolve_evidence("", "The machine hummed."))
+
+
+class TestValidateSegmentAnnotation(unittest.TestCase):
+    def test_clean_annotation_has_no_errors(self):
+        text = "The machine hummed."
+        evidence = schema.EvidenceSpan(start_char=4, end_char=11, quote="machine")
+        entity = schema.Entity(
+            entity_id="e1",
+            canonical_name="the machine",
+            entity_type="machine_or_artifact",
+            mention_ids=["m1"],
+        )
+        mention = schema.EntityMention(
+            mention_id="m1", entity_id="e1", text="machine", evidence=evidence
+        )
+        annotation = schema.SegmentWorldAnnotation(
+            segment_id=1, entities=[entity], mentions=[mention]
+        )
+        errors = schema.validate_segment_annotation(annotation, text)
+        self.assertEqual(errors, [])
+
+    def test_dangling_mention_entity_reference_is_an_error(self):
+        text = "The machine hummed."
+        evidence = schema.EvidenceSpan(start_char=4, end_char=11, quote="machine")
+        mention = schema.EntityMention(
+            mention_id="m1",
+            entity_id="unknown_entity",
+            text="machine",
+            evidence=evidence,
+        )
+        annotation = schema.SegmentWorldAnnotation(segment_id=1, mentions=[mention])
+        errors = schema.validate_segment_annotation(annotation, text)
+        self.assertTrue(any("unknown entity" in e for e in errors))
+
+    def test_dangling_event_anchor_reference_is_an_error(self):
+        text = "The machine hummed."
+        evidence = schema.EvidenceSpan(start_char=4, end_char=11, quote="machine")
+        event = schema.Event(
+            event_id="ev1",
+            predicate="hummed",
+            event_type="sound",
+            evidence=evidence,
+            temporal_anchor_ids=["missing_anchor"],
+        )
+        annotation = schema.SegmentWorldAnnotation(segment_id=1, events=[event])
+        errors = schema.validate_segment_annotation(annotation, text)
+        self.assertTrue(any("unknown anchor" in e for e in errors))
+
+    def test_misaligned_evidence_is_an_error(self):
+        text = "The machine hummed."
+        bad_evidence = schema.EvidenceSpan(start_char=0, end_char=7, quote="machine")
+        event = schema.Event(
+            event_id="ev1",
+            predicate="hummed",
+            event_type="sound",
+            evidence=bad_evidence,
+        )
+        annotation = schema.SegmentWorldAnnotation(segment_id=1, events=[event])
+        errors = schema.validate_segment_annotation(annotation, text)
+        self.assertTrue(any("mismatch" in e for e in errors))
+
+
+# ---------------------------------------------------------------------------
+# Tests: nlp_backend
+# ---------------------------------------------------------------------------
+
+
+class TestFakeNLPBackend(unittest.TestCase):
+    def test_returns_fixed_sentences_and_records_calls(self):
+        token = nlp_backend.TokenRecord(
+            text="hi",
+            lemma="hi",
+            upos="INTJ",
+            xpos="UH",
+            feats="",
+            head_index=0,
+            deprel="root",
+        )
+        fixed = [nlp_backend.SentenceRecord(tokens=[token])]
+        backend = nlp_backend.FakeNLPBackend(sentences=fixed)
+
+        result = backend.analyze("hi")
+
+        self.assertEqual(result, fixed)
+        self.assertEqual(backend.calls, ["hi"])
+
+    def test_default_sentences_is_empty_list(self):
+        backend = nlp_backend.FakeNLPBackend()
+        self.assertEqual(backend.analyze("anything"), [])
+
+
+class TestTokenRecord(unittest.TestCase):
+    def test_to_dict_round_trips_fields(self):
+        token = nlp_backend.TokenRecord(
+            text="ran",
+            lemma="run",
+            upos="VERB",
+            xpos="VBD",
+            feats="Tense=Past",
+            head_index=0,
+            deprel="root",
+        )
+        d = token.to_dict()
+        self.assertEqual(d["text"], "ran")
+        self.assertEqual(d["upos"], "VERB")
+        self.assertEqual(d["head_index"], 0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: surface_feature_extractor
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSurfaceFeatures(unittest.TestCase):
+    def test_counts_words_and_sentences_from_backend_tokens(self):
+        tok = lambda t: nlp_backend.TokenRecord(  # noqa: E731
+            text=t, lemma=t, upos="X", xpos="X", feats="", head_index=0, deprel="root"
+        )
+        sentences = [
+            nlp_backend.SentenceRecord(tokens=[tok("The"), tok("cat"), tok("ran")]),
+            nlp_backend.SentenceRecord(tokens=[tok("It"), tok("stopped")]),
+        ]
+        backend = nlp_backend.FakeNLPBackend(sentences=sentences)
+
+        features = surface_feature_extractor.extract_surface_features(
+            "The cat ran. It stopped.", backend, backend_name="fake"
+        )
+
+        self.assertEqual(features.word_count, 5)
+        self.assertEqual(features.sentence_count, 2)
+        self.assertEqual(features.avg_sentence_length, 2.5)
+        self.assertEqual(features.backend_name, "fake")
+        self.assertEqual(len(features.tokens), 5)
+
+    def test_empty_text_produces_zeroed_features(self):
+        backend = nlp_backend.FakeNLPBackend()
+        features = surface_feature_extractor.extract_surface_features("", backend)
+        self.assertEqual(features.word_count, 0)
+        self.assertEqual(features.sentence_count, 0)
+        self.assertEqual(features.avg_sentence_length, 0.0)
+        self.assertEqual(features.avg_word_length, 0.0)
+
+    def test_whitespace_only_text_does_not_call_backend(self):
+        backend = nlp_backend.FakeNLPBackend()
+        surface_feature_extractor.extract_surface_features("   \n  ", backend)
+        self.assertEqual(backend.calls, [])
+
+
+class TestMakeNlpBackend(unittest.TestCase):
+    def test_rejects_unknown_backend_name(self):
+        with self.assertRaises(ValueError):
+            surface_feature_extractor.make_nlp_backend("not_a_real_backend")
+
+
+def _stanza_model_available() -> bool:
+    """Return True iff the Stanza English model has been downloaded."""
+    try:
+        import stanza
+
+        stanza.Pipeline(
+            lang="en", processors="tokenize,pos,lemma,depparse", download_method=None
+        )
+        return True
+    except Exception:  # noqa: BLE001 - any load failure means "unavailable"
+        return False
+
+
+class TestRealNLPBackends(unittest.TestCase):
+    """Direct integration coverage for both supported real backends.
+
+    Each backend's test skips independently if its model isn't downloaded,
+    so a checkout with only one model present still gets partial coverage
+    rather than an all-or-nothing skip.
+    """
+
+    @unittest.skipUnless(
+        _SPACY_AVAILABLE,
+        "en_core_web_sm not installed; run `python -m spacy download en_core_web_sm`",
+    )
+    def test_spacy_backend_produces_normalized_tokens(self):
+        backend = nlp_backend.SpacyBackend()
+        sentences = backend.analyze("The old machine hummed.")
+        self.assertEqual(len(sentences), 1)
+        tokens = sentences[0].tokens
+        self.assertTrue(any(t.upos == "VERB" for t in tokens))
+        # Exactly one token should be the sentence root (head_index == 0).
+        self.assertEqual(sum(1 for t in tokens if t.head_index == 0), 1)
+
+    @unittest.skipUnless(
+        _stanza_model_available(),
+        "Stanza 'en' model not downloaded; run stanza.download('en')",
+    )
+    def test_stanza_backend_produces_normalized_tokens(self):
+        backend = nlp_backend.StanzaBackend()
+        sentences = backend.analyze("The old machine hummed.")
+        self.assertEqual(len(sentences), 1)
+        tokens = sentences[0].tokens
+        self.assertTrue(any(t.upos == "VERB" for t in tokens))
+        self.assertEqual(sum(1 for t in tokens if t.head_index == 0), 1)
+
+
+# ---------------------------------------------------------------------------
+# Tests: entity_extractor
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEntities(unittest.TestCase):
+    def test_builds_entity_and_mention_with_resolved_evidence(self):
+        text = "The old machine hummed."
+        tool_result = {
+            "entities": [
+                {
+                    "entity_id": "e1",
+                    "canonical_name": "the machine",
+                    "entity_type": "machine_or_artifact",
+                    "aliases": ["it"],
+                    "actant_roles": ["instrument"],
+                    "confidence": 0.9,
+                    "mentions": [
+                        {
+                            "mention_id": "m1",
+                            "text": "the machine",
+                            "quote": "old machine",
+                        }
+                    ],
+                }
+            ]
+        }
+
+        entities, mentions = entity_extractor.build_entities(tool_result, text)
+
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(entities[0].entity_id, "e1")
+        self.assertEqual(entities[0].mention_ids, ["m1"])
+        self.assertEqual(len(mentions), 1)
+        self.assertEqual(mentions[0].evidence.quote, "old machine")
+
+    def test_drops_mention_with_unresolvable_quote(self):
+        text = "The old machine hummed."
+        tool_result = {
+            "entities": [
+                {
+                    "entity_id": "e1",
+                    "canonical_name": "the machine",
+                    "entity_type": "machine_or_artifact",
+                    "mentions": [
+                        {"mention_id": "m1", "text": "x", "quote": "not in the text"}
+                    ],
+                }
+            ]
+        }
+
+        entities, mentions = entity_extractor.build_entities(tool_result, text)
+
+        self.assertEqual(mentions, [])
+        self.assertEqual(entities[0].mention_ids, [])
+
+    def test_empty_tool_result_produces_no_entities(self):
+        entities, mentions = entity_extractor.build_entities({}, "some text")
+        self.assertEqual(entities, [])
+        self.assertEqual(mentions, [])
+
+
+# ---------------------------------------------------------------------------
+# Tests: event_extractor
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEventsAndAnchors(unittest.TestCase):
+    def test_builds_event_with_semantic_role_and_anchors(self):
+        text = "The machine hummed in the pit for decades."
+        tool_result = {
+            "temporal_anchors": [
+                {"anchor_id": "t1", "text": "decades", "quote": "for decades"}
+            ],
+            "spatial_anchors": [
+                {"anchor_id": "s1", "text": "the pit", "quote": "in the pit"}
+            ],
+            "events": [
+                {
+                    "event_id": "ev1",
+                    "predicate": "hummed",
+                    "event_type": "sound_emission",
+                    "quote": "hummed",
+                    "modality": "actual",
+                    "confidence": 0.8,
+                    "temporal_anchor_ids": ["t1"],
+                    "spatial_anchor_ids": ["s1"],
+                    "semantic_roles": [
+                        {
+                            "role": "agent",
+                            "filler_entity_id": "e1",
+                            "quote": "The machine",
+                        }
+                    ],
+                }
+            ],
+        }
+
+        events, temporal_anchors, spatial_anchors = (
+            event_extractor.build_events_and_anchors(tool_result, text)
+        )
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event_id, "ev1")
+        self.assertEqual(len(events[0].semantic_roles), 1)
+        self.assertEqual(events[0].semantic_roles[0].filler_entity_id, "e1")
+        self.assertEqual(len(temporal_anchors), 1)
+        self.assertEqual(len(spatial_anchors), 1)
+
+    def test_drops_event_with_unresolvable_quote(self):
+        text = "The machine hummed."
+        tool_result = {
+            "events": [
+                {
+                    "event_id": "ev1",
+                    "predicate": "hummed",
+                    "event_type": "sound",
+                    "quote": "not present in text",
+                }
+            ]
+        }
+        events, _, _ = event_extractor.build_events_and_anchors(tool_result, text)
+        self.assertEqual(events, [])
+
+    def test_drops_semantic_role_with_unresolvable_quote_but_keeps_event(self):
+        text = "The machine hummed."
+        tool_result = {
+            "events": [
+                {
+                    "event_id": "ev1",
+                    "predicate": "hummed",
+                    "event_type": "sound",
+                    "quote": "hummed",
+                    "semantic_roles": [
+                        {"role": "agent", "filler_entity_id": "e1", "quote": "nowhere"}
+                    ],
+                }
+            ]
+        }
+        events, _, _ = event_extractor.build_events_and_anchors(tool_result, text)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].semantic_roles, [])
+
+
+# ---------------------------------------------------------------------------
+# Tests: baseline
+# ---------------------------------------------------------------------------
+
+
+class TestMakeFixedTokenChunks(unittest.TestCase):
+    def test_empty_text_produces_no_chunks(self):
+        self.assertEqual(baseline.make_fixed_token_chunks(""), [])
+
+    def test_chunks_cover_full_text_contiguously(self):
+        text = "The old machine hummed in the pit. " * 20
+        chunks = baseline.make_fixed_token_chunks(text, chunk_size_tokens=30)
+
+        self.assertGreater(len(chunks), 1)
+        self.assertEqual(chunks[0]["start_char"], 0)
+        self.assertEqual(chunks[-1]["end_char"], len(text))
+        for prev, nxt in zip(chunks, chunks[1:]):
+            self.assertEqual(prev["end_char"], nxt["start_char"])
+
+    def test_chunks_are_labeled_fixed_chunk(self):
+        chunks = baseline.make_fixed_token_chunks(
+            "some short text here", chunk_size_tokens=2
+        )
+        self.assertTrue(all(c["segment_type"] == "fixed_chunk" for c in chunks))
+
+
+class TestSummarizeAndCompare(unittest.TestCase):
+    def _annotation(self, word_count, n_entities, n_events):
+        return schema.SegmentWorldAnnotation(
+            segment_id=1,
+            surface_features=schema.SurfaceFeatures(
+                word_count=word_count,
+                sentence_count=1,
+                avg_sentence_length=word_count,
+                avg_word_length=4.0,
+            ),
+            entities=[
+                schema.Entity(
+                    entity_id=f"e{i}", canonical_name=f"e{i}", entity_type="x"
+                )
+                for i in range(n_entities)
+            ],
+            events=[
+                schema.Event(
+                    event_id=f"ev{i}",
+                    predicate="p",
+                    event_type="x",
+                    evidence=schema.EvidenceSpan(0, 1, "x"),
+                )
+                for i in range(n_events)
+            ],
+        )
+
+    def test_summarize_computes_per_1000_word_rates(self):
+        annotations = [self._annotation(word_count=500, n_entities=1, n_events=2)]
+        summary = baseline.summarize_annotations(annotations)
+        self.assertEqual(summary["total_word_count"], 500)
+        self.assertEqual(summary["entities_per_1000_words"], 2.0)
+        self.assertEqual(summary["events_per_1000_words"], 4.0)
+
+    def test_summarize_handles_zero_words_without_dividing_by_zero(self):
+        annotations = [self._annotation(word_count=0, n_entities=0, n_events=0)]
+        summary = baseline.summarize_annotations(annotations)
+        self.assertEqual(summary["entities_per_1000_words"], 0.0)
+
+    def test_compare_returns_both_strategies(self):
+        seg = [self._annotation(word_count=500, n_entities=1, n_events=1)]
+        chunk = [self._annotation(word_count=500, n_entities=2, n_events=2)]
+        comparison = baseline.compare_chunking_strategies(seg, chunk)
+        self.assertIn("segment", comparison)
+        self.assertIn("fixed_chunk", comparison)
+        self.assertEqual(comparison["fixed_chunk"]["entities_per_1000_words"], 4.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: processor (end-to-end with fakes)
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    _SPACY_AVAILABLE,
+    "en_core_web_sm not installed; run `python -m spacy download en_core_web_sm`",
+)
+class TestProcessSegments(unittest.TestCase):
+    def test_end_to_end_pipeline_with_fakes(self):
+        segment_text = "The old machine hummed in the pit. It had run for decades."
+
+        entity_tool_result = {
+            "entities": [
+                {
+                    "entity_id": "e1",
+                    "canonical_name": "the machine",
+                    "entity_type": "machine_or_artifact",
+                    "aliases": ["it"],
+                    "actant_roles": ["instrument"],
+                    "confidence": 0.9,
+                    "mentions": [
+                        {
+                            "mention_id": "m1",
+                            "text": "the machine",
+                            "quote": "old machine",
+                        }
+                    ],
+                }
+            ]
+        }
+        event_tool_result = {
+            "temporal_anchors": [
+                {"anchor_id": "t1", "text": "decades", "quote": "for decades"}
+            ],
+            "spatial_anchors": [
+                {"anchor_id": "s1", "text": "the pit", "quote": "in the pit"}
+            ],
+            "events": [
+                {
+                    "event_id": "ev1",
+                    "predicate": "hummed",
+                    "event_type": "sound_emission",
+                    "quote": "hummed",
+                    "modality": "actual",
+                    "confidence": 0.8,
+                    "temporal_anchor_ids": [],
+                    "spatial_anchor_ids": ["s1"],
+                    "semantic_roles": [
+                        {
+                            "role": "agent",
+                            "filler_entity_id": "e1",
+                            "quote": "old machine",
+                        }
+                    ],
+                }
+            ],
+        }
+        fake = _SequencedFakeBackend([entity_tool_result, event_tool_result])
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        result = processor.process_segments(
+            segment_text, segments, nlp_backend_name="spacy", llm_backend=fake
+        )
+
+        self.assertEqual(len(result["segments"]), 1)
+        seg = result["segments"][0]
+        self.assertEqual(len(seg["entities"]), 1)
+        self.assertEqual(len(seg["events"]), 1)
+        self.assertEqual(len(seg["temporal_anchors"]), 1)
+        self.assertEqual(len(seg["spatial_anchors"]), 1)
+        self.assertEqual(seg["validation_errors"], [])
+
+        # Exactly one LLM call for entities, one for events - not more.
+        self.assertEqual(len(fake.calls), 2)
+
+        # Cost/usage reporting: token counts, model, and elapsed time per
+        # pass - not just call counts (WI-EVENT-0024 acceptance criterion).
+        usage_by_pass = {u["pass_name"]: u for u in result["usage"]}
+        self.assertIn("surface_feature", usage_by_pass)
+        self.assertIn("entity", usage_by_pass)
+        self.assertIn("event_anchor", usage_by_pass)
+        self.assertFalse(usage_by_pass["surface_feature"]["is_llm_backed"])
+        self.assertTrue(usage_by_pass["entity"]["is_llm_backed"])
+        self.assertEqual(usage_by_pass["entity"]["input_tokens"], 10)
+        self.assertEqual(usage_by_pass["entity"]["model"], "fake-1.0")
+
+    def test_entity_ids_from_stage_3_are_passed_to_stage_4_5_prompt(self):
+        segment_text = "The machine hummed."
+        entity_tool_result = {
+            "entities": [
+                {
+                    "entity_id": "e1",
+                    "canonical_name": "the machine",
+                    "entity_type": "machine_or_artifact",
+                    "mentions": [
+                        {"mention_id": "m1", "text": "machine", "quote": "machine"}
+                    ],
+                }
+            ]
+        }
+        event_tool_result = {"events": []}
+        fake = _SequencedFakeBackend([entity_tool_result, event_tool_result])
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        processor.process_segments(
+            segment_text, segments, nlp_backend_name="spacy", llm_backend=fake
+        )
+
+        second_call_content = fake.calls[1]["messages"][0]["content"]
+        self.assertIn("e1", second_call_content)
+
+    def test_skips_segment_without_char_offsets(self):
+        fake = _SequencedFakeBackend([])
+        segments = [{"segment_id": 1, "start_char": None, "end_char": None}]
+
+        result = processor.process_segments(
+            "some text", segments, nlp_backend_name="spacy", llm_backend=fake
+        )
+
+        self.assertEqual(result["segments"], [])
+        self.assertEqual(fake.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/analysis_tests/event_role_world_test.py
+++ b/lcats/tests/analysis_tests/event_role_world_test.py
@@ -1,6 +1,7 @@
 """Unit tests for lcats.analysis.event_role_world."""
 
 import unittest
+import unittest.mock
 
 from lcats.llm import backend as llm_backend
 from lcats.analysis.event_role_world import baseline
@@ -352,8 +353,11 @@ class TestBuildEntities(unittest.TestCase):
 
         entities, mentions = entity_extractor.build_entities(tool_result, text)
 
+        # The entity's only mention failed to resolve, leaving it with no
+        # grounded evidence at all - it must be dropped entirely rather than
+        # surfaced as an ungrounded "ghost" entity with an empty mention list.
         self.assertEqual(mentions, [])
-        self.assertEqual(entities[0].mention_ids, [])
+        self.assertEqual(entities, [])
 
     def test_empty_tool_result_produces_no_entities(self):
         entities, mentions = entity_extractor.build_entities({}, "some text")
@@ -448,7 +452,47 @@ class TestBuildEventsAndAnchors(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+class _CharEncoder:
+    """Deterministic, network-free fake tiktoken.Encoding test double.
+
+    Operates at the Python-codepoint level (one "token" per character):
+    exactly reversible, so make_fixed_token_chunks' contiguous-coverage
+    invariants can be tested without depending on tiktoken's real vocab
+    data, per tests/AGENTS.md's determinism guidance.
+    """
+
+    def encode(self, text, **kwargs):
+        return [ord(c) for c in text]
+
+    def decode(self, tokens):
+        return "".join(chr(t) for t in tokens)
+
+
+class _ByteEncoder:
+    """Fake encoder operating at the UTF-8 byte level (one token per byte).
+
+    Mirrors real BPE tokenizers closely enough to test that chunk
+    boundaries falling mid-character (a multi-byte UTF-8 character split
+    across two chunks) still produce correct, non-overlapping,
+    non-duplicated char offsets - the exact failure mode a naive
+    per-chunk-decode approach is vulnerable to.
+    """
+
+    def encode(self, text, **kwargs):
+        return list(text.encode("utf-8"))
+
+    def decode(self, tokens):
+        return bytes(tokens).decode("utf-8", errors="ignore")
+
+
 class TestMakeFixedTokenChunks(unittest.TestCase):
+    def setUp(self):
+        self._encoder_patcher = unittest.mock.patch(
+            "lcats.analysis.story_analysis.get_encoder", return_value=_CharEncoder()
+        )
+        self._encoder_patcher.start()
+        self.addCleanup(self._encoder_patcher.stop)
+
     def test_empty_text_produces_no_chunks(self):
         self.assertEqual(baseline.make_fixed_token_chunks(""), [])
 
@@ -467,6 +511,24 @@ class TestMakeFixedTokenChunks(unittest.TestCase):
             "some short text here", chunk_size_tokens=2
         )
         self.assertTrue(all(c["segment_type"] == "fixed_chunk" for c in chunks))
+
+    def test_offsets_stay_contiguous_when_boundary_splits_a_multibyte_char(self):
+        with unittest.mock.patch(
+            "lcats.analysis.story_analysis.get_encoder", return_value=_ByteEncoder()
+        ):
+            # Each of these characters is multi-byte in UTF-8 (é: 2 bytes,
+            # 世/界: 3 bytes each, 🎉: 4 bytes), so a small chunk_size_tokens
+            # (byte count) is very likely to split at least one character's
+            # bytes across two chunks.
+            text = "café 世界 🎉 more plain text after the emoji to pad it out"
+            chunks = baseline.make_fixed_token_chunks(text, chunk_size_tokens=3)
+
+            self.assertGreater(len(chunks), 1)
+            self.assertEqual(chunks[0]["start_char"], 0)
+            self.assertEqual(chunks[-1]["end_char"], len(text))
+            for prev, nxt in zip(chunks, chunks[1:]):
+                self.assertEqual(prev["end_char"], nxt["start_char"])
+                self.assertLessEqual(prev["end_char"], nxt["end_char"])
 
 
 class TestSummarizeAndCompare(unittest.TestCase):
@@ -522,11 +584,25 @@ class TestSummarizeAndCompare(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
-@unittest.skipUnless(
-    _SPACY_AVAILABLE,
-    "en_core_web_sm not installed; run `python -m spacy download en_core_web_sm`",
-)
 class TestProcessSegments(unittest.TestCase):
+    """End-to-end processor tests using entirely faked LLM and NLP backends.
+
+    Runs deterministically in any environment, including a clean checkout
+    with no NLP models downloaded: make_nlp_backend is patched to return
+    FakeNLPBackend regardless of the requested backend name, so these tests
+    exercise process_segments' own logic (error propagation, entity-ID
+    threading, usage capture) without depending on a real model. Real
+    NLPBackend integration coverage lives in TestRealNLPBackends instead.
+    """
+
+    def setUp(self):
+        self._nlp_backend_patcher = unittest.mock.patch(
+            "lcats.analysis.event_role_world.surface_feature_extractor.make_nlp_backend",
+            return_value=nlp_backend.FakeNLPBackend(),
+        )
+        self._nlp_backend_patcher.start()
+        self.addCleanup(self._nlp_backend_patcher.stop)
+
     def test_end_to_end_pipeline_with_fakes(self):
         segment_text = "The old machine hummed in the pit. It had run for decades."
 
@@ -640,6 +716,111 @@ class TestProcessSegments(unittest.TestCase):
 
         self.assertEqual(result["segments"], [])
         self.assertEqual(fake.calls, [])
+
+    def test_entity_extraction_failure_is_recorded_not_silently_empty(self):
+        """A failed entity pass must not read as 'zero entities found'."""
+        segment_text = "The machine hummed."
+
+        class _NoToolResultBackend:
+            def __init__(self):
+                self.calls = 0
+
+            def complete(self, **kwargs):
+                self.calls += 1
+                if self.calls == 1:
+                    # Simulate a tool-call failure on the entity pass: no
+                    # tool_result, which JSONPromptExtractor.extract()
+                    # turns into an "empty_tool_result" api_error.
+                    return llm_backend.BackendResponse(
+                        text="",
+                        tool_result=None,
+                        model="fake-1.0",
+                        input_tokens=5,
+                        output_tokens=0,
+                        raw=None,
+                    )
+                return llm_backend.BackendResponse(
+                    text="",
+                    tool_result={"events": []},
+                    model="fake-1.0",
+                    input_tokens=5,
+                    output_tokens=2,
+                    raw=None,
+                )
+
+        backend = _NoToolResultBackend()
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        result = processor.process_segments(
+            segment_text, segments, nlp_backend_name="spacy", llm_backend=backend
+        )
+
+        seg = result["segments"][0]
+        self.assertEqual(seg["entities"], [])
+        self.assertTrue(
+            any("entity extraction failed" in e for e in seg["extraction_errors"]),
+            seg["extraction_errors"],
+        )
+
+    def test_event_pass_failure_does_not_abort_remaining_segments(self):
+        """A transient failure on one segment's event pass must not lose
+        every other segment's already-processed results (the bug: bypassing
+        JSONPromptExtractor.extract()'s exception handling let a raised
+        exception propagate out of process_segments entirely)."""
+        segment_text_1 = "The machine hummed."
+        segment_text_2 = "It stopped."
+
+        entity_result_empty = {"entities": []}
+
+        class _RaisesOnSecondCallBackend:
+            def __init__(self):
+                self.calls = 0
+
+            def complete(self, **kwargs):
+                self.calls += 1
+                # Call order per segment: entity, event. Raise only on
+                # segment 1's event call (call #2).
+                if self.calls == 2:
+                    raise RuntimeError("simulated transient provider failure")
+                return llm_backend.BackendResponse(
+                    text="",
+                    tool_result=(
+                        entity_result_empty if self.calls % 2 == 1 else {"events": []}
+                    ),
+                    model="fake-1.0",
+                    input_tokens=5,
+                    output_tokens=2,
+                    raw=None,
+                )
+
+        backend = _RaisesOnSecondCallBackend()
+        segments = [
+            {"segment_id": 1, "start_char": 0, "end_char": len(segment_text_1)},
+            {
+                "segment_id": 2,
+                "start_char": len(segment_text_1) + 1,
+                "end_char": len(segment_text_1) + 1 + len(segment_text_2),
+            },
+        ]
+        story_text = segment_text_1 + " " + segment_text_2
+
+        # Must not raise - the transient failure on segment 1's event call
+        # is caught and recorded, not propagated out of process_segments.
+        result = processor.process_segments(
+            story_text, segments, nlp_backend_name="spacy", llm_backend=backend
+        )
+
+        self.assertEqual(len(result["segments"]), 2)
+        seg1 = result["segments"][0]
+        self.assertTrue(
+            any(
+                "event/anchor extraction failed" in e for e in seg1["extraction_errors"]
+            ),
+            seg1["extraction_errors"],
+        )
+        # Segment 2 still got processed despite segment 1's failure.
+        seg2 = result["segments"][1]
+        self.assertEqual(seg2["extraction_errors"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements `WI-EVENT-0024`: stages 1-5 of the Event-Role-World extractor's staged pipeline (input contract, surface features, entity/participant, event/semantic-role, temporal/spatial anchors), reusing the existing scene/sequel segment substrate as the stage-1 input contract.

**Key design decision — swappable NLP backend, both libraries supported:** `WI-EVENT-0025`'s NLP-library evaluation recommended deferring library adoption, which created a real tension with this WI's own acceptance criteria (requiring "syntactic, morphological" output that a dependency-free heuristic can't produce). Resolved by adopting real libraries now rather than narrowing the criterion — **both Stanza and spaCy** are supported behind a new `NLPBackend` Protocol (`nlp_backend.py`) that mirrors `lcats.llm.backend.LLMBackend`'s existing swappable-backend pattern (`lcats/lcats/llm/backend.py:31-68`), so the library choice isn't locked in.

- **`tool=` structured output:** extends `JSONPromptExtractor` with an optional `tool_schema` parameter (backward-compatible — all 75 existing tests pass unmodified) so entity/event extraction go through the backend's schema-checked tool path instead of `json_object` mode.
- **Cost/baseline reporting:** `processor.py` captures token counts, model, and elapsed time per pass (not just call counts); `baseline.py` implements the fixed-chunk-vs-segment comparison required by the proposal's Cost and baseline requirements section.
- **`WI-EVENT-0024.md` revised** to reflect the swappable-backend architecture and adopted libraries, per the corpus-roadmap decision made during planning.

## Test plan

- [x] `scripts/format --check --diff` — 160 files unchanged
- [x] `scripts/lint` — ruff and black checks passed
- [x] `scripts/test` — 1372 tests OK (1337 existing + 35 new, all pass unmodified)
- [x] `lrh validate` — 0 errors (31 pre-existing unrelated warnings)
- [x] Both `StanzaBackend` and `SpacyBackend` verified against real downloaded models (each independently skippable if its model isn't present, per LCATS's offline/no-network-CI constraint)
- [x] End-to-end pipeline smoke-tested with a real NLP backend + fake LLM backend before formal tests were written

🤖 Generated with [Claude Code](https://claude.com/claude-code)
