### PR TITLE
Add work item WI-EVENT-0027: Implement Event-Role-World extractor stage 8 (hypothesis pass)

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_24_21_26_44_WI_EVENT_0027_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_24_21_26_44_WI_EVENT_0027_REVIEW.md
@@ -1,0 +1,37 @@
+---
+execution_id: 2026_07_24_21_26_44_WI_EVENT_0027_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0027_REVIEW)[2026-07-24T21:24:21-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/151
+commit: 0405878
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/151
+session_transcript: pending
+created_at: 2026-07-24T21:26:44-04:00
+---
+
+# Summary
+
+Address 3 open review comments on PR #151 (planning artifact for WI-EVENT-0027, the stage 8 hypothesis-pass follow-up) via /lrh-review-response, run autonomously per the "Land an Open PR to Closeout" playbook (fixes applied without an interactive confirm gate, per this run's explicit pre-authorization). No primary implementation execution record exists for WI-EVENT-0027 yet - this PR only created the planning artifact via /lrh-work-item - so rerun_of is left empty.
+
+# Result
+
+Fixed 2 of 3 comments (chatgpt-codex-connector: 2; copilot-pull-request-reviewer: 1):
+
+1. (chatgpt-codex-connector) Workstream registration (WS-EVENT-ROLE-WORLD's work_items list and Work Items section) - skipped, presence check fails: already fixed by the prior commit (0c4e11f), pushed before this review round ran.
+2. (chatgpt-codex-connector) WI-EVENT-0027 missing from project/work_items/README.md's Proposed Items index - added the entry.
+3. (copilot) Duplication-search note claimed the forbidden_actions strings appear "only" as forbidden_actions markers, but they also appear referentially in schema.py's docstrings - rephrased to describe them as scope-control markers without the inaccurate exclusivity claim.
+
+# Validation
+
+- `scripts/format --check --diff` - clean.
+- `scripts/lint` - ruff and black both pass.
+- `scripts/test` - 1403 tests, all pass (unchanged - this is a planning-artifact-only PR).
+- `lrh validate` (run from `lcats/`) - 0 errors, 35 warnings (all pre-existing owner-field warnings, unrelated to this change).
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Run `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/151` before merge to verify the fixes against the current diff and resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_24_21_28_32_WI_EVENT_0027_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_24_21_28_32_WI_EVENT_0027_CONFIRM.md
@@ -1,0 +1,41 @@
+---
+execution_id: 2026_07_24_21_28_32_WI_EVENT_0027_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0027_CONFIRM)[2026-07-24T21:28:13-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/151
+commit: cb36164
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/151
+session_transcript: pending
+created_at: 2026-07-24T21:28:32-04:00
+---
+
+# Summary
+
+Pre-merge verification of the review fixes pushed to PR #151 (WI-EVENT-0027 planning artifact) via /lrh-confirm-fixes, run autonomously per the "Land an Open PR to Closeout" playbook (classified inline rather than via a subagent, given the full-autonomy directive for this run).
+
+# Result
+
+Gathered all 3 unresolved threads on PR #151 via `lrh github threads --mode raw --state all` filtered to `isResolved == false` (2 chatgpt-codex-connector, 1 copilot-pull-request-reviewer).
+
+Verified each against the current HEAD diff directly:
+- discussion_r3648947931 (workstream registration) - Clear-satisfied: `WS-EVENT-ROLE-WORLD.md` lists WI-EVENT-0027 in both `work_items:` and the Work Items prose section.
+- discussion_r3648947932 (work-item README index) - Clear-satisfied: `project/work_items/README.md` now lists `proposed/WI-EVENT-0027.md`.
+- discussion_r3648948152 (duplication-search exclusivity claim) - Clear-satisfied: the note no longer claims the forbidden_actions strings appear "only" as such; rephrased to describe them as scope-control markers.
+
+Verdict: **3 of 3 Clear-satisfied.** No Unaddressed/Partial/Ambiguous/Problematic findings.
+
+All 3 threads resolved via `gh api graphql resolveReviewThread`. Thread-resolution verdict (Step 6): **green** - every verifiable thread resolved, no exceptions remain open.
+
+# Validation
+
+- `scripts/format --check --diff`, `scripts/lint`, `scripts/test` (1403 tests) - all clean, from the review-response round moments earlier.
+- `lrh validate` (run from `lcats/`) - 0 errors, 35 warnings (all pre-existing owner-field warnings, unrelated to this change).
+- Provisional CI (`gh pr checks 151`): lint SUCCESS; coverage/test still IN_PROGRESS at gather time - re-checked against the post-push HEAD SHA before the final verdict.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- CI re-checked against the post-push HEAD SHA (this record's own commit) before reporting final merge readiness.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -15,6 +15,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md`
+- `proposed/WI-EVENT-0027.md` — Implement Event-Role-World extractor stage 8 (optional hypothesis pass)
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-EVENT-0027.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0027.md
@@ -79,7 +79,10 @@ recorded follow-up, and implements the pass itself.
   or `Hypothesis` dataclass anywhere in `lcats/`. The proposal's own schema
   sketch (`00_proposal.md:175-177`) names `Hypothesis` as a design sketch,
   not code. `implement_stage_8_hypothesis_pass`/`implement_hypothesis_pass`
-  appear only as `forbidden_actions` in `WI-EVENT-0024`/`WI-EVENT-0026`.
+  are used in `WI-EVENT-0024`/`WI-EVENT-0026` as `forbidden_actions` scope-
+  control markers deferring stage 8 (they also appear referentially in
+  `schema.py`'s docstrings, alongside those markers, not as an
+  implementation).
 - Sibling repos: None identified.
 - External libraries: None identified.
 - Recommendation: Proceed.

--- a/lcats/project/work_items/proposed/WI-EVENT-0027.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0027.md
@@ -1,0 +1,195 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EVENT-0027
+title: Implement Event-Role-World extractor stage 8 (optional hypothesis pass)
+type: deliverable
+status: proposed
+priority: medium
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap:
+  - ROADMAP-CORE
+related_workstreams:
+  - WS-EVENT-ROLE-WORLD
+related_design:
+  - project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md
+depends_on:
+  - WI-EVENT-0026
+blocked_by: []
+expected_actions:
+  - create_file
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - implement_graph_database
+  - force_push
+  - delete_branch
+acceptance:
+  - A Hypothesis schema is defined and validated, extending SegmentWorldAnnotation, with an explicit hypothesis marker distinguishing it from extractive claims
+  - The hypothesis pass extracts belief/uncertainty/perspective/emotion-appraisal annotations with subject, proposition/target, evidence, and confidence, excluded from primary quantitative claims unless validated
+  - export.py's artifact-validation and analysis-table export cover the new hypothesis layer
+  - baseline.py's summary/comparison functions are extended to report hypothesis rates alongside the other layers
+  - lrh validate reports 0 errors and scripts/test passes
+  - WS-EVENT-ROLE-WORLD's exit criterion for stage 8 becomes satisfiable
+required_evidence:
+  - lrh_validate
+  - test_output
+  - manual_review
+artifacts_expected:
+  - lcats/lcats/analysis/event_role_world/hypothesis_extractor.py
+  - lcats/lcats/analysis/event_role_world/schema.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/processor.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/export.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/baseline.py (extended, not new)
+  - lcats/tests/analysis_tests/event_role_world_test.py (extended, not new)
+---
+
+## Summary
+
+Implement the last deferred stage of the Event-Role-World extractor's
+Recommended staged pipeline: stage 8, the optional hypothesis pass. Adds a
+`Hypothesis` dataclass recording belief, uncertainty, perspective, or
+emotion/appraisal annotations, with subject, proposition/target, evidence,
+confidence, and an explicit hypothesis marker — extracted per segment and
+integrated into the existing story-level (`StoryWorldAnnotation`) pipeline
+built by `WI-EVENT-0024` and `WI-EVENT-0026`.
+
+## Problem / Context
+
+`WS-EVENT-ROLE-WORLD` coordinates implementation of the Science-Fiction
+Event-Role-World extractor proposed in
+`project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md`,
+in support of the Worldcon "Shape of Science Fiction" paper
+(`FOCUS-WORLDCON-2026`). `WI-EVENT-0024` (stages 1-5) and `WI-EVENT-0026`
+(stages 6-7 and 9) both explicitly deferred stage 8 as optional, per the
+proposal's own framing. `WS-EVENT-ROLE-WORLD`'s exit criteria require stage
+8 to be "implemented, or explicitly deferred with a follow-up work item
+recorded" — prose deferral notes in the other two work items do not satisfy
+this literally, since no work item existed to track it. This item is that
+recorded follow-up, and implements the pass itself.
+
+### Duplication search
+- In-repo: No existing implementation found. No `hypothesis_extractor.py`
+  or `Hypothesis` dataclass anywhere in `lcats/`. The proposal's own schema
+  sketch (`00_proposal.md:175-177`) names `Hypothesis` as a design sketch,
+  not code. `implement_stage_8_hypothesis_pass`/`implement_hypothesis_pass`
+  appear only as `forbidden_actions` in `WI-EVENT-0024`/`WI-EVENT-0026`.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found beyond `WI-EVENT-0024`'s and `WI-EVENT-0026`'s own
+  deferral notes and `WS-EVENT-ROLE-WORLD`'s exit criterion requiring this
+  item to exist.
+- Proposals: None found beyond the governing proposal itself.
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Scope
+
+- Hypothesis pass (stage 8): extract belief, uncertainty, perspective, and
+  emotion/appraisal annotations from segment text, each with a subject,
+  proposition or target, evidence, confidence, and an explicit hypothesis
+  marker — per the proposal's fact/hypothesis distinction, these are never
+  extractive facts even when confidently stated.
+- Schema definition for `Hypothesis` per the proposal's "Core schema
+  sketch", integrated into `SegmentWorldAnnotation` and, via story-level
+  reconciliation, `StoryWorldAnnotation`.
+- Backend `tool=` schema wiring for the new extraction call, consistent
+  with the existing entity/event/relation/discourse extractor pattern
+  (`JSONPromptExtractor`'s `tool_schema` parameter) — not `json_object`
+  mode.
+- Cost/baseline reporting for the new LLM-backed pass, consistent with the
+  existing `PassUsage` pattern.
+- Extending `export.py`'s artifact-validation checks and analysis-table
+  export to cover hypotheses.
+- Extending `baseline.py`'s fixed-chunk-vs-segment comparison to report
+  hypothesis rates alongside the existing layers.
+
+## Required Changes
+
+1. Extend `lcats/lcats/analysis/event_role_world/schema.py` with a
+   `Hypothesis` dataclass, add a `hypotheses` field to
+   `SegmentWorldAnnotation`, and extend `validate_segment_annotation` to
+   check its ID resolution and evidence alignment (mirroring the existing
+   relations/discourse validation added by `WI-EVENT-0026`). Hypotheses
+   must be clearly excluded from any primary quantitative claim by
+   construction — e.g. not counted in the same rate fields as extractive
+   entities/events unless a caller explicitly opts in — per the proposal's
+   risk table entry on confusing interpretive hypotheses with extractive
+   facts.
+2. Create `hypothesis_extractor.py` for stage 8, following the existing
+   entity/event/relation/discourse extractor pattern (LLM extraction via
+   `JSONPromptExtractor` with a `tool_schema`, evidence resolution via
+   `schema.EvidenceCursor`, its own independent cursor per the discourse-
+   layer-cursor-sharing bug fixed in `WI-EVENT-0026`'s review).
+3. Extend `processor.py` to orchestrate the hypothesis pass after stages
+   6-7, following the same `PassUsage`/token-tracking and routed-through-
+   `extract()` error-handling pattern as the existing passes.
+4. Extend `export.py`'s `build_analysis_tables()` and `validate_artifacts()`
+   to cover the hypothesis layer.
+5. Extend `baseline.py`'s `summarize_annotations()` to report a
+   hypotheses-per-1000-words rate alongside the existing layers.
+6. Extend `lcats/tests/analysis_tests/event_role_world_test.py` covering
+   the new schema, the extraction pass, its export/validation coverage,
+   and the baseline extension.
+
+## Non-Goals
+
+- Does not require a graph database or CBR/RAG adaptation.
+- Does not choose the Worldcon paper's final statistical method.
+- Does not treat hypotheses as primary quantitative evidence for any
+  genre-comparison claim — per the proposal, optional hypotheses are
+  excluded from primary quantitative claims unless independently validated.
+- Does not implement cross-segment relation extraction — a separate,
+  already-tracked follow-up in `WS-EVENT-ROLE-WORLD.md`'s "Known
+  Follow-ups" section, unrelated to this item's scope.
+
+## Acceptance Criteria
+
+- A `Hypothesis` schema is defined and validated, extending
+  `SegmentWorldAnnotation`, with an explicit hypothesis marker
+  distinguishing it from extractive claims.
+- The hypothesis pass extracts belief/uncertainty/perspective/emotion-
+  appraisal annotations with subject, proposition/target, evidence, and
+  confidence, excluded from primary quantitative claims unless validated.
+- `export.py`'s artifact-validation and analysis-table export cover the new
+  hypothesis layer.
+- `baseline.py`'s summary/comparison functions are extended to report
+  hypothesis rates alongside the other layers.
+- `lrh validate` reports 0 errors and `scripts/test` passes.
+- `WS-EVENT-ROLE-WORLD`'s exit criterion for stage 8 becomes satisfiable
+  (this work item's existence satisfies "recorded"; its completion
+  satisfies "implemented").
+
+## Validation
+
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `lrh validate`
+
+## Risk Notes
+
+- Confusing interpretive hypotheses with extractive facts is a known risk
+  per the proposal's own risk table; the schema and any downstream
+  reporting must keep hypothesis fields, certainty, and confidence
+  separate from extractive-fact fields, and exclude optional hypotheses
+  from primary quantitative claims unless independently validated.
+- LLM-generated hypotheses (belief, perspective, emotion/appraisal) are
+  inherently more speculative than extractive passes; expect lower
+  precision and plan for stratified human review before treating any
+  hypothesis-derived metric as reliable, consistent with the proposal's
+  general recommendation for interpretive annotations.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md`
+- Design: `project/design/proposals/proposed/lcats-event-role-world-extractor/00_proposal.md`

--- a/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-ROLE-WORLD.md
@@ -14,6 +14,7 @@ work_items:
   - WI-EVENT-0024
   - WI-EVENT-0025
   - WI-EVENT-0026
+  - WI-EVENT-0027
 exit_criteria:
   - The proposal's Recommended staged pipeline stages 1-7 and 9 (input contract, surface feature pass, entity participant pass, event-role pass, anchor pass, relation pass, discourse/SF tag pass, and validation/export) are implemented, reusing the existing segment/evidence substrate without reimplementing scene/sequel extraction
   - The optional hypothesis pass (stage 8) is implemented, or explicitly deferred with a follow-up work item recorded
@@ -94,6 +95,11 @@ the proposal itself prescribes:
   stage 9 (validation/export), building on WI-EVENT-0024's entity/event/
   anchor output. Stage 8 (hypothesis pass) remains optional per the
   proposal itself and is out of scope for this item.
+- **WI-EVENT-0027** — covers stage 8 (optional hypothesis pass), the last
+  deferred pipeline stage, building on WI-EVENT-0026's schema/processor/
+  export substrate. This is the recorded follow-up work item required by
+  the exit criterion below — its existence satisfies "recorded," and its
+  completion satisfies "implemented."
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary
Adds WI-EVENT-0027, the follow-up work item implementing stage 8 (optional hypothesis pass) of the Event-Role-World extractor's Recommended staged pipeline — the last deferred stage, following WI-EVENT-0024 (stages 1-5) and WI-EVENT-0026 (stages 6-7 and 9).

Adds a Hypothesis dataclass recording belief, uncertainty, perspective, or emotion/appraisal annotations, with subject, proposition/target, evidence, confidence, and an explicit hypothesis marker, integrated into the existing per-segment and story-level pipeline.

WS-EVENT-ROLE-WORLD's exit criteria require stage 8 to be "implemented, or explicitly deferred with a follow-up work item recorded" — this item is that recorded follow-up.

Type: deliverable
Related workstream: WS-EVENT-ROLE-WORLD
Depends on: WI-EVENT-0026 (resolved)

## Acceptance criteria
- A Hypothesis schema is defined and validated, extending SegmentWorldAnnotation, with an explicit hypothesis marker distinguishing it from extractive claims.
- The hypothesis pass extracts belief/uncertainty/perspective/emotion-appraisal annotations with subject, proposition/target, evidence, and confidence, excluded from primary quantitative claims unless validated.
- export.py's artifact-validation and analysis-table export cover the new hypothesis layer.
- baseline.py's summary/comparison functions are extended to report hypothesis rates alongside the other layers.
- lrh validate reports 0 errors and scripts/test passes.
- WS-EVENT-ROLE-WORLD's exit criterion for stage 8 becomes satisfiable.

## Test plan
- [x] lrh validate - 0 errors (35 warnings, all pre-existing owner-field pattern)
- [x] This is a planning-artifact-only PR - no code changes; no test suite run needed beyond lrh validate

Generated with Claude Code
