### PR TITLE
Implement Event-Role-World extractor stages 6-7 and 9 (WI-EVENT-0026)

### DIFF
--- a/lcats/lcats/analysis/event_role_world/baseline.py
+++ b/lcats/lcats/analysis/event_role_world/baseline.py
@@ -95,7 +95,16 @@ def summarize_annotations(
 
     Returns:
         A dict with unit_count, total_word_count, and per-1000-word rates
-        for entities, events, temporal_anchors, and spatial_anchors.
+        for entities, events, temporal_anchors, spatial_anchors, relations
+        (main layer only — weakly_inferred relations are reported
+        separately, since they are a distinct, lower-confidence layer per
+        the proposal's causality tradeoff table, and mixing them into the
+        main relation-density metric would understate how much of that
+        density is speculative), speech_acts, explanations, and sf_tags —
+        the new relation/discourse/SF-tag layers WI-EVENT-0026 introduces,
+        alongside the existing entity/event/anchor ones, so genre-
+        comparison metrics built on these new layers are covered by the
+        same fixed-chunk-vs-segment control as the original layers.
     """
     total_words = sum(
         (a.surface_features.word_count if a.surface_features else 0)
@@ -105,6 +114,13 @@ def summarize_annotations(
     total_events = sum(len(a.events) for a in annotations)
     total_temporal = sum(len(a.temporal_anchors) for a in annotations)
     total_spatial = sum(len(a.spatial_anchors) for a in annotations)
+    total_relations = sum(len(a.relations) for a in annotations)
+    total_weakly_inferred_relations = sum(
+        len(a.weakly_inferred_relations) for a in annotations
+    )
+    total_speech_acts = sum(len(a.speech_acts) for a in annotations)
+    total_explanations = sum(len(a.explanations) for a in annotations)
+    total_sf_tags = sum(len(a.sf_tags) for a in annotations)
 
     return {
         "unit_count": len(annotations),
@@ -117,6 +133,17 @@ def summarize_annotations(
         "spatial_anchors_per_1000_words": _rate_per_1000_words(
             total_spatial, total_words
         ),
+        "relations_per_1000_words": _rate_per_1000_words(total_relations, total_words),
+        "weakly_inferred_relations_per_1000_words": _rate_per_1000_words(
+            total_weakly_inferred_relations, total_words
+        ),
+        "speech_acts_per_1000_words": _rate_per_1000_words(
+            total_speech_acts, total_words
+        ),
+        "explanations_per_1000_words": _rate_per_1000_words(
+            total_explanations, total_words
+        ),
+        "sf_tags_per_1000_words": _rate_per_1000_words(total_sf_tags, total_words),
     }
 
 

--- a/lcats/lcats/analysis/event_role_world/discourse_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/discourse_extractor.py
@@ -1,0 +1,241 @@
+"""Stage 7: speech act, explanation discourse, and SF world-model tag extraction.
+
+Uses lcats.analysis.llm_extractor.JSONPromptExtractor's tool_schema
+parameter (schema-checked structured output) rather than json_object mode,
+per the governing proposal's Implementation prerequisites section. Speech
+acts, explanations, and SF tags are extracted in one call since they share
+the same segment context and may reference the same entities/events.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from lcats.analysis import llm_extractor
+from lcats.analysis.event_role_world import schema
+
+DISCOURSE_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "extract_discourse",
+    "description": (
+        "Extract speech acts, explanatory passages, and SF world-model "
+        "tags from a story segment."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "speech_acts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "speech_act_id": {"type": "string"},
+                        "act_type": {
+                            "type": "string",
+                            "description": (
+                                "e.g. assertion, question, command, promise, " "warning"
+                            ),
+                        },
+                        "quote": {"type": "string"},
+                        "speaker_entity_id": {"type": "string"},
+                        "addressee_entity_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "linked_event_id": {"type": "string"},
+                        "confidence": {"type": "number"},
+                    },
+                    "required": ["speech_act_id", "act_type", "quote"],
+                },
+            },
+            "explanations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "explanation_id": {"type": "string"},
+                        "topic": {"type": "string"},
+                        "mechanism_or_rationale_type": {
+                            "type": "string",
+                            "description": (
+                                "e.g. scientific_mechanism, technical_operation, "
+                                "personal_rationale, historical_cause"
+                            ),
+                        },
+                        "quote": {"type": "string"},
+                        "linked_entity_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "linked_event_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "confidence": {"type": "number"},
+                    },
+                    "required": [
+                        "explanation_id",
+                        "topic",
+                        "mechanism_or_rationale_type",
+                        "quote",
+                    ],
+                },
+            },
+            "sf_tags": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "tag_id": {"type": "string"},
+                        "tag": {
+                            "type": "string",
+                            "description": (
+                                "Controlled tag, e.g. anomaly_or_novum, "
+                                "ontological_rule, technology_as_agent, "
+                                "nonhuman_actant"
+                            ),
+                        },
+                        "quote": {"type": "string"},
+                        "linked_entity_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "linked_event_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "status": {
+                            "type": "string",
+                            "enum": ["extractive", "hypothesis"],
+                            "description": (
+                                "extractive if the text states the tag "
+                                "explicitly, hypothesis if inferred"
+                            ),
+                        },
+                        "confidence": {"type": "number"},
+                    },
+                    "required": ["tag_id", "tag", "quote"],
+                },
+            },
+        },
+        "required": [],
+    },
+}
+
+DISCOURSE_SYSTEM_PROMPT = """You are extracting discourse-level features from
+a segment of a story for structured narrative analysis: speech acts
+(who said/asked/commanded what, to whom), explanatory passages (mechanisms,
+rationales, technical or scientific explanations), and SF world-model tags
+(controlled tags marking science-fictional elements such as anomalies,
+ontological rules, or nonhuman/technological actants). Only link speech acts,
+explanations, and tags to entity/event IDs already identified for this
+segment. Mark an SF tag's status as "extractive" only if the text states it
+explicitly; otherwise mark it "hypothesis". Quote exact segment text for
+every claim."""
+
+DISCOURSE_USER_PROMPT_TEMPLATE = """Segment text:
+---
+{story_text}
+---
+
+Known entity IDs for this segment: {entity_ids}
+Known event IDs for this segment: {event_ids}
+
+Extract speech acts, explanations, and SF world-model tags per the
+extract_discourse tool schema. Only use entity/event IDs from the known
+lists above for any linked_entity_ids/linked_event_ids/speaker_entity_id/
+addressee_entity_ids/linked_event_id fields."""
+
+
+def make_discourse_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
+    """Create a JSONPromptExtractor configured for stage-7 discourse extraction.
+
+    Args:
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
+
+    Returns:
+        Configured JSONPromptExtractor using the tool= structured-output path.
+    """
+    return llm_extractor.JSONPromptExtractor(
+        backend,
+        system_prompt=DISCOURSE_SYSTEM_PROMPT,
+        user_prompt_template=DISCOURSE_USER_PROMPT_TEMPLATE,
+        default_model="gpt-4o",
+        temperature=0.2,
+        tool_schema=DISCOURSE_TOOL_SCHEMA,
+    )
+
+
+def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
+    List[schema.SpeechAct],
+    List[schema.ExplanationDiscourse],
+    List[schema.SFWorldModelTag],
+]:
+    """Convert a raw extract_discourse tool result into schema objects.
+
+    Args:
+        tool_result: The dict returned by the extract_discourse tool call.
+        segment_text: The segment text quotes are resolved against.
+
+    Returns:
+        (speech_acts, explanations, sf_tags) — any item whose quote cannot
+        be located in `segment_text` is dropped (not fabricated with a
+        guessed span). Repeated identical quotes across all three resolve
+        to successive occurrences via a per-segment EvidenceCursor shared
+        across all three, not all onto the first match.
+    """
+    cursor = schema.EvidenceCursor()
+
+    speech_acts: List[schema.SpeechAct] = []
+    for raw in tool_result.get("speech_acts") or []:
+        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
+        if evidence is None:
+            continue
+        speech_acts.append(
+            schema.SpeechAct(
+                speech_act_id=raw["speech_act_id"],
+                act_type=raw.get("act_type", "other"),
+                evidence=evidence,
+                speaker_entity_id=raw.get("speaker_entity_id"),
+                addressee_entity_ids=raw.get("addressee_entity_ids") or [],
+                linked_event_id=raw.get("linked_event_id"),
+                confidence=raw.get("confidence", 1.0),
+            )
+        )
+
+    explanations: List[schema.ExplanationDiscourse] = []
+    for raw in tool_result.get("explanations") or []:
+        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
+        if evidence is None:
+            continue
+        explanations.append(
+            schema.ExplanationDiscourse(
+                explanation_id=raw["explanation_id"],
+                topic=raw.get("topic", ""),
+                mechanism_or_rationale_type=raw.get(
+                    "mechanism_or_rationale_type", "other"
+                ),
+                evidence=evidence,
+                linked_entity_ids=raw.get("linked_entity_ids") or [],
+                linked_event_ids=raw.get("linked_event_ids") or [],
+                confidence=raw.get("confidence", 1.0),
+            )
+        )
+
+    sf_tags: List[schema.SFWorldModelTag] = []
+    for raw in tool_result.get("sf_tags") or []:
+        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
+        if evidence is None:
+            continue
+        sf_tags.append(
+            schema.SFWorldModelTag(
+                tag_id=raw["tag_id"],
+                tag=raw.get("tag", "other"),
+                evidence=evidence,
+                linked_entity_ids=raw.get("linked_entity_ids") or [],
+                linked_event_ids=raw.get("linked_event_ids") or [],
+                status=raw.get("status", "hypothesis"),
+                confidence=raw.get("confidence", 1.0),
+            )
+        )
+
+    return speech_acts, explanations, sf_tags

--- a/lcats/lcats/analysis/event_role_world/discourse_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/discourse_extractor.py
@@ -179,15 +179,22 @@ def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
     Returns:
         (speech_acts, explanations, sf_tags) — any item whose quote cannot
         be located in `segment_text` is dropped (not fabricated with a
-        guessed span). Repeated identical quotes across all three resolve
-        to successive occurrences via a per-segment EvidenceCursor shared
-        across all three, not all onto the first match.
+        guessed span). Each layer gets its own EvidenceCursor rather than
+        sharing one: a single passage can legitimately be claimed by more
+        than one layer at once (e.g. the same quoted line is both a speech
+        act and an SF-tagged phrase), and a shared cursor would let the
+        first layer's claim consume the only occurrence, silently starving
+        a later layer's otherwise-valid claim on that same span. Within one
+        layer, repeated identical quotes still resolve to successive
+        occurrences via that layer's own cursor.
     """
-    cursor = schema.EvidenceCursor()
+    speech_act_cursor = schema.EvidenceCursor()
+    explanation_cursor = schema.EvidenceCursor()
+    sf_tag_cursor = schema.EvidenceCursor()
 
     speech_acts: List[schema.SpeechAct] = []
     for raw in tool_result.get("speech_acts") or []:
-        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
+        evidence = speech_act_cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
         speech_acts.append(
@@ -204,7 +211,7 @@ def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
 
     explanations: List[schema.ExplanationDiscourse] = []
     for raw in tool_result.get("explanations") or []:
-        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
+        evidence = explanation_cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
         explanations.append(
@@ -223,7 +230,7 @@ def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
 
     sf_tags: List[schema.SFWorldModelTag] = []
     for raw in tool_result.get("sf_tags") or []:
-        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
+        evidence = sf_tag_cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
         sf_tags.append(

--- a/lcats/lcats/analysis/event_role_world/export.py
+++ b/lcats/lcats/analysis/event_role_world/export.py
@@ -1,0 +1,222 @@
+"""Stage 9: validation and export.
+
+Emits canonical per-story JSON and derived JSONL/CSV analysis tables, and
+runs the proposal's "Artifact validation" checks (Validation and metrics
+section): all entity/event/relation IDs resolve, evidence spans align,
+causal links carry evidence and certainty, SF tags carry evidence and a
+fact/hypothesis status, and exports are deterministic for the same input.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+
+from typing import Any, Dict, List
+
+from lcats.analysis.event_role_world import schema
+
+_VALID_RELATION_CERTAINTIES = {"explicit", "strongly_implied", "weakly_inferred"}
+_VALID_SF_TAG_STATUSES = {"extractive", "hypothesis"}
+
+
+def validate_artifacts(story: schema.StoryWorldAnnotation) -> List[str]:
+    """Run the proposal's Artifact validation checks against `story`.
+
+    Args:
+        story: A StoryWorldAnnotation produced by
+            schema.reconcile_story_annotations.
+
+    Returns:
+        A list of human-readable error strings; empty if all checks pass.
+        Aggregates each segment's own validation_errors (ID resolution,
+        evidence-span alignment) plus story.validation_errors (story-scoped
+        ID resolution), and additionally checks that every relation's
+        certainty and every SF tag's status are valid controlled values —
+        the proposal's "inferred claims are marked inferred or hypothesis"
+        requirement.
+    """
+    errors: List[str] = []
+
+    for segment in story.segment_annotations:
+        for error in segment.validation_errors:
+            errors.append(f"segment {segment.segment_id!r}: {error}")
+
+        for relation in segment.relations + segment.weakly_inferred_relations:
+            if relation.certainty not in _VALID_RELATION_CERTAINTIES:
+                errors.append(
+                    f"segment {segment.segment_id!r} relation "
+                    f"{relation.relation_id!r} has invalid certainty "
+                    f"{relation.certainty!r}"
+                )
+
+        for tag in segment.sf_tags:
+            if tag.status not in _VALID_SF_TAG_STATUSES:
+                errors.append(
+                    f"segment {segment.segment_id!r} SF tag {tag.tag_id!r} "
+                    f"has invalid status {tag.status!r}"
+                )
+
+    errors.extend(story.validation_errors)
+
+    return errors
+
+
+def to_canonical_json(story: schema.StoryWorldAnnotation) -> str:
+    """Serialize `story` to canonical, deterministic JSON.
+
+    Args:
+        story: A StoryWorldAnnotation to serialize.
+
+    Returns:
+        A JSON string with sorted keys and stable formatting — calling
+        this twice on the same (unmodified) StoryWorldAnnotation produces
+        byte-identical output, satisfying the proposal's "exports are
+        deterministic" requirement.
+    """
+    return json.dumps(story.to_dict(), indent=2, sort_keys=True)
+
+
+def export_story_json(story: schema.StoryWorldAnnotation, path: str) -> None:
+    """Write `story`'s canonical JSON to `path`."""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(to_canonical_json(story))
+
+
+def build_analysis_tables(
+    story: schema.StoryWorldAnnotation,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Flatten `story` into per-table rows for JSONL/CSV export.
+
+    Args:
+        story: A StoryWorldAnnotation to flatten.
+
+    Returns:
+        A dict of table_name -> list of flat row dicts, one table per
+        annotation layer (entities, events, relations, speech_acts,
+        explanations, sf_tags, temporal_anchors, spatial_anchors), each row
+        tagged with segment_id (or "story" for story-level entities).
+    """
+    tables: Dict[str, List[Dict[str, Any]]] = {
+        "entities": [],
+        "events": [],
+        "relations": [],
+        "speech_acts": [],
+        "explanations": [],
+        "sf_tags": [],
+        "temporal_anchors": [],
+        "spatial_anchors": [],
+    }
+
+    for entity in story.entities:
+        row = entity.to_dict()
+        row["segment_id"] = "story"
+        tables["entities"].append(row)
+
+    for segment in story.segment_annotations:
+        for event in segment.events:
+            row = {
+                "segment_id": segment.segment_id,
+                "event_id": event.event_id,
+                "predicate": event.predicate,
+                "event_type": event.event_type,
+                "modality": event.modality,
+                "confidence": event.confidence,
+            }
+            tables["events"].append(row)
+
+        for relation in segment.relations + segment.weakly_inferred_relations:
+            row = relation.to_dict()
+            row["segment_id"] = segment.segment_id
+            tables["relations"].append(row)
+
+        for speech_act in segment.speech_acts:
+            row = speech_act.to_dict()
+            row["segment_id"] = segment.segment_id
+            tables["speech_acts"].append(row)
+
+        for explanation in segment.explanations:
+            row = explanation.to_dict()
+            row["segment_id"] = segment.segment_id
+            tables["explanations"].append(row)
+
+        for tag in segment.sf_tags:
+            row = tag.to_dict()
+            row["segment_id"] = segment.segment_id
+            tables["sf_tags"].append(row)
+
+        for anchor in segment.temporal_anchors:
+            row = anchor.to_dict()
+            row["segment_id"] = segment.segment_id
+            tables["temporal_anchors"].append(row)
+
+        for anchor in segment.spatial_anchors:
+            row = anchor.to_dict()
+            row["segment_id"] = segment.segment_id
+            tables["spatial_anchors"].append(row)
+
+    return tables
+
+
+def rows_to_jsonl(rows: List[Dict[str, Any]]) -> str:
+    """Serialize `rows` as newline-delimited JSON, one object per line."""
+    return "\n".join(json.dumps(row, sort_keys=True) for row in rows)
+
+
+def rows_to_csv(rows: List[Dict[str, Any]]) -> str:
+    """Serialize `rows` as CSV text with a stable, sorted column order.
+
+    Nested values (e.g. an evidence dict, a list of linked IDs) are
+    JSON-encoded into their cell rather than dropped, so no information is
+    lost in the CSV form even though it is a flatter representation than
+    JSONL.
+    """
+    if not rows:
+        return ""
+    fieldnames = sorted({key for row in rows for key in row})
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        flat_row = {
+            key: (
+                json.dumps(value, sort_keys=True)
+                if isinstance(value, (dict, list))
+                else value
+            )
+            for key, value in row.items()
+        }
+        writer.writerow(flat_row)
+    return buffer.getvalue()
+
+
+def export_analysis_tables(
+    story: schema.StoryWorldAnnotation, output_dir: str
+) -> Dict[str, str]:
+    """Write JSONL and CSV derived tables for `story` to `output_dir`.
+
+    Args:
+        story: A StoryWorldAnnotation to export.
+        output_dir: Directory to write "<table_name>.jsonl"/".csv" files
+            into. Must already exist.
+
+    Returns:
+        A dict of "<table_name>.<ext>" -> the path written.
+    """
+    tables = build_analysis_tables(story)
+    written: Dict[str, str] = {}
+
+    for table_name, rows in tables.items():
+        jsonl_path = os.path.join(output_dir, f"{table_name}.jsonl")
+        with open(jsonl_path, "w", encoding="utf-8") as f:
+            f.write(rows_to_jsonl(rows))
+        written[f"{table_name}.jsonl"] = jsonl_path
+
+        csv_path = os.path.join(output_dir, f"{table_name}.csv")
+        with open(csv_path, "w", encoding="utf-8", newline="") as f:
+            f.write(rows_to_csv(rows))
+        written[f"{table_name}.csv"] = csv_path
+
+    return written

--- a/lcats/lcats/analysis/event_role_world/processor.py
+++ b/lcats/lcats/analysis/event_role_world/processor.py
@@ -1,10 +1,11 @@
-"""Pipeline orchestration for Event-Role-World extractor stages 1-5.
+"""Pipeline orchestration for Event-Role-World extractor stages 1-7 and 9.
 
 Stage 1 (input contract) reuses the existing segment/evidence substrate
 (lcats.analysis.story_processors, lcats.analysis.text_segmenter) rather than
 reimplementing segmentation — this module accepts already-produced segments
-(scene/sequel, or fixed_chunk from baseline.py) and runs stages 2-5 over
-each one's sliced text.
+(scene/sequel, or fixed_chunk from baseline.py) and runs stages 2-7 over
+each one's sliced text, then stage 9's story-level reconciliation over the
+resulting segment annotations.
 """
 
 from __future__ import annotations
@@ -14,9 +15,15 @@ import time
 
 from typing import Any, Dict, List
 
+from lcats.analysis.event_role_world import (
+    discourse_extractor as discourse_extractor_module,
+)
 from lcats.analysis.event_role_world import entity_extractor as entity_extractor_module
 from lcats.analysis.event_role_world import event_extractor as event_extractor_module
 from lcats.analysis.event_role_world import nlp_backend as nlp_backend_module
+from lcats.analysis.event_role_world import (
+    relation_extractor as relation_extractor_module,
+)
 from lcats.analysis.event_role_world import schema
 from lcats.analysis.event_role_world import surface_feature_extractor
 
@@ -51,8 +58,10 @@ def process_segment(
     nlp_backend_name: str,
     entity_llm_extractor: Any,
     event_llm_extractor: Any,
+    relation_llm_extractor: Any,
+    discourse_llm_extractor: Any,
 ) -> "tuple[schema.SegmentWorldAnnotation, List[PassUsage]]":
-    """Run stages 2-5 over one segment's text.
+    """Run stages 2-7 over one segment's text.
 
     Args:
         segment_id: The segment's ID, carried through to the annotation.
@@ -65,6 +74,10 @@ def process_segment(
             entity_extractor.make_entity_extractor.
         event_llm_extractor: A JSONPromptExtractor configured via
             event_extractor.make_event_extractor.
+        relation_llm_extractor: A JSONPromptExtractor configured via
+            relation_extractor.make_relation_extractor.
+        discourse_llm_extractor: A JSONPromptExtractor configured via
+            discourse_extractor.make_discourse_extractor.
 
     Returns:
         (annotation, usage_records) — annotation.validation_errors is
@@ -111,14 +124,14 @@ def process_segment(
     # JSONPromptExtractor.extract() only substitutes {story_text}/
     # {indexed_story_text}; entity IDs are interpolated via a dedicated
     # helper that still routes through extract() (see
-    # _extract_events_with_entity_ids), so this makes exactly one backend
+    # _extract_with_placeholders), so this makes exactly one backend
     # call, not two, and keeps extract()'s exception/api_error handling
     # intact rather than letting a transient failure abort process_segments
     # for every remaining segment.
     entity_ids = [e.entity_id for e in entities]
     t0 = time.monotonic()
-    event_result = _extract_events_with_entity_ids(
-        event_llm_extractor, segment_text, entity_ids
+    event_result = _extract_with_placeholders(
+        event_llm_extractor, segment_text, {"entity_ids": entity_ids}
     )
     usage_records.append(
         _pass_usage_from_extraction(segment_id, "event_anchor", event_result, t0)
@@ -132,6 +145,45 @@ def process_segment(
         )
     )
 
+    # Stage 6: relations between events (LLM-backed). Same routed-through-
+    # extract() pattern as the event/anchor pass, so a transient failure is
+    # caught and recorded rather than aborting process_segments().
+    event_ids = [e.event_id for e in events]
+    t0 = time.monotonic()
+    relation_result = _extract_with_placeholders(
+        relation_llm_extractor, segment_text, {"event_ids": event_ids}
+    )
+    usage_records.append(
+        _pass_usage_from_extraction(segment_id, "relation", relation_result, t0)
+    )
+    relation_error = relation_result.get("api_error") or relation_result.get(
+        "extraction_error"
+    )
+    if relation_error:
+        extraction_errors.append(f"relation extraction failed: {relation_error}")
+    relations, weakly_inferred_relations = relation_extractor_module.build_relations(
+        relation_result.get("extracted_output") or {}, segment_text
+    )
+
+    # Stage 7: speech acts, explanations, and SF world-model tags (LLM-backed).
+    t0 = time.monotonic()
+    discourse_result = _extract_with_placeholders(
+        discourse_llm_extractor,
+        segment_text,
+        {"entity_ids": entity_ids, "event_ids": event_ids},
+    )
+    usage_records.append(
+        _pass_usage_from_extraction(segment_id, "discourse", discourse_result, t0)
+    )
+    discourse_error = discourse_result.get("api_error") or discourse_result.get(
+        "extraction_error"
+    )
+    if discourse_error:
+        extraction_errors.append(f"discourse extraction failed: {discourse_error}")
+    speech_acts, explanations, sf_tags = discourse_extractor_module.build_discourse(
+        discourse_result.get("extracted_output") or {}, segment_text
+    )
+
     annotation = schema.SegmentWorldAnnotation(
         segment_id=segment_id,
         surface_features=surface_features,
@@ -140,6 +192,11 @@ def process_segment(
         events=events,
         temporal_anchors=temporal_anchors,
         spatial_anchors=spatial_anchors,
+        relations=relations,
+        weakly_inferred_relations=weakly_inferred_relations,
+        speech_acts=speech_acts,
+        explanations=explanations,
+        sf_tags=sf_tags,
         extraction_errors=extraction_errors,
     )
     annotation.validation_errors = schema.validate_segment_annotation(
@@ -165,31 +222,46 @@ def _pass_usage_from_extraction(
     )
 
 
-def _extract_events_with_entity_ids(
-    event_llm_extractor: Any, segment_text: str, entity_ids: List[str]
+def _extract_with_placeholders(
+    llm_extractor_instance: Any,
+    segment_text: str,
+    id_placeholders: Dict[str, List[str]],
 ) -> Dict[str, Any]:
-    """Run the event extractor with entity IDs interpolated into the prompt.
+    """Run an extractor with named ID-list placeholders interpolated into the prompt.
 
     JSONPromptExtractor.extract() only substitutes {story_text}/
-    {indexed_story_text} into user_prompt_template. {entity_ids} is
-    resolved by temporarily replacing that one placeholder in the template
-    with a literal string (leaving {story_text}/{indexed_story_text}
-    intact for extract() to fill in as usual), then calling
-    extract() itself — not the backend directly — so a transient provider
-    failure or missing tool_result produces the same normalized
-    api_error/extraction_error result extract() gives every other call,
-    instead of an uncaught exception that would abort process_segments()
-    for every remaining segment.
+    {indexed_story_text} into user_prompt_template. Any other named
+    placeholder (e.g. {entity_ids}, {event_ids}) is resolved by temporarily
+    replacing it in the template with a literal, comma-joined string
+    (leaving {story_text}/{indexed_story_text} intact for extract() to fill
+    in as usual), then calling extract() itself — not the backend directly
+    — so a transient provider failure or missing tool_result produces the
+    same normalized api_error/extraction_error result extract() gives every
+    other call, instead of an uncaught exception that would abort
+    process_segments() for every remaining segment.
+
+    Args:
+        llm_extractor_instance: A JSONPromptExtractor whose
+            user_prompt_template contains zero or more of the placeholder
+            names in `id_placeholders`.
+        segment_text: The segment text to extract from.
+        id_placeholders: Maps placeholder name (without braces) to the list
+            of IDs to interpolate there, e.g. {"entity_ids": ["e1", "e2"]}.
+            A missing/empty list renders as "(none known yet)".
+
+    Returns:
+        The dict returned by llm_extractor_instance.extract(segment_text).
     """
-    original_template = event_llm_extractor.user_prompt_template
-    entity_ids_text = ", ".join(entity_ids) if entity_ids else "(none known yet)"
-    event_llm_extractor.user_prompt_template = original_template.replace(
-        "{entity_ids}", entity_ids_text
-    )
+    original_template = llm_extractor_instance.user_prompt_template
+    template = original_template
+    for name, ids in id_placeholders.items():
+        ids_text = ", ".join(ids) if ids else "(none known yet)"
+        template = template.replace("{" + name + "}", ids_text)
+    llm_extractor_instance.user_prompt_template = template
     try:
-        return event_llm_extractor.extract(segment_text)
+        return llm_extractor_instance.extract(segment_text)
     finally:
-        event_llm_extractor.user_prompt_template = original_template
+        llm_extractor_instance.user_prompt_template = original_template
 
 
 def process_segments(
@@ -198,8 +270,9 @@ def process_segments(
     *,
     nlp_backend_name: str,
     llm_backend: Any,
+    story_id: Any = None,
 ) -> Dict[str, Any]:
-    """Run stages 2-5 over every segment in `segments`.
+    """Run stages 2-7 over every segment in `segments`, then reconcile stage 9.
 
     Args:
         story_text: Full story text; segments are sliced from this by
@@ -208,15 +281,27 @@ def process_segments(
             produced by story_processors.make_annotated_segment_extractor,
             or baseline.make_fixed_token_chunks).
         nlp_backend_name: "stanza" or "spacy".
-        llm_backend: LLMBackend for the entity/event extraction passes.
+        llm_backend: LLMBackend for the entity/event/relation/discourse
+            extraction passes.
+        story_id: Identifier carried onto the reconciled StoryWorldAnnotation.
+            Defaults to None if the caller has no natural story ID.
 
     Returns:
         {"segments": [SegmentWorldAnnotation.to_dict(), ...],
-         "usage": [PassUsage.to_dict(), ...]}
+         "usage": [PassUsage.to_dict(), ...],
+         "story": StoryWorldAnnotation.to_dict()} — "story" is the stage-9
+         story-level reconciliation (alias resolution, cross-segment
+         relation qualification) over every segment annotation produced.
     """
     nlp_backend = surface_feature_extractor.make_nlp_backend(nlp_backend_name)
     entity_llm_extractor = entity_extractor_module.make_entity_extractor(llm_backend)
     event_llm_extractor = event_extractor_module.make_event_extractor(llm_backend)
+    relation_llm_extractor = relation_extractor_module.make_relation_extractor(
+        llm_backend
+    )
+    discourse_llm_extractor = discourse_extractor_module.make_discourse_extractor(
+        llm_backend
+    )
 
     annotations: List[schema.SegmentWorldAnnotation] = []
     all_usage: List[PassUsage] = []
@@ -235,11 +320,16 @@ def process_segments(
             nlp_backend_name=nlp_backend_name,
             entity_llm_extractor=entity_llm_extractor,
             event_llm_extractor=event_llm_extractor,
+            relation_llm_extractor=relation_llm_extractor,
+            discourse_llm_extractor=discourse_llm_extractor,
         )
         annotations.append(annotation)
         all_usage.extend(usage_records)
 
+    story = schema.reconcile_story_annotations(story_id, annotations)
+
     return {
         "segments": [a.to_dict() for a in annotations],
         "usage": [u.to_dict() for u in all_usage],
+        "story": story.to_dict(),
     }

--- a/lcats/lcats/analysis/event_role_world/relation_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/relation_extractor.py
@@ -1,0 +1,150 @@
+"""Stage 6: causal/temporal relation extraction between events.
+
+Uses lcats.analysis.llm_extractor.JSONPromptExtractor's tool_schema
+parameter (schema-checked structured output) rather than json_object mode,
+per the governing proposal's Implementation prerequisites section.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from lcats.analysis import llm_extractor
+from lcats.analysis.event_role_world import schema
+
+RELATION_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "extract_relations",
+    "description": (
+        "Extract causal, enabling, preventing, temporal, motivational, and "
+        "explanatory links between events already identified in a story "
+        "segment."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "relations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "relation_id": {"type": "string"},
+                        "source_event_id": {"type": "string"},
+                        "target_event_id": {"type": "string"},
+                        "relation_type": {
+                            "type": "string",
+                            "description": (
+                                "e.g. causes, enables, prevents, precedes, "
+                                "motivates, explains"
+                            ),
+                        },
+                        "quote": {
+                            "type": "string",
+                            "description": (
+                                "Exact substring of the segment text that "
+                                "grounds this relation."
+                            ),
+                        },
+                        "certainty": {
+                            "type": "string",
+                            "enum": ["explicit", "strongly_implied", "weakly_inferred"],
+                        },
+                        "confidence": {"type": "number"},
+                    },
+                    "required": [
+                        "relation_id",
+                        "source_event_id",
+                        "target_event_id",
+                        "relation_type",
+                        "quote",
+                    ],
+                },
+            }
+        },
+        "required": ["relations"],
+    },
+}
+
+RELATION_SYSTEM_PROMPT = """You are extracting causal and temporal relations
+between events from a segment of a story for structured narrative analysis.
+Only link events using the event IDs already identified for this segment.
+For each relation, classify its certainty: "explicit" if the text states the
+relation directly, "strongly_implied" if a careful reader would confidently
+infer it, or "weakly_inferred" if it is a plausible but speculative reading.
+Quote exact segment text for every claim; do not infer relations between
+events not both present in the provided event ID list."""
+
+RELATION_USER_PROMPT_TEMPLATE = """Segment text:
+---
+{story_text}
+---
+
+Known event IDs for this segment: {event_ids}
+
+Extract relations between these events per the extract_relations tool
+schema. Only use source_event_id/target_event_id values from the known
+event IDs above."""
+
+
+def make_relation_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
+    """Create a JSONPromptExtractor configured for stage-6 relation extraction.
+
+    Args:
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
+
+    Returns:
+        Configured JSONPromptExtractor using the tool= structured-output path.
+    """
+    return llm_extractor.JSONPromptExtractor(
+        backend,
+        system_prompt=RELATION_SYSTEM_PROMPT,
+        user_prompt_template=RELATION_USER_PROMPT_TEMPLATE,
+        default_model="gpt-4o",
+        temperature=0.2,
+        tool_schema=RELATION_TOOL_SCHEMA,
+    )
+
+
+def build_relations(
+    tool_result: Dict[str, Any], segment_text: str
+) -> Tuple[List[schema.EventRelation], List[schema.EventRelation]]:
+    """Convert a raw extract_relations tool result into schema objects.
+
+    Args:
+        tool_result: The dict returned by the extract_relations tool call.
+        segment_text: The segment text quotes are resolved against.
+
+    Returns:
+        (relations, weakly_inferred_relations) — relations whose quote
+        cannot be located in `segment_text` are dropped (not fabricated
+        with a guessed span). Relations with certainty "explicit" or
+        "strongly_implied" go in the first list (the main relations
+        layer); "weakly_inferred" relations are partitioned into the
+        second list per the proposal's causality tradeoff table. Repeated
+        identical quotes resolve to successive occurrences via a
+        per-segment EvidenceCursor.
+    """
+    cursor = schema.EvidenceCursor()
+
+    relations: List[schema.EventRelation] = []
+    weakly_inferred_relations: List[schema.EventRelation] = []
+
+    for raw in tool_result.get("relations") or []:
+        evidence = cursor.resolve(raw.get("quote", ""), segment_text)
+        if evidence is None:
+            continue
+        certainty = raw.get("certainty", "explicit")
+        relation = schema.EventRelation(
+            relation_id=raw["relation_id"],
+            source_event_id=raw["source_event_id"],
+            target_event_id=raw["target_event_id"],
+            relation_type=raw.get("relation_type", "other"),
+            evidence=evidence,
+            certainty=certainty,
+            confidence=raw.get("confidence", 1.0),
+        )
+        if certainty == "weakly_inferred":
+            weakly_inferred_relations.append(relation)
+        else:
+            relations.append(relation)
+
+    return relations, weakly_inferred_relations

--- a/lcats/lcats/analysis/event_role_world/schema.py
+++ b/lcats/lcats/analysis/event_role_world/schema.py
@@ -617,19 +617,32 @@ def validate_segment_annotation(
 class StoryWorldAnnotation:
     """Story-level reconciliation of per-segment Event-Role-World annotations.
 
-    Reconciles entities across segment boundaries (same canonical name,
-    case-insensitively, is treated as the same real-world entity) and
-    re-qualifies relations with story-scoped event IDs, since Event IDs are
-    only unique within one segment. This is the executable story-level
+    Reconciles entities across segment boundaries (matching on canonical
+    name OR any alias, case-insensitively — see reconcile_story_annotations)
+    and re-qualifies relations with story-scoped event IDs, since Event IDs
+    are only unique within one segment. This is the executable story-level
     reconciliation the proposal requires beyond just holding per-segment
     results in a list — see reconcile_story_annotations().
+
+    Known limitation (tracked in WS-EVENT-ROLE-WORLD as a follow-up, not
+    fixed by this WI): relation qualification here only makes segment-local
+    relations safely representable at story scope — it does not, and
+    cannot, discover genuinely cross-segment causal relations (cause in one
+    segment, effect in another). Stage 6's relation_extractor only ever
+    receives its own segment's event IDs, so a relation's source_event_id/
+    target_event_id can never actually reference a different segment's
+    event today; every relation this function qualifies is, by
+    construction, entirely local to the one segment it came from. Real
+    cross-segment relation extraction would require giving stage 6 broader
+    (multi-segment or full-story) context, which is out of this WI's scope.
 
     Attributes:
         story_id: Identifier for the story these segments belong to.
         segment_annotations: The per-segment annotations, in segment order.
-        entities: Reconciled entities, one per distinct canonical name
-            (case-insensitive) observed across all segments. entity_id on
-            each is a story-scoped global ID (e.g. "global_e0").
+        entities: Reconciled entities, one per distinct real-world entity
+            inferred by matching canonical names/aliases across segments
+            (see reconcile_story_annotations). entity_id on each is a
+            story-scoped global ID (e.g. "global_e0").
         entity_alias_map: Maps "{segment_id}:{local_entity_id}" to the
             reconciled global entity_id, so callers can translate a
             per-segment entity reference into the story-level entity.
@@ -672,47 +685,102 @@ def reconcile_story_annotations(
 
     Returns:
         A StoryWorldAnnotation with entities merged across segments by
-        case-insensitive canonical_name (a simple, deterministic alias
+        case-insensitive name matching (a simple, deterministic alias
         heuristic — not full coreference resolution, which remains the
         existing scene/sequel substrate's job, not this pipeline's), and
         every relation re-qualified with segment-scoped event IDs.
 
+    Merging matches an incoming entity against any *previously seen* name
+    for an existing global entity — its own canonical_name or any of its
+    aliases, case-insensitively — not canonical_name alone. This handles
+    the case where the same participant is given a different canonical
+    name across segments (e.g. canonical "Elizabeth" in one segment, then
+    canonical "Liz" with alias "Elizabeth" in another): matching on
+    canonical_name alone would never notice the alias overlap and would
+    fragment the two into separate global entities.
+
+    Every alias/canonical name an entity has ever been merged under is
+    registered so later segments can match through any of them — this
+    only extends transitively forward (a name becomes matchable once
+    something using it has been merged), it does not retroactively
+    reconcile two already-created global entities that turn out to share
+    a name only discovered later.
+
+    Merged entities also carry segment-qualified mention IDs
+    ("{segment_id}:{local_mention_id}") rather than dropping them, so
+    story.entities[i].mention_ids stays traceable back to
+    segment_annotations[*].mentions — the qualification avoids collisions
+    since mention IDs, like entity/event IDs, are only unique per segment.
+
     Merging is deterministic given the same input: entities are visited in
-    segment order, then within-segment list order, and the first-seen
-    canonical_name (case-insensitively) for a given normalized key becomes
-    the reconciled entity's canonical_name. Running this function twice on
-    the same input produces identical global_entity_ids and ordering.
+    segment order, then within-segment list order, name-lookup order is a
+    list (canonical_name first, then aliases in order) rather than set
+    iteration, and the first-seen canonical_name for a given matched global
+    entity becomes its canonical_name. Running this function twice on the
+    same input produces identical global_entity_ids and ordering.
     """
-    entities_by_key: Dict[str, Entity] = {}
+    entities_by_global_id: Dict[str, Entity] = {}
+    name_to_global_id: Dict[str, str] = {}
     entity_alias_map: Dict[str, str] = {}
     relations: List[EventRelation] = []
 
     for segment in segment_annotations:
         for entity in segment.entities:
-            key = entity.canonical_name.strip().lower()
-            if key not in entities_by_key:
-                global_id = f"global_e{len(entities_by_key)}"
-                entities_by_key[key] = Entity(
+            candidate_names = [entity.canonical_name.strip().lower()] + [
+                alias.strip().lower() for alias in entity.aliases
+            ]
+
+            global_id = None
+            for name in candidate_names:
+                if name in name_to_global_id:
+                    global_id = name_to_global_id[name]
+                    break
+
+            qualified_mention_ids = [
+                f"{segment.segment_id}:{mid}" for mid in entity.mention_ids
+            ]
+
+            if global_id is None:
+                global_id = f"global_e{len(entities_by_global_id)}"
+                entities_by_global_id[global_id] = Entity(
                     entity_id=global_id,
                     canonical_name=entity.canonical_name,
                     entity_type=entity.entity_type,
                     aliases=list(entity.aliases),
+                    mention_ids=list(qualified_mention_ids),
                     actant_roles=list(entity.actant_roles),
                     confidence=entity.confidence,
                 )
             else:
-                merged = entities_by_key[key]
-                for alias in entity.aliases:
+                merged = entities_by_global_id[global_id]
+                new_aliases = list(entity.aliases)
+                if entity.canonical_name != merged.canonical_name:
+                    new_aliases.append(entity.canonical_name)
+                for alias in new_aliases:
                     if alias not in merged.aliases:
                         merged.aliases.append(alias)
+                for mid in qualified_mention_ids:
+                    if mid not in merged.mention_ids:
+                        merged.mention_ids.append(mid)
                 for role in entity.actant_roles:
                     if role not in merged.actant_roles:
                         merged.actant_roles.append(role)
                 merged.confidence = max(merged.confidence, entity.confidence)
-            entity_alias_map[f"{segment.segment_id}:{entity.entity_id}"] = (
-                entities_by_key[key].entity_id
-            )
 
+            for name in candidate_names:
+                name_to_global_id[name] = global_id
+            entity_alias_map[f"{segment.segment_id}:{entity.entity_id}"] = global_id
+
+        # Every relation qualified here is, by construction, entirely
+        # local to `segment`: stage 6's relation_extractor only ever
+        # receives this segment's own event IDs (see relation_extractor.py
+        # and processor.py's per-segment placeholder interpolation), so
+        # relation.source_event_id/target_event_id can never actually
+        # reference a different segment's event. Qualifying both endpoints
+        # with `segment.segment_id` is therefore correct for every relation
+        # this pipeline can produce today — see the "Known limitation" note
+        # on StoryWorldAnnotation for what this does not do (discover
+        # genuinely cross-segment causal relations).
         for relation in segment.relations + segment.weakly_inferred_relations:
             relations.append(
                 dataclasses.replace(
@@ -725,7 +793,7 @@ def reconcile_story_annotations(
     story = StoryWorldAnnotation(
         story_id=story_id,
         segment_annotations=list(segment_annotations),
-        entities=list(entities_by_key.values()),
+        entities=list(entities_by_global_id.values()),
         entity_alias_map=entity_alias_map,
         relations=relations,
     )

--- a/lcats/lcats/analysis/event_role_world/schema.py
+++ b/lcats/lcats/analysis/event_role_world/schema.py
@@ -1,11 +1,13 @@
-"""Event-Role-World object schemas for extractor stages 1-5.
+"""Event-Role-World object schemas for extractor stages 1-7 and 9.
 
 Implements the object responsibilities sketched in the governing proposal's
 "Core schema sketch" (project/design/proposals/proposed/
-lcats-event-role-world-extractor/00_proposal.md), scoped to the stages this
-work item covers: entities/participants, events/semantic roles, and
-temporal/spatial anchors. Relation, discourse, SF-tag, and hypothesis
-objects are out of scope (WI-EVENT-0024 forbidden_actions).
+lcats-event-role-world-extractor/00_proposal.md): entities/participants,
+events/semantic roles, temporal/spatial anchors (WI-EVENT-0024), plus
+relations, speech acts, explanation discourse, and SF world-model tags
+(WI-EVENT-0026). The stage-8 hypothesis object (belief/uncertainty/
+perspective/emotion) remains out of scope (WI-EVENT-0026 forbidden_actions:
+implement_stage_8_hypothesis_pass).
 """
 
 from __future__ import annotations
@@ -188,6 +190,119 @@ class SpatialAnchor:
 
 
 @dataclasses.dataclass
+class EventRelation:
+    """Links two events with a controlled causal/temporal relation type.
+
+    Attributes:
+        certainty: One of "explicit", "strongly_implied", or
+            "weakly_inferred". Per the proposal's causality tradeoff table,
+            explicit/strongly_implied relations belong in the main relations
+            layer; weakly_inferred relations are partitioned into a
+            separate list (see SegmentWorldAnnotation.weakly_inferred_relations)
+            rather than the stage-8 Hypothesis dataclass — this is a storage
+            split on EventRelation itself, not a stage-8 concept.
+    """
+
+    relation_id: str
+    source_event_id: str
+    target_event_id: str
+    relation_type: str
+    evidence: EvidenceSpan
+    certainty: str = "explicit"
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "relation_id": self.relation_id,
+            "source_event_id": self.source_event_id,
+            "target_event_id": self.target_event_id,
+            "relation_type": self.relation_type,
+            "evidence": self.evidence.to_dict(),
+            "certainty": self.certainty,
+            "confidence": self.confidence,
+        }
+
+
+@dataclasses.dataclass
+class SpeechAct:
+    """A speech act: who said what to whom, and its function."""
+
+    speech_act_id: str
+    act_type: str
+    evidence: EvidenceSpan
+    speaker_entity_id: Optional[str] = None
+    addressee_entity_ids: List[str] = dataclasses.field(default_factory=list)
+    linked_event_id: Optional[str] = None
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "speech_act_id": self.speech_act_id,
+            "act_type": self.act_type,
+            "evidence": self.evidence.to_dict(),
+            "speaker_entity_id": self.speaker_entity_id,
+            "addressee_entity_ids": self.addressee_entity_ids,
+            "linked_event_id": self.linked_event_id,
+            "confidence": self.confidence,
+        }
+
+
+@dataclasses.dataclass
+class ExplanationDiscourse:
+    """Marks an explanatory passage (mechanism or rationale)."""
+
+    explanation_id: str
+    topic: str
+    mechanism_or_rationale_type: str
+    evidence: EvidenceSpan
+    linked_entity_ids: List[str] = dataclasses.field(default_factory=list)
+    linked_event_ids: List[str] = dataclasses.field(default_factory=list)
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "explanation_id": self.explanation_id,
+            "topic": self.topic,
+            "mechanism_or_rationale_type": self.mechanism_or_rationale_type,
+            "evidence": self.evidence.to_dict(),
+            "linked_entity_ids": self.linked_entity_ids,
+            "linked_event_ids": self.linked_event_ids,
+            "confidence": self.confidence,
+        }
+
+
+@dataclasses.dataclass
+class SFWorldModelTag:
+    """A controlled SF world-model tag (e.g. anomaly_or_novum, ontological_rule).
+
+    Attributes:
+        status: "extractive" if the text states the tag explicitly,
+            "hypothesis" if inferred — per the proposal's fact/hypothesis
+            distinction, interpretive tags are hypotheses unless the text
+            states them explicitly.
+    """
+
+    tag_id: str
+    tag: str
+    evidence: EvidenceSpan
+    linked_entity_ids: List[str] = dataclasses.field(default_factory=list)
+    linked_event_ids: List[str] = dataclasses.field(default_factory=list)
+    status: str = "hypothesis"
+    confidence: float = 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tag_id": self.tag_id,
+            "tag": self.tag,
+            "evidence": self.evidence.to_dict(),
+            "linked_entity_ids": self.linked_entity_ids,
+            "linked_event_ids": self.linked_event_ids,
+            "status": self.status,
+            "confidence": self.confidence,
+        }
+
+
+@dataclasses.dataclass
 class SurfaceFeatures:
     """Lexical, syntactic, and morphological features for a segment.
 
@@ -222,6 +337,16 @@ class SegmentWorldAnnotation:
     """Collects all Event-Role-World annotations for one segment.
 
     Attributes:
+        relations: EventRelation instances with certainty "explicit" or
+            "strongly_implied" — the main causal/relation layer.
+        weakly_inferred_relations: EventRelation instances with certainty
+            "weakly_inferred", stored separately per the proposal's
+            causality tradeoff table. This is a storage partition on
+            EventRelation itself, not the stage-8 Hypothesis dataclass.
+        speech_acts: SpeechAct instances extracted by the discourse pass.
+        explanations: ExplanationDiscourse instances extracted by the
+            discourse pass.
+        sf_tags: SFWorldModelTag instances extracted by the discourse pass.
         extraction_errors: Backend/API-level failures (e.g. a transient
             provider error, an empty tool result) for any LLM-backed pass
             on this segment. Distinct from validation_errors: an
@@ -230,7 +355,7 @@ class SegmentWorldAnnotation:
             nothing."
         validation_errors: ID-resolution and evidence-alignment failures
             found by validate_segment_annotation, given whatever entities/
-            events/anchors were actually extracted.
+            events/anchors/relations/discourse were actually extracted.
     """
 
     segment_id: Any
@@ -240,6 +365,13 @@ class SegmentWorldAnnotation:
     events: List[Event] = dataclasses.field(default_factory=list)
     temporal_anchors: List[TemporalAnchor] = dataclasses.field(default_factory=list)
     spatial_anchors: List[SpatialAnchor] = dataclasses.field(default_factory=list)
+    relations: List[EventRelation] = dataclasses.field(default_factory=list)
+    weakly_inferred_relations: List[EventRelation] = dataclasses.field(
+        default_factory=list
+    )
+    speech_acts: List[SpeechAct] = dataclasses.field(default_factory=list)
+    explanations: List[ExplanationDiscourse] = dataclasses.field(default_factory=list)
+    sf_tags: List[SFWorldModelTag] = dataclasses.field(default_factory=list)
     extraction_errors: List[str] = dataclasses.field(default_factory=list)
     validation_errors: List[str] = dataclasses.field(default_factory=list)
 
@@ -254,6 +386,13 @@ class SegmentWorldAnnotation:
             "events": [e.to_dict() for e in self.events],
             "temporal_anchors": [a.to_dict() for a in self.temporal_anchors],
             "spatial_anchors": [a.to_dict() for a in self.spatial_anchors],
+            "relations": [r.to_dict() for r in self.relations],
+            "weakly_inferred_relations": [
+                r.to_dict() for r in self.weakly_inferred_relations
+            ],
+            "speech_acts": [s.to_dict() for s in self.speech_acts],
+            "explanations": [e.to_dict() for e in self.explanations],
+            "sf_tags": [t.to_dict() for t in self.sf_tags],
             "extraction_errors": self.extraction_errors,
             "validation_errors": self.validation_errors,
         }
@@ -337,6 +476,7 @@ def validate_segment_annotation(
     anchor_ids = {a.anchor_id for a in annotation.temporal_anchors} | {
         a.anchor_id for a in annotation.spatial_anchors
     }
+    event_ids = {e.event_id for e in annotation.events}
 
     for mention in annotation.mentions:
         if mention.entity_id not in entity_ids:
@@ -385,5 +525,255 @@ def validate_segment_annotation(
         span_error = anchor.evidence.validate(segment_text)
         if span_error:
             errors.append(f"spatial anchor {anchor.anchor_id!r}: {span_error}")
+
+    relation_buckets = [
+        (annotation.relations, False),
+        (annotation.weakly_inferred_relations, True),
+    ]
+    for bucket, is_weakly_inferred_bucket in relation_buckets:
+        for relation in bucket:
+            span_error = relation.evidence.validate(segment_text)
+            if span_error:
+                errors.append(f"relation {relation.relation_id!r}: {span_error}")
+            if relation.source_event_id not in event_ids:
+                errors.append(
+                    f"relation {relation.relation_id!r} references unknown "
+                    f"source event {relation.source_event_id!r}"
+                )
+            if relation.target_event_id not in event_ids:
+                errors.append(
+                    f"relation {relation.relation_id!r} references unknown "
+                    f"target event {relation.target_event_id!r}"
+                )
+            is_weakly_inferred_certainty = relation.certainty == "weakly_inferred"
+            if is_weakly_inferred_certainty != is_weakly_inferred_bucket:
+                errors.append(
+                    f"relation {relation.relation_id!r} has certainty "
+                    f"{relation.certainty!r} but is stored in the "
+                    f"{'weakly_inferred_relations' if is_weakly_inferred_bucket else 'relations'} "
+                    "list"
+                )
+
+    for speech_act in annotation.speech_acts:
+        span_error = speech_act.evidence.validate(segment_text)
+        if span_error:
+            errors.append(f"speech act {speech_act.speech_act_id!r}: {span_error}")
+        if (
+            speech_act.speaker_entity_id
+            and speech_act.speaker_entity_id not in entity_ids
+        ):
+            errors.append(
+                f"speech act {speech_act.speech_act_id!r} references unknown "
+                f"speaker entity {speech_act.speaker_entity_id!r}"
+            )
+        for addressee_id in speech_act.addressee_entity_ids:
+            if addressee_id not in entity_ids:
+                errors.append(
+                    f"speech act {speech_act.speech_act_id!r} references "
+                    f"unknown addressee entity {addressee_id!r}"
+                )
+        if speech_act.linked_event_id and speech_act.linked_event_id not in event_ids:
+            errors.append(
+                f"speech act {speech_act.speech_act_id!r} references unknown "
+                f"linked event {speech_act.linked_event_id!r}"
+            )
+
+    for explanation in annotation.explanations:
+        span_error = explanation.evidence.validate(segment_text)
+        if span_error:
+            errors.append(f"explanation {explanation.explanation_id!r}: {span_error}")
+        for eid in explanation.linked_entity_ids:
+            if eid not in entity_ids:
+                errors.append(
+                    f"explanation {explanation.explanation_id!r} references "
+                    f"unknown entity {eid!r}"
+                )
+        for evid in explanation.linked_event_ids:
+            if evid not in event_ids:
+                errors.append(
+                    f"explanation {explanation.explanation_id!r} references "
+                    f"unknown event {evid!r}"
+                )
+
+    for tag in annotation.sf_tags:
+        span_error = tag.evidence.validate(segment_text)
+        if span_error:
+            errors.append(f"SF tag {tag.tag_id!r}: {span_error}")
+        for eid in tag.linked_entity_ids:
+            if eid not in entity_ids:
+                errors.append(
+                    f"SF tag {tag.tag_id!r} references unknown entity {eid!r}"
+                )
+        for evid in tag.linked_event_ids:
+            if evid not in event_ids:
+                errors.append(
+                    f"SF tag {tag.tag_id!r} references unknown event {evid!r}"
+                )
+
+    return errors
+
+
+@dataclasses.dataclass
+class StoryWorldAnnotation:
+    """Story-level reconciliation of per-segment Event-Role-World annotations.
+
+    Reconciles entities across segment boundaries (same canonical name,
+    case-insensitively, is treated as the same real-world entity) and
+    re-qualifies relations with story-scoped event IDs, since Event IDs are
+    only unique within one segment. This is the executable story-level
+    reconciliation the proposal requires beyond just holding per-segment
+    results in a list — see reconcile_story_annotations().
+
+    Attributes:
+        story_id: Identifier for the story these segments belong to.
+        segment_annotations: The per-segment annotations, in segment order.
+        entities: Reconciled entities, one per distinct canonical name
+            (case-insensitive) observed across all segments. entity_id on
+            each is a story-scoped global ID (e.g. "global_e0").
+        entity_alias_map: Maps "{segment_id}:{local_entity_id}" to the
+            reconciled global entity_id, so callers can translate a
+            per-segment entity reference into the story-level entity.
+        relations: All relations (main + weakly_inferred) across every
+            segment, with source_event_id/target_event_id re-qualified to
+            "{segment_id}:{local_event_id}" so they remain unambiguous at
+            story scope (event IDs are otherwise only unique per segment).
+        validation_errors: Story-level validation failures (see
+            validate_story_annotation).
+    """
+
+    story_id: Any
+    segment_annotations: List[SegmentWorldAnnotation] = dataclasses.field(
+        default_factory=list
+    )
+    entities: List[Entity] = dataclasses.field(default_factory=list)
+    entity_alias_map: Dict[str, str] = dataclasses.field(default_factory=dict)
+    relations: List[EventRelation] = dataclasses.field(default_factory=list)
+    validation_errors: List[str] = dataclasses.field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "story_id": self.story_id,
+            "segment_annotations": [a.to_dict() for a in self.segment_annotations],
+            "entities": [e.to_dict() for e in self.entities],
+            "entity_alias_map": dict(self.entity_alias_map),
+            "relations": [r.to_dict() for r in self.relations],
+            "validation_errors": self.validation_errors,
+        }
+
+
+def reconcile_story_annotations(
+    story_id: Any, segment_annotations: List[SegmentWorldAnnotation]
+) -> StoryWorldAnnotation:
+    """Reconcile per-segment annotations into one story-level annotation.
+
+    Args:
+        story_id: Identifier for the story.
+        segment_annotations: Per-segment annotations, in segment order.
+
+    Returns:
+        A StoryWorldAnnotation with entities merged across segments by
+        case-insensitive canonical_name (a simple, deterministic alias
+        heuristic — not full coreference resolution, which remains the
+        existing scene/sequel substrate's job, not this pipeline's), and
+        every relation re-qualified with segment-scoped event IDs.
+
+    Merging is deterministic given the same input: entities are visited in
+    segment order, then within-segment list order, and the first-seen
+    canonical_name (case-insensitively) for a given normalized key becomes
+    the reconciled entity's canonical_name. Running this function twice on
+    the same input produces identical global_entity_ids and ordering.
+    """
+    entities_by_key: Dict[str, Entity] = {}
+    entity_alias_map: Dict[str, str] = {}
+    relations: List[EventRelation] = []
+
+    for segment in segment_annotations:
+        for entity in segment.entities:
+            key = entity.canonical_name.strip().lower()
+            if key not in entities_by_key:
+                global_id = f"global_e{len(entities_by_key)}"
+                entities_by_key[key] = Entity(
+                    entity_id=global_id,
+                    canonical_name=entity.canonical_name,
+                    entity_type=entity.entity_type,
+                    aliases=list(entity.aliases),
+                    actant_roles=list(entity.actant_roles),
+                    confidence=entity.confidence,
+                )
+            else:
+                merged = entities_by_key[key]
+                for alias in entity.aliases:
+                    if alias not in merged.aliases:
+                        merged.aliases.append(alias)
+                for role in entity.actant_roles:
+                    if role not in merged.actant_roles:
+                        merged.actant_roles.append(role)
+                merged.confidence = max(merged.confidence, entity.confidence)
+            entity_alias_map[f"{segment.segment_id}:{entity.entity_id}"] = (
+                entities_by_key[key].entity_id
+            )
+
+        for relation in segment.relations + segment.weakly_inferred_relations:
+            relations.append(
+                dataclasses.replace(
+                    relation,
+                    source_event_id=f"{segment.segment_id}:{relation.source_event_id}",
+                    target_event_id=f"{segment.segment_id}:{relation.target_event_id}",
+                )
+            )
+
+    story = StoryWorldAnnotation(
+        story_id=story_id,
+        segment_annotations=list(segment_annotations),
+        entities=list(entities_by_key.values()),
+        entity_alias_map=entity_alias_map,
+        relations=relations,
+    )
+    story.validation_errors = validate_story_annotation(story)
+    return story
+
+
+def validate_story_annotation(story: StoryWorldAnnotation) -> List[str]:
+    """Validate story-level ID resolution for a StoryWorldAnnotation.
+
+    Per the proposal's Artifact validation section: all entity/event/
+    relation IDs must resolve, and causal links must carry evidence and
+    certainty (already enforced by EventRelation's required fields — this
+    checks that every relation's referenced qualified event ID actually
+    corresponds to a real event in some segment).
+
+    Args:
+        story: The StoryWorldAnnotation to validate.
+
+    Returns:
+        A list of human-readable error strings; empty if valid.
+    """
+    errors: List[str] = []
+
+    qualified_event_ids = {
+        f"{segment.segment_id}:{event.event_id}"
+        for segment in story.segment_annotations
+        for event in segment.events
+    }
+    global_entity_ids = {e.entity_id for e in story.entities}
+
+    for relation in story.relations:
+        if relation.source_event_id not in qualified_event_ids:
+            errors.append(
+                f"story relation {relation.relation_id!r} references unknown "
+                f"source event {relation.source_event_id!r}"
+            )
+        if relation.target_event_id not in qualified_event_ids:
+            errors.append(
+                f"story relation {relation.relation_id!r} references unknown "
+                f"target event {relation.target_event_id!r}"
+            )
+
+    for alias_key, global_id in story.entity_alias_map.items():
+        if global_id not in global_entity_ids:
+            errors.append(
+                f"entity_alias_map entry {alias_key!r} references unknown "
+                f"global entity {global_id!r}"
+            )
 
     return errors

--- a/lcats/project/executions/AD_HOC/2026_07_24_15_37_56_WI_EVENT_0026_IMPLEMENT_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_24_15_37_56_WI_EVENT_0026_IMPLEMENT_REVIEW.md
@@ -1,0 +1,41 @@
+---
+execution_id: 2026_07_24_15_37_56_WI_EVENT_0026_IMPLEMENT_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0026_IMPLEMENT_REVIEW)[2026-07-24T15:27:09-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_24_13_47_45_WI_EVENT_0026
+pr: https://github.com/xenotaur/LCATS/pull/150
+commit: b757335
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/150
+session_transcript: pending
+created_at: 2026-07-24T15:37:56-04:00
+---
+
+# Summary
+
+Address 4 open review comments on PR #150 (WI-EVENT-0026, the Event-Role-World extractor stages 6-7/9 implementation) via /lrh-review-response.
+
+# Result
+
+Fixed all 4 comments (chatgpt-codex-connector: 1 P1 + 2 P2; copilot-pull-request-reviewer: 1):
+
+1. (P1) Story-level relation qualification (`schema.reconcile_story_annotations`) unconditionally prefixes both relation endpoints with the *current* segment's ID. Traced the actual code path: stage 6's `relation_extractor.py` only ever receives its own segment's event IDs (the `{event_ids}` placeholder is built from that segment's own events), so a relation's source/target event ID can never reference a different segment's event today - this is a real scope limitation (genuine cross-segment causal relations cannot be extracted at all by the current per-segment stage-6 pass), not a bug in the qualification arithmetic itself. Per user direction, documented this explicitly: a "Known limitation" note on `StoryWorldAnnotation`'s docstring, an inline comment at the relation-qualification loop in `reconcile_story_annotations`, renamed the test that had misleadingly claimed to cover "cross-segment relations" (it only ever exercised same-segment relation qualification alongside cross-segment *entity* alias merging) to accurately describe what it tests, and recorded the follow-up in a new "Known Follow-ups" section on `WS-EVENT-ROLE-WORLD.md` so a future work item can design broader (multi-segment/full-story) context for stage 6 if the paper's analysis needs genuine cross-segment causal relations.
+2. (P2) Entity reconciliation matched only on `canonical_name` (case-insensitive), missing the case where the same participant has a different canonical name across segments with an overlapping alias (e.g. canonical "Elizabeth" in one segment, canonical "Liz" with alias "Elizabeth" in another) - these fragmented into two separate global entities. Reconciliation now matches an incoming entity against any of its own `{canonical_name} ∪ aliases}` (case-insensitive) against every name previously registered for an existing global entity, not canonical_name alone.
+3. (copilot) Story-level merged entities dropped `Entity.mention_ids` entirely, breaking traceability from `StoryWorldAnnotation.entities` back to `segment_annotations[*].mentions`. Now preserved as segment-qualified mention IDs (`"{segment_id}:{mention_id}"`) to avoid cross-segment mention-ID collisions.
+4. (P2) `discourse_extractor.build_discourse` shared one `EvidenceCursor` across the speech_acts/explanations/sf_tags loops, so when the *same* quoted span was legitimately claimed by more than one discourse layer at once (e.g. a line that is both a speech act and an SF-tagged phrase), the first layer's claim would consume the only occurrence and silently starve the later layers' otherwise-valid claims on that same span. Each layer now gets its own independent `EvidenceCursor`.
+
+Added/renamed 5 tests covering these fixes: `test_merges_entities_via_alias_overlap_not_just_canonical_name`, `test_preserves_segment_qualified_mention_ids_on_merge`, `test_same_quote_can_be_claimed_by_multiple_layers`, plus renamed `test_cross_segment_relation_targets_a_different_segments_event_via_alias` → `test_entity_alias_merge_across_segments_does_not_disturb_relation_qualification` with an honest docstring about what it does and does not cover.
+
+# Validation
+
+- `scripts/format --check --diff` - clean after reinstalling the repo-pinned `black==25.11.0` (local install had drifted to 26.3.1 again, unrelated to this diff - confirmed via `git status --short` showing only the 4 intended files).
+- `scripts/lint` - ruff and black both pass.
+- `scripts/test` - 1403 tests, all pass (up from 1400 before this fix round).
+- `lrh validate` (run from `lcats/`) - 0 errors, 33 warnings (all pre-existing `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS` warnings across the whole project, unrelated to this change).
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Cross-segment relation extraction (item 1 above) is now tracked in `WS-EVENT-ROLE-WORLD.md`'s "Known Follow-ups" section as a future work item, not something this PR attempts to fix.
+- Run `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/150` before merge to verify the fixes against the current diff and resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_24_16_40_14_WI_EVENT_0026_IMPLEMENT_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_24_16_40_14_WI_EVENT_0026_IMPLEMENT_CONFIRM.md
@@ -1,0 +1,45 @@
+---
+execution_id: 2026_07_24_16_40_14_WI_EVENT_0026_IMPLEMENT_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0026_IMPLEMENT_CONFIRM)[2026-07-24T16:06:10-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_24_13_47_45_WI_EVENT_0026
+pr: https://github.com/xenotaur/LCATS/pull/150
+commit: 38bd1a8
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/150
+session_transcript: pending
+created_at: 2026-07-24T16:40:14-04:00
+---
+
+# Summary
+
+Pre-merge verification of the review fixes pushed to PR #150 (WI-EVENT-0026) via /lrh-confirm-fixes: independently re-check the current HEAD diff against each of the 4 open review threads, resolve the ones it plainly satisfies, and surface anything else.
+
+# Result
+
+Gathered all 4 unresolved threads on PR #150 via `lrh github threads --mode raw --state all` filtered to `isResolved == false` (all chatgpt-codex-connector except one copilot-pull-request-reviewer thread).
+
+Per the user's explicit choice, fresh-eyes classification (Step 3) was dispatched to a cold subagent (no session memory) rather than classified inline, since this session authored the fixes being verified. The subagent checked out the PR branch independently and, notably for thread #1, was instructed to independently verify (not trust) the fix author's architectural claim that cross-segment relation endpoints are structurally unreachable — the subagent traced `processor.py`'s per-segment event_ids construction itself and confirmed the claim holds before classifying that thread.
+
+Verdict: **4 of 4 Clear-satisfied** — every thread's concern is plainly resolved by the current diff. No Unaddressed, Partial, Ambiguous, or Problematic findings.
+
+User confirmed the full batch. All 4 threads resolved via `gh api graphql resolveReviewThread`:
+- discussion_r3647186472 (P1, cross-segment relation endpoint qualification — resolved via documentation + WS-EVENT-ROLE-WORLD.md follow-up tracking, since the underlying scenario is architecturally unreachable given stage 6's per-segment-only event ID scope)
+- discussion_r3647186475 (entity reconciliation now matches through aliases, not just canonical name)
+- discussion_r3647186486 (discourse layers now use independent evidence cursors)
+- discussion_r3647188461 (copilot, story-level merged entities now preserve segment-qualified mention_ids)
+
+Thread-resolution verdict (Step 6): **green** — every verifiable thread resolved, no exceptions remain open.
+
+# Validation
+
+- Subagent independently ran `python -m pytest tests/analysis_tests/event_role_world_test.py -v` on the checked-out PR branch: 66 passed, 0 failed.
+- Subagent independently ran `lrh validate` on the checked-out PR branch: 0 errors, 33 warnings (all pre-existing owner-field warnings, unrelated to this PR).
+- Provisional CI (pre-confirm-commit, `gh pr checks 150 --json name,state,bucket`; this repo has no required-status-checks configured, so the unfiltered check list is authoritative): coverage, lint, test all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- CI must be re-checked against the post-push HEAD SHA (this record's own commit) before reporting final merge readiness — see the readiness report that follows this record's push.
+- Cross-segment relation extraction remains tracked as a future work item in `WS-EVENT-ROLE-WORLD.md`'s "Known Follow-ups" section, not something this PR or its fixes attempt.

--- a/lcats/project/executions/WI-EVENT-0026/2026_07_24_13_47_45_WI_EVENT_0026.md
+++ b/lcats/project/executions/WI-EVENT-0026/2026_07_24_13_47_45_WI_EVENT_0026.md
@@ -1,0 +1,44 @@
+---
+execution_id: 2026_07_24_13_47_45_WI_EVENT_0026
+prompt_id: PROMPT(WI-EVENT-0026:WI_EVENT_0026)[2026-07-24T13:22:01-04:00]
+work_item: WI-EVENT-0026
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/150
+commit: ec1c557
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-EVENT-0026.md
+session_transcript: pending
+created_at: 2026-07-24T13:47:45-04:00
+---
+
+# Summary
+
+Implement WI-EVENT-0026: the Event-Role-World extractor's stages 6-7 (relation pass, discourse/SF-tag pass) and 9 (validation/export), building on WI-EVENT-0024's stages 1-5. Also required: story-level reconciliation and a baseline.py extension covering the new layers, per review feedback that shaped this work item's final acceptance criteria (PR #149).
+
+# Result
+
+Implemented all required changes:
+
+- `schema.py`: added `EventRelation` (partitions `weakly_inferred` certainty into a separate list from `explicit`/`strongly_implied`, distinct from the stage-8 `Hypothesis` dataclass), `SpeechAct`, `ExplanationDiscourse`, `SFWorldModelTag`; extended `SegmentWorldAnnotation` with `relations`/`weakly_inferred_relations`/`speech_acts`/`explanations`/`sf_tags`; extended `validate_segment_annotation` to check the new layers' ID resolution and evidence alignment; added `StoryWorldAnnotation` and `reconcile_story_annotations()` for story-level entity alias resolution (case-insensitive canonical-name merge) and cross-segment relation qualification (event IDs re-qualified as `"{segment_id}:{event_id}"`); added `validate_story_annotation()`.
+- `relation_extractor.py` (new): stage 6, same `JSONPromptExtractor` tool-schema pattern as `entity_extractor.py`/`event_extractor.py`.
+- `discourse_extractor.py` (new): stage 7, same pattern, extracting speech acts/explanations/SF tags in one call.
+- `export.py` (new): stage 9 — `to_canonical_json()` (deterministic, sorted keys), `build_analysis_tables()`/`rows_to_jsonl()`/`rows_to_csv()` for derived tables, `validate_artifacts()` running the proposal's Artifact validation checks.
+- `processor.py`: generalized the existing `_extract_events_with_entity_ids` helper into `_extract_with_placeholders()` (supports multiple named ID-list placeholders), used it to wire in the relation and discourse passes with the same routed-through-`extract()` error handling as the existing entity/event passes; `process_segments()` now also runs `schema.reconcile_story_annotations()` and returns a `"story"` key in its result.
+- `baseline.py`: `summarize_annotations()` extended to report relation/weakly-inferred-relation/speech-act/explanation/SF-tag per-1000-word rates alongside the existing entity/event/anchor ones.
+- `tests/analysis_tests/event_role_world_test.py`: added `TestBuildRelations`, `TestBuildDiscourse`, `TestReconcileStoryAnnotations` (including a dedicated cross-segment alias/relation test), `TestExport`; extended `TestSummarizeAndCompare` and `TestProcessSegments` (including relation/discourse extraction-failure propagation tests mirroring the existing entity/event ones, and updated the two pre-existing `_SequencedFakeBackend`-based tests for the new 4-call-per-segment flow).
+
+Manual smoke-testing (before formal tests) confirmed: exactly 4 LLM calls per segment (entity, event, relation, discourse — no dead calls), story-level reconciliation correctly merges same-canonical-name entities across segments and re-qualifies a cross-segment weakly-inferred relation, and `export.to_canonical_json()` is byte-identical across repeated calls on the same input.
+
+# Validation
+
+- `scripts/format --check --diff` — clean (after reinstalling the repo-pinned `black==25.11.0`; local install had drifted to 26.3.1, unrelated to this diff — confirmed via `git status --short` showing only the intended files).
+- `scripts/lint` — ruff and black both pass.
+- `scripts/test` — 1400 tests, all pass (up from 1375 before this change).
+- `lrh validate` (run from `lcats/`) — 0 errors, 33 warnings (all pre-existing `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS` warnings across the whole project, unrelated to this change).
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Stage 8 (optional hypothesis pass) remains deferred, per this work item's own Non-Goals — a follow-up work item should be recorded if and when the workstream picks it up.
+- Wait for reviewer comments and run `/lrh-review-response https://github.com/xenotaur/LCATS/pull/150` to address them, then `/lrh-confirm-fixes` before merge. After merging, run `/lrh-closeout` to land this record and move WI-EVENT-0026 to `resolved/`.

--- a/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
@@ -99,6 +99,26 @@ the proposal itself prescribes:
 
 (see frontmatter `exit_criteria:` above)
 
+## Known Follow-ups
+
+- **Cross-segment relation extraction is not implemented.** WI-EVENT-0026's
+  stage-6 relation pass (and the story-level reconciliation that qualifies
+  its output) only operate within one segment at a time:
+  `relation_extractor.py` only ever receives its own segment's event IDs,
+  so a relation's source/target event can never actually reference a
+  different segment's event today. Story-level reconciliation
+  (`schema.reconcile_story_annotations`) correctly qualifies every
+  same-segment relation for safe story-scoped representation, but it
+  cannot discover or represent a genuinely cross-segment causal link
+  (e.g. a cause established in one scene and its effect appearing several
+  segments later). Raised during WI-EVENT-0026's review
+  (`chatgpt-codex-connector`, PR #150); see the "Known limitation" note on
+  `schema.StoryWorldAnnotation`. If the paper's analysis needs
+  cross-segment causal relations, a follow-up work item should design how
+  stage 6 gets broader (multi-segment or full-story) context — likely a
+  meaningfully different extraction strategy than the current per-segment
+  `tool=` call, so it is not a small addition to WI-EVENT-0026's scope.
+
 ## Non-Goals
 
 - Does not reimplement scene/sequel extraction, GACD/ERAC classification,

--- a/lcats/tests/analysis_tests/event_role_world_test.py
+++ b/lcats/tests/analysis_tests/event_role_world_test.py
@@ -5,10 +5,13 @@ import unittest.mock
 
 from lcats.llm import backend as llm_backend
 from lcats.analysis.event_role_world import baseline
+from lcats.analysis.event_role_world import discourse_extractor
 from lcats.analysis.event_role_world import entity_extractor
 from lcats.analysis.event_role_world import event_extractor
+from lcats.analysis.event_role_world import export
 from lcats.analysis.event_role_world import nlp_backend
 from lcats.analysis.event_role_world import processor
+from lcats.analysis.event_role_world import relation_extractor
 from lcats.analysis.event_role_world import schema
 from lcats.analysis.event_role_world import surface_feature_extractor
 
@@ -448,6 +451,402 @@ class TestBuildEventsAndAnchors(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Tests: relation_extractor (stage 6)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRelations(unittest.TestCase):
+    def test_builds_explicit_relation_in_main_list(self):
+        text = "The machine hummed, which caused the lights to flicker."
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "ev1",
+                    "target_event_id": "ev2",
+                    "relation_type": "causes",
+                    "quote": "hummed",
+                    "certainty": "explicit",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+        relations, weakly_inferred = relation_extractor.build_relations(
+            tool_result, text
+        )
+        self.assertEqual(len(relations), 1)
+        self.assertEqual(relations[0].relation_id, "r1")
+        self.assertEqual(relations[0].certainty, "explicit")
+        self.assertEqual(weakly_inferred, [])
+
+    def test_partitions_weakly_inferred_relation_into_separate_list(self):
+        text = "The machine hummed."
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "ev1",
+                    "target_event_id": "ev2",
+                    "relation_type": "motivates",
+                    "quote": "hummed",
+                    "certainty": "weakly_inferred",
+                }
+            ]
+        }
+        relations, weakly_inferred = relation_extractor.build_relations(
+            tool_result, text
+        )
+        self.assertEqual(relations, [])
+        self.assertEqual(len(weakly_inferred), 1)
+        self.assertEqual(weakly_inferred[0].certainty, "weakly_inferred")
+
+    def test_drops_relation_with_unresolvable_quote(self):
+        text = "The machine hummed."
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "ev1",
+                    "target_event_id": "ev2",
+                    "relation_type": "causes",
+                    "quote": "not present in text",
+                }
+            ]
+        }
+        relations, weakly_inferred = relation_extractor.build_relations(
+            tool_result, text
+        )
+        self.assertEqual(relations, [])
+        self.assertEqual(weakly_inferred, [])
+
+    def test_empty_tool_result_produces_no_relations(self):
+        relations, weakly_inferred = relation_extractor.build_relations({}, "some text")
+        self.assertEqual(relations, [])
+        self.assertEqual(weakly_inferred, [])
+
+
+# ---------------------------------------------------------------------------
+# Tests: discourse_extractor (stage 7)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDiscourse(unittest.TestCase):
+    def test_builds_speech_act_explanation_and_sf_tag(self):
+        text = (
+            '"Reroute the plasma conduits," she said, since the core was overheating.'
+        )
+        tool_result = {
+            "speech_acts": [
+                {
+                    "speech_act_id": "sp1",
+                    "act_type": "command",
+                    "quote": "Reroute the plasma conduits",
+                    "speaker_entity_id": "e1",
+                    "addressee_entity_ids": ["e2"],
+                }
+            ],
+            "explanations": [
+                {
+                    "explanation_id": "ex1",
+                    "topic": "overheating core",
+                    "mechanism_or_rationale_type": "technical_operation",
+                    "quote": "the core was overheating",
+                    "linked_entity_ids": ["e2"],
+                }
+            ],
+            "sf_tags": [
+                {
+                    "tag_id": "sf1",
+                    "tag": "technology_as_agent",
+                    "quote": "plasma conduits",
+                    "linked_entity_ids": ["e2"],
+                    "status": "extractive",
+                }
+            ],
+        }
+        speech_acts, explanations, sf_tags = discourse_extractor.build_discourse(
+            tool_result, text
+        )
+        self.assertEqual(len(speech_acts), 1)
+        self.assertEqual(speech_acts[0].speaker_entity_id, "e1")
+        self.assertEqual(len(explanations), 1)
+        self.assertEqual(
+            explanations[0].mechanism_or_rationale_type, "technical_operation"
+        )
+        self.assertEqual(len(sf_tags), 1)
+        self.assertEqual(sf_tags[0].status, "extractive")
+
+    def test_defaults_sf_tag_status_to_hypothesis(self):
+        text = "The old machine hummed."
+        tool_result = {
+            "sf_tags": [
+                {"tag_id": "sf1", "tag": "anomaly_or_novum", "quote": "machine"}
+            ]
+        }
+        _, _, sf_tags = discourse_extractor.build_discourse(tool_result, text)
+        self.assertEqual(sf_tags[0].status, "hypothesis")
+
+    def test_drops_items_with_unresolvable_quotes(self):
+        text = "The machine hummed."
+        tool_result = {
+            "speech_acts": [
+                {"speech_act_id": "sp1", "act_type": "assertion", "quote": "nowhere"}
+            ],
+            "explanations": [
+                {
+                    "explanation_id": "ex1",
+                    "topic": "x",
+                    "mechanism_or_rationale_type": "x",
+                    "quote": "nowhere",
+                }
+            ],
+            "sf_tags": [{"tag_id": "sf1", "tag": "x", "quote": "nowhere"}],
+        }
+        speech_acts, explanations, sf_tags = discourse_extractor.build_discourse(
+            tool_result, text
+        )
+        self.assertEqual(speech_acts, [])
+        self.assertEqual(explanations, [])
+        self.assertEqual(sf_tags, [])
+
+    def test_empty_tool_result_produces_nothing(self):
+        speech_acts, explanations, sf_tags = discourse_extractor.build_discourse(
+            {}, "some text"
+        )
+        self.assertEqual(speech_acts, [])
+        self.assertEqual(explanations, [])
+        self.assertEqual(sf_tags, [])
+
+
+# ---------------------------------------------------------------------------
+# Tests: schema.reconcile_story_annotations / validate_story_annotation (stage 9)
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileStoryAnnotations(unittest.TestCase):
+    def _entity(self, entity_id, canonical_name):
+        return schema.Entity(
+            entity_id=entity_id, canonical_name=canonical_name, entity_type="x"
+        )
+
+    def test_merges_entities_with_same_canonical_name_case_insensitively(self):
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1, entities=[self._entity("e1", "the machine")]
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2, entities=[self._entity("e1", "The Machine")]
+        )
+
+        story = schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+        self.assertEqual(len(story.entities), 1)
+        self.assertEqual(
+            story.entity_alias_map,
+            {"1:e1": story.entities[0].entity_id, "2:e1": story.entities[0].entity_id},
+        )
+        self.assertEqual(story.validation_errors, [])
+
+    def test_keeps_distinct_entities_separate(self):
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1, entities=[self._entity("e1", "the machine")]
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2, entities=[self._entity("e1", "the captain")]
+        )
+
+        story = schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+        self.assertEqual(len(story.entities), 2)
+
+    def test_qualifies_relation_event_ids_with_segment_id(self):
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        relation = schema.EventRelation(
+            relation_id="r1",
+            source_event_id="ev1",
+            target_event_id="ev2",
+            relation_type="causes",
+            evidence=evidence,
+            certainty="explicit",
+        )
+        seg = schema.SegmentWorldAnnotation(segment_id=7, relations=[relation])
+
+        story = schema.reconcile_story_annotations("s1", [seg])
+
+        self.assertEqual(len(story.relations), 1)
+        self.assertEqual(story.relations[0].source_event_id, "7:ev1")
+        self.assertEqual(story.relations[0].target_event_id, "7:ev2")
+
+    def test_cross_segment_relation_targets_a_different_segments_event_via_alias(self):
+        """A cross-segment reference: the story-level view must keep a
+        relation's segment-qualified event ID resolvable even though the
+        relation was extracted within one segment's local ID space and the
+        referenced entity is reconciled across a different segment."""
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        event = schema.Event(
+            event_id="ev1", predicate="p", event_type="x", evidence=evidence
+        )
+        relation = schema.EventRelation(
+            relation_id="r1",
+            source_event_id="ev1",
+            target_event_id="ev1",
+            relation_type="precedes",
+            evidence=evidence,
+            certainty="weakly_inferred",
+        )
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1, entities=[self._entity("e1", "the machine")], events=[event]
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2,
+            entities=[self._entity("e1", "The Machine")],
+            events=[event],
+            weakly_inferred_relations=[relation],
+        )
+
+        story = schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+        # Entities from both segments merged into one global entity.
+        self.assertEqual(len(story.entities), 1)
+        global_id = story.entities[0].entity_id
+        self.assertEqual(story.entity_alias_map["1:e1"], global_id)
+        self.assertEqual(story.entity_alias_map["2:e1"], global_id)
+        # The weakly_inferred relation (from segment 2) is qualified with
+        # segment 2's ID, not segment 1's, and resolves against segment 2's
+        # own event list.
+        self.assertEqual(len(story.relations), 1)
+        self.assertEqual(story.relations[0].source_event_id, "2:ev1")
+        self.assertEqual(story.validation_errors, [])
+
+    def test_validate_story_annotation_flags_dangling_relation(self):
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        relation = schema.EventRelation(
+            relation_id="r1",
+            source_event_id="does_not_exist",
+            target_event_id="also_missing",
+            relation_type="causes",
+            evidence=evidence,
+        )
+        story = schema.StoryWorldAnnotation(story_id="s1", relations=[relation])
+        errors = schema.validate_story_annotation(story)
+        self.assertTrue(any("does_not_exist" in e for e in errors))
+        self.assertTrue(any("also_missing" in e for e in errors))
+
+    def test_reconciliation_is_deterministic(self):
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1, entities=[self._entity("e1", "the machine")]
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2, entities=[self._entity("e1", "The Machine")]
+        )
+
+        story_a = schema.reconcile_story_annotations("s1", [seg1, seg2])
+        story_b = schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+        self.assertEqual(story_a.to_dict(), story_b.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Tests: export (stage 9)
+# ---------------------------------------------------------------------------
+
+
+class TestExport(unittest.TestCase):
+    def _story_with_one_of_everything(self):
+        evidence = schema.EvidenceSpan(start_char=0, end_char=7, quote="machine")
+        entity = schema.Entity(
+            entity_id="e1",
+            canonical_name="the machine",
+            entity_type="x",
+            mention_ids=["m1"],
+        )
+        mention = schema.EntityMention(
+            mention_id="m1", entity_id="e1", text="machine", evidence=evidence
+        )
+        event = schema.Event(
+            event_id="ev1", predicate="hummed", event_type="x", evidence=evidence
+        )
+        relation = schema.EventRelation(
+            relation_id="r1",
+            source_event_id="ev1",
+            target_event_id="ev1",
+            relation_type="causes",
+            evidence=evidence,
+            certainty="explicit",
+        )
+        speech_act = schema.SpeechAct(
+            speech_act_id="sp1", act_type="assertion", evidence=evidence
+        )
+        explanation = schema.ExplanationDiscourse(
+            explanation_id="ex1",
+            topic="t",
+            mechanism_or_rationale_type="x",
+            evidence=evidence,
+        )
+        sf_tag = schema.SFWorldModelTag(
+            tag_id="sf1", tag="novum", evidence=evidence, status="extractive"
+        )
+        seg = schema.SegmentWorldAnnotation(
+            segment_id=1,
+            entities=[entity],
+            mentions=[mention],
+            events=[event],
+            relations=[relation],
+            speech_acts=[speech_act],
+            explanations=[explanation],
+            sf_tags=[sf_tag],
+        )
+        return schema.reconcile_story_annotations("s1", [seg])
+
+    def test_validate_artifacts_passes_for_clean_story(self):
+        story = self._story_with_one_of_everything()
+        self.assertEqual(export.validate_artifacts(story), [])
+
+    def test_validate_artifacts_flags_invalid_sf_tag_status(self):
+        story = self._story_with_one_of_everything()
+        story.segment_annotations[0].sf_tags[0].status = "not_a_valid_status"
+        errors = export.validate_artifacts(story)
+        self.assertTrue(any("invalid status" in e for e in errors))
+
+    def test_validate_artifacts_flags_invalid_relation_certainty(self):
+        story = self._story_with_one_of_everything()
+        story.segment_annotations[0].relations[0].certainty = "not_a_valid_certainty"
+        errors = export.validate_artifacts(story)
+        self.assertTrue(any("invalid certainty" in e for e in errors))
+
+    def test_to_canonical_json_is_deterministic(self):
+        story = self._story_with_one_of_everything()
+        self.assertEqual(
+            export.to_canonical_json(story), export.to_canonical_json(story)
+        )
+
+    def test_build_analysis_tables_covers_every_layer(self):
+        story = self._story_with_one_of_everything()
+        tables = export.build_analysis_tables(story)
+        for table_name in (
+            "entities",
+            "events",
+            "relations",
+            "speech_acts",
+            "explanations",
+            "sf_tags",
+        ):
+            self.assertEqual(len(tables[table_name]), 1, table_name)
+
+    def test_rows_to_jsonl_produces_one_line_per_row(self):
+        rows = [{"a": 1}, {"a": 2}]
+        lines = export.rows_to_jsonl(rows).splitlines()
+        self.assertEqual(len(lines), 2)
+
+    def test_rows_to_csv_handles_empty_rows(self):
+        self.assertEqual(export.rows_to_csv([]), "")
+
+    def test_rows_to_csv_json_encodes_nested_values(self):
+        rows = [{"evidence": {"quote": "x"}, "linked_entity_ids": ["e1"]}]
+        csv_text = export.rows_to_csv(rows)
+        self.assertIn('"quote"', csv_text)
+
+
+# ---------------------------------------------------------------------------
 # Tests: baseline
 # ---------------------------------------------------------------------------
 
@@ -532,7 +931,18 @@ class TestMakeFixedTokenChunks(unittest.TestCase):
 
 
 class TestSummarizeAndCompare(unittest.TestCase):
-    def _annotation(self, word_count, n_entities, n_events):
+    def _annotation(
+        self,
+        word_count,
+        n_entities,
+        n_events,
+        n_relations=0,
+        n_weakly_inferred_relations=0,
+        n_speech_acts=0,
+        n_explanations=0,
+        n_sf_tags=0,
+    ):
+        evidence = schema.EvidenceSpan(0, 1, "x")
         return schema.SegmentWorldAnnotation(
             segment_id=1,
             surface_features=schema.SurfaceFeatures(
@@ -556,6 +966,33 @@ class TestSummarizeAndCompare(unittest.TestCase):
                 )
                 for i in range(n_events)
             ],
+            relations=[
+                schema.EventRelation(f"r{i}", "ev0", "ev0", "causes", evidence)
+                for i in range(n_relations)
+            ],
+            weakly_inferred_relations=[
+                schema.EventRelation(
+                    f"wr{i}",
+                    "ev0",
+                    "ev0",
+                    "causes",
+                    evidence,
+                    certainty="weakly_inferred",
+                )
+                for i in range(n_weakly_inferred_relations)
+            ],
+            speech_acts=[
+                schema.SpeechAct(f"sp{i}", "assertion", evidence)
+                for i in range(n_speech_acts)
+            ],
+            explanations=[
+                schema.ExplanationDiscourse(f"ex{i}", "t", "x", evidence)
+                for i in range(n_explanations)
+            ],
+            sf_tags=[
+                schema.SFWorldModelTag(f"sf{i}", "x", evidence)
+                for i in range(n_sf_tags)
+            ],
         )
 
     def test_summarize_computes_per_1000_word_rates(self):
@@ -569,6 +1006,26 @@ class TestSummarizeAndCompare(unittest.TestCase):
         annotations = [self._annotation(word_count=0, n_entities=0, n_events=0)]
         summary = baseline.summarize_annotations(annotations)
         self.assertEqual(summary["entities_per_1000_words"], 0.0)
+
+    def test_summarize_covers_relation_discourse_and_sf_tag_layers(self):
+        annotations = [
+            self._annotation(
+                word_count=500,
+                n_entities=0,
+                n_events=0,
+                n_relations=1,
+                n_weakly_inferred_relations=2,
+                n_speech_acts=3,
+                n_explanations=4,
+                n_sf_tags=5,
+            )
+        ]
+        summary = baseline.summarize_annotations(annotations)
+        self.assertEqual(summary["relations_per_1000_words"], 2.0)
+        self.assertEqual(summary["weakly_inferred_relations_per_1000_words"], 4.0)
+        self.assertEqual(summary["speech_acts_per_1000_words"], 6.0)
+        self.assertEqual(summary["explanations_per_1000_words"], 8.0)
+        self.assertEqual(summary["sf_tags_per_1000_words"], 10.0)
 
     def test_compare_returns_both_strategies(self):
         seg = [self._annotation(word_count=500, n_entities=1, n_events=1)]
@@ -652,7 +1109,37 @@ class TestProcessSegments(unittest.TestCase):
                 }
             ],
         }
-        fake = _SequencedFakeBackend([entity_tool_result, event_tool_result])
+        relation_tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "ev1",
+                    "target_event_id": "ev1",
+                    "relation_type": "enables",
+                    "quote": "hummed",
+                    "certainty": "explicit",
+                }
+            ]
+        }
+        discourse_tool_result = {
+            "sf_tags": [
+                {
+                    "tag_id": "sf1",
+                    "tag": "nonhuman_actant",
+                    "quote": "machine",
+                    "linked_entity_ids": ["e1"],
+                    "status": "extractive",
+                }
+            ]
+        }
+        fake = _SequencedFakeBackend(
+            [
+                entity_tool_result,
+                event_tool_result,
+                relation_tool_result,
+                discourse_tool_result,
+            ]
+        )
         segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
 
         result = processor.process_segments(
@@ -665,10 +1152,13 @@ class TestProcessSegments(unittest.TestCase):
         self.assertEqual(len(seg["events"]), 1)
         self.assertEqual(len(seg["temporal_anchors"]), 1)
         self.assertEqual(len(seg["spatial_anchors"]), 1)
+        self.assertEqual(len(seg["relations"]), 1)
+        self.assertEqual(seg["weakly_inferred_relations"], [])
+        self.assertEqual(len(seg["sf_tags"]), 1)
         self.assertEqual(seg["validation_errors"], [])
 
-        # Exactly one LLM call for entities, one for events - not more.
-        self.assertEqual(len(fake.calls), 2)
+        # Exactly one LLM call each for entities, events, relations, discourse.
+        self.assertEqual(len(fake.calls), 4)
 
         # Cost/usage reporting: token counts, model, and elapsed time per
         # pass - not just call counts (WI-EVENT-0024 acceptance criterion).
@@ -676,10 +1166,17 @@ class TestProcessSegments(unittest.TestCase):
         self.assertIn("surface_feature", usage_by_pass)
         self.assertIn("entity", usage_by_pass)
         self.assertIn("event_anchor", usage_by_pass)
+        self.assertIn("relation", usage_by_pass)
+        self.assertIn("discourse", usage_by_pass)
         self.assertFalse(usage_by_pass["surface_feature"]["is_llm_backed"])
         self.assertTrue(usage_by_pass["entity"]["is_llm_backed"])
         self.assertEqual(usage_by_pass["entity"]["input_tokens"], 10)
         self.assertEqual(usage_by_pass["entity"]["model"], "fake-1.0")
+
+        # Stage 9: story-level reconciliation is included in the result.
+        self.assertIn("story", result)
+        self.assertEqual(len(result["story"]["entities"]), 1)
+        self.assertEqual(result["story"]["entity_alias_map"], {"1:e1": "global_e0"})
 
     def test_entity_ids_from_stage_3_are_passed_to_stage_4_5_prompt(self):
         segment_text = "The machine hummed."
@@ -696,7 +1193,9 @@ class TestProcessSegments(unittest.TestCase):
             ]
         }
         event_tool_result = {"events": []}
-        fake = _SequencedFakeBackend([entity_tool_result, event_tool_result])
+        fake = _SequencedFakeBackend(
+            [entity_tool_result, event_tool_result, {"relations": []}, {}]
+        )
         segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
 
         processor.process_segments(
@@ -821,6 +1320,96 @@ class TestProcessSegments(unittest.TestCase):
         # Segment 2 still got processed despite segment 1's failure.
         seg2 = result["segments"][1]
         self.assertEqual(seg2["extraction_errors"], [])
+
+    def test_relation_extraction_failure_is_recorded_not_silently_empty(self):
+        """A failed relation pass must not read as 'zero relations found'."""
+        segment_text = "The machine hummed."
+
+        class _NoToolResultOnThirdCallBackend:
+            def __init__(self):
+                self.calls = 0
+
+            def complete(self, **kwargs):
+                self.calls += 1
+                if self.calls == 3:
+                    # Call order per segment: entity, event, relation,
+                    # discourse. Simulate a tool-call failure on the
+                    # relation pass (call #3).
+                    return llm_backend.BackendResponse(
+                        text="",
+                        tool_result=None,
+                        model="fake-1.0",
+                        input_tokens=5,
+                        output_tokens=0,
+                        raw=None,
+                    )
+                return llm_backend.BackendResponse(
+                    text="",
+                    tool_result={},
+                    model="fake-1.0",
+                    input_tokens=5,
+                    output_tokens=2,
+                    raw=None,
+                )
+
+        backend = _NoToolResultOnThirdCallBackend()
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        result = processor.process_segments(
+            segment_text, segments, nlp_backend_name="spacy", llm_backend=backend
+        )
+
+        seg = result["segments"][0]
+        self.assertEqual(seg["relations"], [])
+        self.assertTrue(
+            any("relation extraction failed" in e for e in seg["extraction_errors"]),
+            seg["extraction_errors"],
+        )
+
+    def test_discourse_extraction_failure_is_recorded_not_silently_empty(self):
+        """A failed discourse pass must not read as 'nothing found'."""
+        segment_text = "The machine hummed."
+
+        class _NoToolResultOnFourthCallBackend:
+            def __init__(self):
+                self.calls = 0
+
+            def complete(self, **kwargs):
+                self.calls += 1
+                if self.calls == 4:
+                    # Call order per segment: entity, event, relation,
+                    # discourse. Simulate a tool-call failure on the
+                    # discourse pass (call #4).
+                    return llm_backend.BackendResponse(
+                        text="",
+                        tool_result=None,
+                        model="fake-1.0",
+                        input_tokens=5,
+                        output_tokens=0,
+                        raw=None,
+                    )
+                return llm_backend.BackendResponse(
+                    text="",
+                    tool_result={},
+                    model="fake-1.0",
+                    input_tokens=5,
+                    output_tokens=2,
+                    raw=None,
+                )
+
+        backend = _NoToolResultOnFourthCallBackend()
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        result = processor.process_segments(
+            segment_text, segments, nlp_backend_name="spacy", llm_backend=backend
+        )
+
+        seg = result["segments"][0]
+        self.assertEqual(seg["sf_tags"], [])
+        self.assertTrue(
+            any("discourse extraction failed" in e for e in seg["extraction_errors"]),
+            seg["extraction_errors"],
+        )
 
 
 if __name__ == "__main__":

--- a/lcats/tests/analysis_tests/event_role_world_test.py
+++ b/lcats/tests/analysis_tests/event_role_world_test.py
@@ -617,6 +617,44 @@ class TestBuildDiscourse(unittest.TestCase):
         self.assertEqual(explanations, [])
         self.assertEqual(sf_tags, [])
 
+    def test_same_quote_can_be_claimed_by_multiple_layers(self):
+        """A single passage can legitimately be both a speech act AND an
+        explanation AND an SF tag at once. A shared cursor across layers
+        would let the first layer's claim consume the only occurrence of
+        the quote, silently dropping the later layers' otherwise-valid
+        claims on that same span."""
+        text = '"Reroute the plasma conduits," she said.'
+        tool_result = {
+            "speech_acts": [
+                {
+                    "speech_act_id": "sp1",
+                    "act_type": "command",
+                    "quote": "Reroute the plasma conduits",
+                }
+            ],
+            "explanations": [
+                {
+                    "explanation_id": "ex1",
+                    "topic": "plasma routing",
+                    "mechanism_or_rationale_type": "technical_operation",
+                    "quote": "Reroute the plasma conduits",
+                }
+            ],
+            "sf_tags": [
+                {
+                    "tag_id": "sf1",
+                    "tag": "technology_as_agent",
+                    "quote": "Reroute the plasma conduits",
+                }
+            ],
+        }
+        speech_acts, explanations, sf_tags = discourse_extractor.build_discourse(
+            tool_result, text
+        )
+        self.assertEqual(len(speech_acts), 1)
+        self.assertEqual(len(explanations), 1)
+        self.assertEqual(len(sf_tags), 1)
+
 
 # ---------------------------------------------------------------------------
 # Tests: schema.reconcile_story_annotations / validate_story_annotation (stage 9)
@@ -624,9 +662,13 @@ class TestBuildDiscourse(unittest.TestCase):
 
 
 class TestReconcileStoryAnnotations(unittest.TestCase):
-    def _entity(self, entity_id, canonical_name):
+    def _entity(self, entity_id, canonical_name, aliases=None, mention_ids=None):
         return schema.Entity(
-            entity_id=entity_id, canonical_name=canonical_name, entity_type="x"
+            entity_id=entity_id,
+            canonical_name=canonical_name,
+            entity_type="x",
+            aliases=list(aliases or []),
+            mention_ids=list(mention_ids or []),
         )
 
     def test_merges_entities_with_same_canonical_name_case_insensitively(self):
@@ -645,6 +687,49 @@ class TestReconcileStoryAnnotations(unittest.TestCase):
             {"1:e1": story.entities[0].entity_id, "2:e1": story.entities[0].entity_id},
         )
         self.assertEqual(story.validation_errors, [])
+
+    def test_merges_entities_via_alias_overlap_not_just_canonical_name(self):
+        """Two segments give the same participant different canonical
+        names ("Elizabeth" vs "Liz"), but the second segment's alias list
+        overlaps the first segment's canonical name — matching on
+        canonical_name alone would never notice this and would fragment
+        the participant into two global entities."""
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1, entities=[self._entity("e1", "Elizabeth")]
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2,
+            entities=[self._entity("e1", "Liz", aliases=["Elizabeth"])],
+        )
+
+        story = schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+        self.assertEqual(len(story.entities), 1)
+        merged = story.entities[0]
+        self.assertEqual(merged.canonical_name, "Elizabeth")
+        self.assertIn("Liz", merged.aliases)
+        self.assertEqual(
+            story.entity_alias_map, {"1:e1": merged.entity_id, "2:e1": merged.entity_id}
+        )
+
+    def test_preserves_segment_qualified_mention_ids_on_merge(self):
+        """Story-level merged entities must not drop Entity.mention_ids —
+        they should be segment-qualified so they stay traceable back to
+        segment_annotations[*].mentions without colliding across segments
+        that both use e.g. mention_id "m1"."""
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1,
+            entities=[self._entity("e1", "the machine", mention_ids=["m1"])],
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2,
+            entities=[self._entity("e1", "The Machine", mention_ids=["m1"])],
+        )
+
+        story = schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+        self.assertEqual(len(story.entities), 1)
+        self.assertEqual(sorted(story.entities[0].mention_ids), ["1:m1", "2:m1"])
 
     def test_keeps_distinct_entities_separate(self):
         seg1 = schema.SegmentWorldAnnotation(
@@ -676,11 +761,18 @@ class TestReconcileStoryAnnotations(unittest.TestCase):
         self.assertEqual(story.relations[0].source_event_id, "7:ev1")
         self.assertEqual(story.relations[0].target_event_id, "7:ev2")
 
-    def test_cross_segment_relation_targets_a_different_segments_event_via_alias(self):
-        """A cross-segment reference: the story-level view must keep a
-        relation's segment-qualified event ID resolvable even though the
-        relation was extracted within one segment's local ID space and the
-        referenced entity is reconciled across a different segment."""
+    def test_entity_alias_merge_across_segments_does_not_disturb_relation_qualification(
+        self,
+    ):
+        """Entity reconciliation (which does span segments) and relation
+        qualification (which does not — see the "Known limitation" note on
+        StoryWorldAnnotation) are independent: merging the same entity seen
+        under different segments must not affect how a same-segment
+        relation's event IDs get qualified. This is NOT a test of a
+        genuinely cross-segment relation (source event in one segment,
+        target event in another) — the current per-segment stage-6
+        relation_extractor cannot produce one, since it only ever sees its
+        own segment's event IDs."""
         evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
         event = schema.Event(
             event_id="ev1", predicate="p", event_type="x", evidence=evidence
@@ -711,8 +803,8 @@ class TestReconcileStoryAnnotations(unittest.TestCase):
         self.assertEqual(story.entity_alias_map["1:e1"], global_id)
         self.assertEqual(story.entity_alias_map["2:e1"], global_id)
         # The weakly_inferred relation (from segment 2) is qualified with
-        # segment 2's ID, not segment 1's, and resolves against segment 2's
-        # own event list.
+        # segment 2's ID, not segment 1's — entirely local to segment 2,
+        # unaffected by the cross-segment entity merge above.
         self.assertEqual(len(story.relations), 1)
         self.assertEqual(story.relations[0].source_event_id, "2:ev1")
         self.assertEqual(story.validation_errors, [])


### PR DESCRIPTION
## Summary
Implements WI-EVENT-0026: the Event-Role-World extractor's stages 6-7 and 9, building on WI-EVENT-0024 (merged in #148, #149).

- Stage 6 (relation pass): causal/enabling/preventing/temporal/motivational/explanatory links between events. Explicit and strongly-implied relations go in the main relations list; weakly-inferred relations are partitioned into a separate list on the same EventRelation type, not the stage-8 Hypothesis dataclass.
- Stage 7 (discourse/SF-tag pass): speech acts, explanation discourse, and SF world-model tags.
- Stage 9 (validation/export): canonical deterministic per-story JSON, derived JSONL/CSV analysis tables, and the proposal's artifact-validation checks.
- Story-level reconciliation: entities are merged across segments by case-insensitive canonical name, and relations are re-qualified with segment-scoped event IDs so they remain resolvable at story scope.
- baseline.py extended so the fixed-chunk-vs-segment comparison covers relation/discourse/SF-tag rates alongside the existing entity/event/anchor ones.

Stage 8 (hypothesis pass) remains explicitly out of scope per forbidden_actions (`implement_stage_8_hypothesis_pass`).

Prompt ID: `PROMPT(WI-EVENT-0026:WI_EVENT_0026)[2026-07-24T13:22:01-04:00]`

## Files changed
- `lcats/lcats/analysis/event_role_world/schema.py` (extended): EventRelation, SpeechAct, ExplanationDiscourse, SFWorldModelTag, StoryWorldAnnotation, reconcile_story_annotations(), validate_story_annotation()
- `lcats/lcats/analysis/event_role_world/relation_extractor.py` (new)
- `lcats/lcats/analysis/event_role_world/discourse_extractor.py` (new)
- `lcats/lcats/analysis/event_role_world/export.py` (new)
- `lcats/lcats/analysis/event_role_world/processor.py` (extended)
- `lcats/lcats/analysis/event_role_world/baseline.py` (extended)
- `lcats/tests/analysis_tests/event_role_world_test.py` (extended)

## Acceptance criteria
- [x] New object schemas defined and validated, extending SegmentWorldAnnotation
- [x] Relation pass extracts links with evidence and certainty; weakly-inferred partitioned separately
- [x] Discourse/SF-tag pass extracts speech acts, explanations, and SF tags with evidence
- [x] Validation/export emits canonical JSON + derived tables and passes artifact-validation checks
- [x] baseline.py extended to cover relation/discourse/SF-tag counts
- [x] Story-level reconciliation actually implemented and covered by a dedicated cross-segment test
- [x] lrh validate 0 errors and scripts/test passes; stage 8 out of scope

## Test plan
- [x] `scripts/format --check --diff` - clean
- [x] `scripts/lint` - clean
- [x] `scripts/test` - 1400 tests pass (up from 1375)
- [x] `lrh validate` - 0 errors, 33 pre-existing warnings (unrelated owner-field convention)

Generated with Claude Code
