### PR TITLE
Add work item WI-EVENT-0026: Implement Event-Role-World extractor stages 6-7 and 9

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_24_03_31_18_WI_EVENT_0026_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_24_03_31_18_WI_EVENT_0026_REVIEW.md
@@ -1,0 +1,39 @@
+---
+execution_id: 2026_07_24_03_31_18_WI_EVENT_0026_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0026_REVIEW)[2026-07-24T03:31:08-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/149
+commit: e2575fd
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/149
+session_transcript: pending
+created_at: 2026-07-24T03:31:18-04:00
+---
+
+# Summary
+
+Address 5 open review comments on PR #149 (planning artifact for WI-EVENT-0026, the stages 6-7/9 follow-up work item) via /lrh-review-response. No primary implementation execution record exists for WI-EVENT-0026 yet — this PR only created the planning artifact via /lrh-work-item — so `rerun_of` is left empty.
+
+# Result
+
+Fixed 4 of 5 comments (chatgpt-codex-connector: 1 P1 + 3 P2; copilot-pull-request-reviewer: 1):
+
+1. (copilot) `forbidden_actions: implement_hypothesis_pass` was ambiguous against the acceptance criterion requiring weakly-inferred relations to be "stored separately as hypotheses": renamed to `implement_stage_8_hypothesis_pass` and clarified throughout (Scope, Required Changes, Non-Goals, Acceptance Criteria, frontmatter `acceptance`) that this is a storage partition on `EventRelation` itself (certainty="weakly_inferred"), not the stage-8 `Hypothesis` dataclass or any stage-8 orchestration.
+2. (P1, chatgpt-codex-connector) `baseline.py` was only required to report token/model/timing for the new layers, not relation/discourse/SF-tag counts: added a baseline-extension requirement to Scope, Required Changes, frontmatter `acceptance`, and `artifacts_expected` (`baseline.py` extended).
+3. (P2, chatgpt-codex-connector) Workstream `work_items:` list and phase description weren't updated to include WI-EVENT-0026: **skipped — presence check fails.** Already fixed in the prior commit (`f8bd8ff`, pushed before this review round); `WS-EVENT-ROLE-WORLD` already lists `WI-EVENT-0026` and its body prose no longer says "to be created."
+4. (P2, chatgpt-codex-connector) `StoryWorldAnnotation` dataclass alone doesn't require actual reconciliation logic or a test: added explicit story-level reconciliation implementation and a dedicated cross-segment test requirement to Required Changes and Acceptance Criteria.
+5. (P2, chatgpt-codex-connector) `project/work_items/README.md`'s Proposed Items index was missing WI-EVENT-0026: added the entry.
+
+# Validation
+
+- `scripts/format --check --diff` — clean after reinstalling the repo-pinned `black==25.11.0` (local install had drifted to 26.3.1, unrelated to this diff — confirmed via `git status --short` showing only the two intended markdown files).
+- `scripts/lint` — ruff and black both pass.
+- `scripts/test` — 1375 tests, all pass.
+- `lrh validate` (run from `lcats/`) — 0 errors, 33 warnings (all pre-existing `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS` warnings across the whole project, unrelated to this change).
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Run `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/149` before merge to verify the fixes against the current diff and resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_24_13_05_29_WI_EVENT_0026_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_24_13_05_29_WI_EVENT_0026_CONFIRM.md
@@ -1,0 +1,44 @@
+---
+execution_id: 2026_07_24_13_05_29_WI_EVENT_0026_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0026_CONFIRM)[2026-07-24T11:37:10-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/149
+commit: c5f6c8f
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/149
+session_transcript: pending
+created_at: 2026-07-24T13:05:29-04:00
+---
+
+# Summary
+
+Pre-merge verification of the review fixes pushed to PR #149 (WI-EVENT-0026 planning artifact) via /lrh-confirm-fixes: independently re-check the current HEAD diff against each open review thread, resolve the ones it plainly satisfies, and surface anything else. No primary WI-EVENT-0026 execution record exists yet (this PR only created the planning artifact via /lrh-work-item, no implementation has landed), so `rerun_of` is left empty.
+
+# Result
+
+Gathered unresolved threads on PR #149 via `lrh github threads --mode raw --state all` filtered to `isResolved == false`: 4 remained open (all chatgpt-codex-connector). A 5th thread (copilot-pull-request-reviewer, the `forbidden_actions`/hypothesis-pass ambiguity comment) already showed `isResolved: true` on GitHub before this run — no action needed on it.
+
+Per the user's explicit choice, fresh-eyes classification (Step 3) was dispatched to a cold subagent (no session memory) rather than classified inline, since this session authored the fixes being verified. The subagent checked out the PR branch independently and read the actual current content of `WI-EVENT-0026.md`, `WS-EVENT-ROLE-WORLD.md`, and `project/work_items/README.md` against each comment's literal ask.
+
+Verdict: **4 of 4 Clear-satisfied** — every thread's concern is plainly addressed by the current file content. No Unaddressed, Partial, Ambiguous, or Problematic-resolution/Problematic-comment findings.
+
+User confirmed the full batch. All 4 threads resolved via `gh api graphql resolveReviewThread`:
+- discussion_r3642960529 (P1, baseline.py extension for relation/discourse/SF-tag layers)
+- discussion_r3642960532 (workstream registration reciprocal update)
+- discussion_r3642960534 (story-level reconciliation as an executable requirement)
+- discussion_r3642960542 (work-item README index entry)
+
+Thread-resolution verdict (Step 6): **green** — every verifiable thread resolved, no exceptions remain open.
+
+# Validation
+
+- Subagent independently ran `lrh validate` on the checked-out PR branch: 0 errors, 33 warnings (all pre-existing `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS` items tied to the repo-wide `owner: unassigned` convention, including one for WI-EVENT-0026 itself, consistent with every other work item in the repo — not new schema errors from this PR's edits).
+- Provisional CI (pre-confirm-commit, `gh pr checks 149 --json name,state,bucket`; this repo has no required-status-checks configured, so the unfiltered check list is authoritative): test, lint, coverage all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- CI must be re-checked against the post-push HEAD SHA (this record's own commit) before reporting final merge readiness — see the readiness report that follows this record's push.
+- This PR is planning-artifact-only; the actual WI-EVENT-0026 implementation (relation/discourse/export passes) has not started. Run `/lrh-implement WI-EVENT-0026` once ready to begin that work.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -15,6 +15,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md`
+- `proposed/WI-EVENT-0026.md` — Implement Event-Role-World extractor stages 6-7 and 9 (relation, discourse/SF-tag, and validation/export)
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-EVENT-0026.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0026.md
@@ -1,0 +1,187 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EVENT-0026
+title: Implement Event-Role-World extractor stages 6-7 and 9 (relation, discourse/SF-tag, and validation/export)
+type: deliverable
+status: proposed
+priority: medium
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap:
+  - ROADMAP-CORE
+related_workstreams:
+  - WS-EVENT-ROLE-WORLD
+related_design:
+  - project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
+depends_on:
+  - WI-EVENT-0024
+blocked_by: []
+expected_actions:
+  - create_file
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - implement_hypothesis_pass
+  - implement_graph_database
+  - force_push
+  - delete_branch
+acceptance:
+  - New Event-Role-World object schemas (EventRelation, SpeechAct, ExplanationDiscourse, SFWorldModelTag) are defined and validated, extending the existing SegmentWorldAnnotation
+  - The relation pass extracts causal/enabling/preventing/temporal/motivational/explanatory links between existing Event IDs, with evidence and certainty (explicit/strongly_implied/weakly_inferred); explicit and strongly-implied links are in the main layer, weakly-inferred links are stored separately as hypotheses
+  - The discourse/SF-tag pass extracts speech acts, explanation discourse, and SF world-model tags, each with evidence and, where possible, linked entity/event IDs
+  - Validation/export emits canonical per-story JSON plus derived JSONL/CSV analysis tables, and the proposal's Artifact validation checks pass
+  - lrh validate reports 0 errors and scripts/test passes; stage 8 (hypothesis pass) is explicitly out of scope
+required_evidence:
+  - lrh_validate
+  - test_output
+  - manual_review
+artifacts_expected:
+  - lcats/lcats/analysis/event_role_world/relation_extractor.py
+  - lcats/lcats/analysis/event_role_world/discourse_extractor.py
+  - lcats/lcats/analysis/event_role_world/export.py
+  - lcats/lcats/analysis/event_role_world/schema.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/processor.py (extended, not new)
+  - lcats/tests/analysis_tests/event_role_world_test.py (extended, not new)
+---
+
+## Summary
+
+Implement the next three stages of the Event-Role-World extractor's
+Recommended staged pipeline — relation pass, discourse/SF-tag pass, and
+validation/export — extending WI-EVENT-0024's entity/participant,
+event/semantic-role, and temporal/spatial anchor output with causal/relation
+links between events, speech-act and explanation-discourse tagging, SF
+world-model tags, and a canonical export path with artifact validation.
+
+## Problem / Context
+
+`WS-EVENT-ROLE-WORLD` coordinates implementation of the Science-Fiction
+Event-Role-World extractor proposed in
+`project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md`,
+in support of the Worldcon "Shape of Science Fiction" paper
+(`FOCUS-WORLDCON-2026`). `WI-EVENT-0024` implemented stages 1-5 (input
+contract through anchor pass) and was merged in PR #148; its own scope
+explicitly deferred stages 6-7 (relation, discourse/SF tag) and 9
+(validation/export) "to a closely-following work item" and stage 8
+(optional hypothesis pass) to whenever the workstream chooses to pick it up.
+This work item is that closely-following item for stages 6-7 and 9. Stage 8
+remains out of scope per the proposal's own framing of it as optional.
+
+### Duplication search
+- In-repo: No existing implementation found. No `relation_extractor.py`,
+  `discourse_extractor.py`, `export.py`, `EventRelation`, `SpeechAct`, or
+  `SFWorldModelTag` anywhere in `lcats/`. The proposal's own schema sketch
+  (`00_proposal.md:166-179`) names these as a design sketch, not code.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found beyond `WI-EVENT-0024`'s own deferral note.
+- Proposals: None found beyond the governing proposal itself.
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Scope
+
+- Relation pass (stage 6): extract causal, enabling, preventing, temporal,
+  motivational, and explanatory links between events already produced by
+  `WI-EVENT-0024`'s event-role pass.
+- Discourse/SF-tag pass (stage 7): extract speech acts, explanatory
+  passages, and SF world-model tags from segment text.
+- Validation and export (stage 9): emit canonical per-story JSON artifacts
+  and derived JSONL/CSV analysis tables, and run the proposal's artifact
+  validation checks (ID resolution, evidence alignment, evidence/certainty
+  on causal links, evidence on SF tags, inferred/hypothesis marking,
+  deterministic exports).
+- Schema definitions for `EventRelation`, `SpeechAct`,
+  `ExplanationDiscourse`, and `SFWorldModelTag` per the proposal's "Core
+  schema sketch", plus `StoryWorldAnnotation` for story-level entity/alias
+  reconciliation and cross-segment relations.
+- Backend `tool=` schema wiring for the new extraction calls, consistent
+  with `WI-EVENT-0024`'s existing pattern (`JSONPromptExtractor`'s
+  `tool_schema` parameter) — not `json_object` mode.
+- Cost/baseline reporting for the new LLM-backed passes (token counts,
+  model, elapsed time), consistent with `WI-EVENT-0024`'s `PassUsage`
+  pattern.
+
+## Required Changes
+
+1. Extend `lcats/lcats/analysis/event_role_world/schema.py` with
+   `EventRelation`, `SpeechAct`, `ExplanationDiscourse`, `SFWorldModelTag`,
+   and `StoryWorldAnnotation` dataclasses, plus validation helpers
+   analogous to `validate_segment_annotation`.
+2. Create `relation_extractor.py` for stage 6, following the existing
+   entity/event extractor pattern (LLM extraction via `JSONPromptExtractor`
+   with a `tool_schema`, evidence resolution via `schema.EvidenceCursor`).
+3. Create `discourse_extractor.py` for stage 7, same extraction pattern.
+4. Create `export.py` for stage 9: canonical per-story JSON serialization,
+   JSONL/CSV derived table export, and the artifact-validation checks from
+   the proposal's "Validation and metrics" > "Artifact validation" section.
+5. Extend `processor.py` to orchestrate stages 6-7-9 after the existing
+   stages 2-5, following the same `PassUsage`/token-tracking pattern.
+6. Extend `lcats/tests/analysis_tests/event_role_world_test.py` covering
+   the new schemas, both new extraction passes, and the export/validation
+   path.
+
+## Non-Goals
+
+- Does not implement stage 8 (optional hypothesis pass) — deferred per the
+  proposal's own framing of it as optional; a follow-up work item should be
+  recorded if and when the workstream picks it up.
+- Does not require a graph database or CBR/RAG adaptation.
+- Does not choose the Worldcon paper's final statistical method.
+- Does not re-implement or modify stages 1-5 (`WI-EVENT-0024`'s scope).
+
+## Acceptance Criteria
+
+- New Event-Role-World object schemas (`EventRelation`, `SpeechAct`,
+  `ExplanationDiscourse`, `SFWorldModelTag`) are defined and validated,
+  extending the existing `SegmentWorldAnnotation`.
+- The relation pass extracts causal/enabling/preventing/temporal/
+  motivational/explanatory links between existing `Event` IDs, with
+  evidence and certainty (`explicit`/`strongly_implied`/`weakly_inferred`);
+  explicit and strongly-implied links are in the main layer, weakly-inferred
+  links are stored separately as hypotheses, per the proposal's causality
+  tradeoff table.
+- The discourse/SF-tag pass extracts speech acts, explanation discourse,
+  and SF world-model tags, each with evidence and, where possible, linked
+  entity/event IDs.
+- Validation/export emits canonical per-story JSON plus derived JSONL/CSV
+  analysis tables, and the proposal's "Artifact validation" checks pass (IDs
+  resolve, evidence spans align, causal links carry evidence+certainty, SF
+  tags carry evidence, inferred claims are marked, exports are
+  deterministic).
+- `lrh validate` reports 0 errors and `scripts/test` passes; stage 8
+  (hypothesis pass) is explicitly out of scope and not implemented here.
+
+## Validation
+
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `lrh validate`
+
+## Risk Notes
+
+- LLM-hallucinated causal links are a known risk per the proposal's own risk
+  table; require aligned evidence, certainty, and confidence, and compare
+  against an explicit-link baseline before treating relation-density metrics
+  as reliable.
+- Over-tagging SF categories is a known risk; use the proposal's small
+  controlled tag inventory and grounded examples, and expect stratified
+  human review before treating SF-tag counts as publication-quality.
+- Deterministic export is an explicit artifact-validation requirement; any
+  non-determinism in ID assignment or ordering during export will fail
+  validation and must be caught before this item is considered complete.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md`
+- Design: `project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md`

--- a/lcats/project/work_items/proposed/WI-EVENT-0026.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0026.md
@@ -27,15 +27,17 @@ expected_actions:
   - run_tests
   - create_pr
 forbidden_actions:
-  - implement_hypothesis_pass
+  - implement_stage_8_hypothesis_pass
   - implement_graph_database
   - force_push
   - delete_branch
 acceptance:
   - New Event-Role-World object schemas (EventRelation, SpeechAct, ExplanationDiscourse, SFWorldModelTag) are defined and validated, extending the existing SegmentWorldAnnotation
-  - The relation pass extracts causal/enabling/preventing/temporal/motivational/explanatory links between existing Event IDs, with evidence and certainty (explicit/strongly_implied/weakly_inferred); explicit and strongly-implied links are in the main layer, weakly-inferred links are stored separately as hypotheses
+  - The relation pass extracts causal/enabling/preventing/temporal/motivational/explanatory links between existing Event IDs, with evidence and certainty (explicit/strongly_implied/weakly_inferred); explicit and strongly-implied links are in the main relations list, weakly-inferred links are partitioned into a separate list on the same EventRelation type (not the stage-8 Hypothesis dataclass)
   - The discourse/SF-tag pass extracts speech acts, explanation discourse, and SF world-model tags, each with evidence and, where possible, linked entity/event IDs
   - Validation/export emits canonical per-story JSON plus derived JSONL/CSV analysis tables, and the proposal's Artifact validation checks pass
+  - baseline.py's summary/comparison functions are extended to cover relations, discourse, and SF-tag counts (not just token/model/timing), and the fixed-chunk-vs-segment comparison is run with the full stage 1-9-minus-8 extractor so the new layers' metrics are covered by the same chunking control as the existing ones
+  - Story-level reconciliation (alias resolution and cross-segment relation linking into StoryWorldAnnotation) is actually implemented and covered by a dedicated test, not just the container dataclass
   - lrh validate reports 0 errors and scripts/test passes; stage 8 (hypothesis pass) is explicitly out of scope
 required_evidence:
   - lrh_validate
@@ -47,6 +49,7 @@ artifacts_expected:
   - lcats/lcats/analysis/event_role_world/export.py
   - lcats/lcats/analysis/event_role_world/schema.py (extended, not new)
   - lcats/lcats/analysis/event_role_world/processor.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/baseline.py (extended, not new)
   - lcats/tests/analysis_tests/event_role_world_test.py (extended, not new)
 ---
 
@@ -110,13 +113,26 @@ remains out of scope per the proposal's own framing of it as optional.
 - Cost/baseline reporting for the new LLM-backed passes (token counts,
   model, elapsed time), consistent with `WI-EVENT-0024`'s `PassUsage`
   pattern.
+- Extending the fixed-chunk-vs-segment baseline comparison
+  (`baseline.py`) to cover the new relation/discourse/SF-tag layers, not
+  just the existing entity/event/anchor counts — the proposal's Cost and
+  baseline requirements section requires every SF-vs-other-genre comparison
+  metric to be checked against this control, and relation-density/SF-tag
+  metrics are new comparison metrics this item introduces.
+- Implementing story-level reconciliation (alias resolution across
+  segments, cross-segment relation linking) into `StoryWorldAnnotation` —
+  not just defining the container dataclass.
 
 ## Required Changes
 
 1. Extend `lcats/lcats/analysis/event_role_world/schema.py` with
    `EventRelation`, `SpeechAct`, `ExplanationDiscourse`, `SFWorldModelTag`,
    and `StoryWorldAnnotation` dataclasses, plus validation helpers
-   analogous to `validate_segment_annotation`.
+   analogous to `validate_segment_annotation`. `EventRelation` instances
+   with `certainty="weakly_inferred"` are partitioned into a separate list
+   from `explicit`/`strongly_implied` ones — this is a storage split on
+   `EventRelation` itself, not the stage-8 `Hypothesis` dataclass or any
+   stage-8 orchestration logic (out of scope per `forbidden_actions`).
 2. Create `relation_extractor.py` for stage 6, following the existing
    entity/event extractor pattern (LLM extraction via `JSONPromptExtractor`
    with a `tool_schema`, evidence resolution via `schema.EvidenceCursor`).
@@ -126,15 +142,28 @@ remains out of scope per the proposal's own framing of it as optional.
    the proposal's "Validation and metrics" > "Artifact validation" section.
 5. Extend `processor.py` to orchestrate stages 6-7-9 after the existing
    stages 2-5, following the same `PassUsage`/token-tracking pattern.
-6. Extend `lcats/tests/analysis_tests/event_role_world_test.py` covering
-   the new schemas, both new extraction passes, and the export/validation
-   path.
+   Implement actual story-level reconciliation (alias resolution,
+   cross-segment relation linking) that populates `StoryWorldAnnotation`
+   from the per-segment annotations — not just the dataclass shape.
+6. Extend `baseline.py`'s `summarize_annotations()` and
+   `compare_chunking_strategies()` to report relation, discourse, and
+   SF-tag counts/rates alongside the existing entity/event/anchor ones, and
+   run the fixed-chunk-vs-segment comparison with the full stages-1-9-minus-8
+   extractor so the new layers are covered by the same chunking control.
+7. Extend `lcats/tests/analysis_tests/event_role_world_test.py` covering
+   the new schemas, both new extraction passes, the export/validation
+   path, the extended baseline comparison, and story-level reconciliation
+   (including a case with a cross-segment alias or relation).
 
 ## Non-Goals
 
-- Does not implement stage 8 (optional hypothesis pass) — deferred per the
-  proposal's own framing of it as optional; a follow-up work item should be
-  recorded if and when the workstream picks it up.
+- Does not implement stage 8 (optional hypothesis pass) — the standalone
+  `Hypothesis` dataclass (belief/uncertainty/perspective/emotion
+  annotations) and any orchestration of a dedicated hypothesis pass are
+  deferred per the proposal's own framing of stage 8 as optional; a
+  follow-up work item should be recorded if and when the workstream picks
+  it up. This is distinct from partitioning `weakly_inferred` `EventRelation`
+  instances into a separate list, which is in scope for stage 6 itself.
 - Does not require a graph database or CBR/RAG adaptation.
 - Does not choose the Worldcon paper's final statistical method.
 - Does not re-implement or modify stages 1-5 (`WI-EVENT-0024`'s scope).
@@ -147,9 +176,10 @@ remains out of scope per the proposal's own framing of it as optional.
 - The relation pass extracts causal/enabling/preventing/temporal/
   motivational/explanatory links between existing `Event` IDs, with
   evidence and certainty (`explicit`/`strongly_implied`/`weakly_inferred`);
-  explicit and strongly-implied links are in the main layer, weakly-inferred
-  links are stored separately as hypotheses, per the proposal's causality
-  tradeoff table.
+  explicit and strongly-implied links are in the main relations list,
+  weakly-inferred links are partitioned into a separate list on the same
+  `EventRelation` type (not the stage-8 `Hypothesis` dataclass), per the
+  proposal's causality tradeoff table.
 - The discourse/SF-tag pass extracts speech acts, explanation discourse,
   and SF world-model tags, each with evidence and, where possible, linked
   entity/event IDs.
@@ -158,6 +188,14 @@ remains out of scope per the proposal's own framing of it as optional.
   resolve, evidence spans align, causal links carry evidence+certainty, SF
   tags carry evidence, inferred claims are marked, exports are
   deterministic).
+- `baseline.py`'s summary/comparison functions are extended to cover
+  relations, discourse, and SF-tag counts (not just token/model/timing
+  reporting), and the fixed-chunk-vs-segment comparison is run with the
+  full stages-1-9-minus-8 extractor so the new layers' metrics are covered
+  by the same chunking control as the existing entity/event/anchor metrics.
+- Story-level reconciliation (alias resolution and cross-segment relation
+  linking into `StoryWorldAnnotation`) is actually implemented and covered
+  by a dedicated test — not just the container dataclass.
 - `lrh validate` reports 0 errors and `scripts/test` passes; stage 8
   (hypothesis pass) is explicitly out of scope and not implemented here.
 

--- a/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
@@ -13,6 +13,7 @@ related_design:
 work_items:
   - WI-EVENT-0024
   - WI-EVENT-0025
+  - WI-EVENT-0026
 exit_criteria:
   - The proposal's Recommended staged pipeline stages 1-7 and 9 (input contract, surface feature pass, entity participant pass, event-role pass, anchor pass, relation pass, discourse/SF tag pass, and validation/export) are implemented, reusing the existing segment/evidence substrate without reimplementing scene/sequel extraction
   - The optional hypothesis pass (stage 8) is implemented, or explicitly deferred with a follow-up work item recorded
@@ -89,12 +90,10 @@ the proposal itself prescribes:
   whether a real NLP library (spaCy, NLTK, Stanza, UDPipe) should be
   adopted for stage 2's syntactic/morphological features, since this repo
   has no such dependency today. Produces a design recommendation only.
-
-Stages 6-7 (relation, discourse/SF tag) and stage 9 (validation/export) are
-expected as closely-following follow-up work items, since validation/export
-is required to check any of the earlier stages' output; stage 8 (hypothesis
-pass) remains optional per the proposal itself. To be created via
-`/lrh-work-item` once WI-EVENT-0024 is underway.
+- **WI-EVENT-0026** — covers stages 6-7 (relation, discourse/SF tag) and
+  stage 9 (validation/export), building on WI-EVENT-0024's entity/event/
+  anchor output. Stage 8 (hypothesis pass) remains optional per the
+  proposal itself and is out of scope for this item.
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary
Adds WI-EVENT-0026, the follow-up work item to WI-EVENT-0024 (merged in #148), covering the next three stages of the Event-Role-World extractor Recommended staged pipeline:

- Stage 6 (relation pass): causal/enabling/preventing/temporal/motivational/explanatory links between existing Event IDs, with evidence and certainty.
- Stage 7 (discourse/SF-tag pass): speech acts, explanation discourse, and SF world-model tags.
- Stage 9 (validation/export): canonical per-story JSON plus derived JSONL/CSV analysis tables, with the proposal artifact-validation checks.

Stage 8 (optional hypothesis pass) remains explicitly out of scope, per the governing proposal's own framing of it as optional and WI-EVENT-0024's deferral note.

Type: deliverable
Related workstream: WS-EVENT-ROLE-WORLD
Depends on: WI-EVENT-0024 (resolved)

## Acceptance criteria
- New schemas (EventRelation, SpeechAct, ExplanationDiscourse, SFWorldModelTag) defined and validated.
- Relation pass extracts causal/etc. links with evidence and certainty; weakly-inferred links stored separately as hypotheses.
- Discourse/SF-tag pass extracts speech acts, explanation discourse, and SF tags with evidence.
- Validation/export emits canonical JSON plus derived tables and passes the proposal artifact-validation checks.
- lrh validate reports 0 errors and scripts/test passes; stage 8 out of scope.

## Test plan
- [x] lrh validate - 0 errors (33 warnings, all pre-existing owner-field pattern)
- [x] This is a planning-artifact-only PR - no code changes; no test suite run needed beyond lrh validate

Generated with Claude Code
