### PR TITLE
Add WS-EVENT-CROSS-SEGMENT-RELATIONS and WI-EVENT-0028

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_25_01_29_40_WS_EVENT_CROSS_SEGMENT_RELATIONS_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_25_01_29_40_WS_EVENT_CROSS_SEGMENT_RELATIONS_REVIEW.md
@@ -1,0 +1,30 @@
+---
+execution_id: 2026_07_25_01_29_40_WS_EVENT_CROSS_SEGMENT_RELATIONS_REVIEW
+prompt_id: PROMPT(AD_HOC:WS_EVENT_CROSS_SEGMENT_RELATIONS_REVIEW)[2026-07-25T01:28:36-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/153
+commit: 08cb352
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/153
+session_transcript: pending
+created_at: 2026-07-25T01:29:40-04:00
+---
+
+# Summary
+
+Address 1 open review comment on PR #153 (WS-EVENT-CROSS-SEGMENT-RELATIONS + WI-EVENT-0028 planning artifacts) via /lrh-review-response, run autonomously per the "Land an Open PR to Closeout" playbook. No primary implementation execution record exists for WI-EVENT-0028 yet - this PR only created planning artifacts via /lrh-workstream + /lrh-work-item - so rerun_of is left empty.
+
+# Result
+
+Fixed the 1 comment (copilot): `WI-EVENT-0028.md`'s `expected_actions` listed `run_tests`, inconsistent with its stated investigation-only/design-doc scope (the PR's own test plan says no test suite run is needed beyond `lrh validate`). Removed `run_tests` from `expected_actions`.
+
+# Validation
+
+- `lrh validate` (run from `lcats/`) - 0 errors, 37 warnings (all pre-existing owner-field warnings, unrelated to this change).
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Run `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/153` before merge to verify the fix against the current diff and resolve the review thread.

--- a/lcats/project/executions/AD_HOC/2026_07_25_01_31_38_WS_EVENT_CROSS_SEGMENT_RELATIONS_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_25_01_31_38_WS_EVENT_CROSS_SEGMENT_RELATIONS_CONFIRM.md
@@ -1,0 +1,33 @@
+---
+execution_id: 2026_07_25_01_31_38_WS_EVENT_CROSS_SEGMENT_RELATIONS_CONFIRM
+prompt_id: PROMPT(AD_HOC:WS_EVENT_CROSS_SEGMENT_RELATIONS_CONFIRM)[2026-07-25T01:31:23-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/153
+commit: 7a0d549
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/153
+session_transcript: pending
+created_at: 2026-07-25T01:31:38-04:00
+---
+
+# Summary
+
+Pre-merge verification of the review fix pushed to PR #153 via /lrh-confirm-fixes, run autonomously per the "Land an Open PR to Closeout" playbook.
+
+# Result
+
+Gathered unresolved threads via `lrh github threads --mode raw --state all`: the single comment (copilot, `expected_actions` inconsistency) had already auto-resolved itself before this check ran, per the known copilot-bot-auto-resolves-its-own-threads pattern. No threads required action.
+
+Thread-resolution verdict (Step 6): **green** - no unresolved threads remain.
+
+# Validation
+
+- `lrh validate` (run from `lcats/`) - 0 errors, 37 pre-existing warnings, unrelated to this change.
+- Provisional CI (`gh pr checks 153`): lint SUCCESS; coverage/test IN_PROGRESS at gather time - re-checked against the post-push HEAD SHA before the final verdict.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- CI re-checked against the post-push HEAD SHA (this record's own commit) before reporting final merge readiness.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -15,6 +15,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md`
+- `proposed/WI-EVENT-0028.md` — Investigate need and design for cross-segment causal relation extraction
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-EVENT-0028.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0028.md
@@ -22,7 +22,6 @@ depends_on:
 blocked_by: []
 expected_actions:
   - create_file
-  - run_tests
   - create_pr
 forbidden_actions:
   - implement_cross_segment_relation_extraction

--- a/lcats/project/work_items/proposed/WI-EVENT-0028.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0028.md
@@ -1,0 +1,164 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EVENT-0028
+title: Investigate need and design for cross-segment causal relation extraction
+type: investigation
+status: proposed
+priority: medium
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-EVENT-CROSS-SEGMENT-RELATIONS
+related_design:
+  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+depends_on:
+  - WI-EVENT-0026
+blocked_by: []
+expected_actions:
+  - create_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - implement_cross_segment_relation_extraction
+  - implement_stage_8_hypothesis_pass
+  - force_push
+  - delete_branch
+acceptance:
+  - A clear yes/no determination on whether the paper's analysis needs cross-segment causal relations, grounded in the paper's actual claims rather than speculative need
+  - If needed, at least two candidate architectures are evaluated with tradeoffs (cost/latency, implementation complexity, accuracy risk), and a recommendation is made
+  - The investigation is recorded as a design doc under project/design/, following WI-EVENT-0025's precedent
+  - lrh validate reports 0 errors
+required_evidence:
+  - lrh_validate
+  - manual_review
+artifacts_expected:
+  - project/design/event-role-world-cross-segment-relations-evaluation.md
+---
+
+## Summary
+
+Determine whether the Worldcon "Shape of Science Fiction" paper's
+comparative analysis requires causal relations that span segment boundaries
+— a cause established in one segment and its effect appearing in a
+different segment — which the current per-segment stage-6 relation pass
+(`relation_extractor.py`, WI-EVENT-0026) cannot represent. If cross-segment
+relations are needed, evaluate architecture options for giving stage 6
+broader (multi-segment or full-story) context and produce a design
+recommendation. This work item does not implement any architecture.
+
+## Problem / Context
+
+`WS-EVENT-CROSS-SEGMENT-RELATIONS` was created after a review comment on
+WI-EVENT-0026 (`chatgpt-codex-connector`, PR #150) established that the
+per-segment stage-6 relation pass structurally cannot produce a relation
+whose source and target events live in different segments — the extractor
+only ever receives its own segment's event IDs. That review round documented
+the limitation rather than fixing it, since designing broader context for
+stage 6 is a meaningfully different extraction strategy, not a small
+addition. WS-EVENT-ROLE-WORLD (which coordinated WI-EVENT-0024 through
+WI-EVENT-0027) has since closed without addressing this — its own exit
+criteria did not require it. This work item is the recorded follow-up.
+
+### Duplication search
+- In-repo: No existing cross-segment relation extraction or investigation
+  exists in `lcats/`. `schema.reconcile_story_annotations` (WI-EVENT-0026)
+  performs story-level entity alias reconciliation and relation ID
+  qualification only — its own docstring explicitly disclaims discovering
+  cross-segment relations.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found beyond the review comment and Known-Follow-up note
+  that prompted this item.
+- Proposals: None found beyond the governing Event-Role-World extractor
+  proposal, which this item's eventual recommendation would extend.
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Scope
+
+- Determine whether the paper's candidate metrics and claims (per the
+  governing proposal's "Resulting scientific claim" and "Candidate
+  paper-facing metrics" sections) actually require cross-segment causal
+  links, or whether per-segment relation density (already implemented) is
+  sufficient.
+- If cross-segment relations are needed, evaluate at least two candidate
+  architectures, for example:
+  - A story-level relation pass run after per-segment extraction and
+    story-level reconciliation have produced global entity/event IDs,
+    querying across all segments' events at once.
+  - Feeding stage 6 a compact story-level event index (summaries, not full
+    text) alongside the current segment, so it can reference prior events
+    without a full-story context window.
+  - Widening the per-segment extraction window to include a fixed number of
+    neighboring segments.
+- Evaluate each candidate on cost/latency (additional LLM calls or larger
+  context per call), implementation complexity relative to the existing
+  per-segment pattern, and accuracy risk (hallucinated cross-segment links
+  are a known general risk per the governing proposal's risk table).
+- Produce a design recommendation only.
+
+## Required Changes
+
+1. Research the governing proposal's claims and metrics sections to
+   determine whether cross-segment causal relations are actually load-bearing
+   for the paper, or a purely hypothetical concern the review raised.
+2. If needed, draft and evaluate candidate architectures per Scope above.
+3. Write `project/design/event-role-world-cross-segment-relations-evaluation.md`
+   recording the determination, the evaluated architectures (if any), and
+   the recommendation — following the structure of
+   `project/design/event-role-world-surface-feature-nlp-evaluation.md`
+   (WI-EVENT-0025's precedent).
+4. If a recommendation to implement is made, note that a follow-up
+   deliverable work item should be created — do not create it as part of
+   this item.
+
+## Non-Goals
+
+- Does not implement any chosen architecture — implementation is a follow-up
+  deliverable work item's scope, not this one's.
+- Does not implement stage 8 (hypothesis pass) — already implemented by
+  WI-EVENT-0027; out of scope here regardless.
+- Does not reopen or modify WS-EVENT-ROLE-WORLD or any of its resolved work
+  items.
+- Does not choose the Worldcon paper's final statistical method.
+
+## Acceptance Criteria
+
+- A clear yes/no determination on whether the paper's analysis needs
+  cross-segment causal relations, grounded in the paper's actual claims
+  rather than speculative need.
+- If needed, at least two candidate architectures are evaluated with
+  tradeoffs (cost/latency, implementation complexity, accuracy risk), and a
+  recommendation is made.
+- The investigation is recorded as a design doc under `project/design/`,
+  following WI-EVENT-0025's precedent.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `lrh validate`
+
+## Risk Notes
+
+- LLM-hallucinated cross-segment causal links are a known general risk per
+  the governing proposal's risk table; any recommended architecture must
+  require aligned evidence, certainty, and confidence, and expect stratified
+  human review before treating cross-segment relation-density metrics as
+  reliable.
+- There is a real risk this investigation concludes cross-segment relations
+  are not needed at all — that is a valid, complete outcome, not a failure
+  to find one; do not manufacture a need to justify an architecture change.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-EVENT-CROSS-SEGMENT-RELATIONS.md`
+- Design: `project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`

--- a/lcats/project/workstreams/proposed/WS-EVENT-CROSS-SEGMENT-RELATIONS.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-CROSS-SEGMENT-RELATIONS.md
@@ -1,0 +1,105 @@
+---
+id: WS-EVENT-CROSS-SEGMENT-RELATIONS
+kind: planning_node
+title: Cross-Segment Causal Relation Extraction for Event-Role-World
+status: proposed
+stage: designed
+origin: design_review
+summary: Investigate whether the Worldcon paper's analysis needs causal relations spanning segment boundaries, and if so, design how the Event-Role-World extractor's stage-6 relation pass gets broader (multi-segment or full-story) context.
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_design:
+  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+work_items:
+  - WI-EVENT-0028
+exit_criteria:
+  - A design recommendation exists on whether cross-segment causal relation extraction is needed for the Worldcon paper's analysis, grounded in the paper's actual claims
+  - If needed, a recommended architecture for giving stage 6 broader context is documented with tradeoffs, ready to hand off to an implementation work item
+  - All work items under this workstream resolved and lrh validate reports 0 errors
+---
+
+# Workstream: Cross-Segment Causal Relation Extraction for Event-Role-World
+
+## Purpose
+
+This workstream investigates and, if warranted, designs an extension to the
+Event-Role-World extractor's relation layer (stage 6) so it can represent
+genuinely cross-segment causal relations — a cause established in one
+segment and its effect appearing in a different segment. The current
+per-segment stage-6 pass (`relation_extractor.py`, implemented in
+WI-EVENT-0026) cannot represent this today: it only ever receives its own
+segment's event IDs, so a relation's source/target event can never actually
+reference a different segment's event.
+
+## Origin
+
+Raised as a P1 review comment during WI-EVENT-0026's review
+(`chatgpt-codex-connector`, PR #150). The review-response fix documented the
+limitation (a "Known limitation" note on `schema.StoryWorldAnnotation` and a
+"Known Follow-ups" entry on WS-EVENT-ROLE-WORLD) rather than attempting a fix
+in that PR, since designing broader context for stage 6 is a meaningfully
+different, larger extraction strategy than the current per-segment `tool=`
+call — not a small addition to that work item's scope. WS-EVENT-ROLE-WORLD
+has since closed (all its own exit criteria were met without this); this
+workstream picks up that recorded follow-up as new scope.
+
+## Scope
+
+- Investigate whether the Worldcon "Shape of Science Fiction" paper's
+  comparative analysis actually requires cross-segment causal relations, or
+  whether per-segment relations (already implemented) are sufficient for the
+  paper's claims.
+- If cross-segment relations are needed: evaluate candidate architectures for
+  giving stage 6 broader context (e.g., a story-level relation pass run
+  after per-segment extraction completes and story-level reconciliation has
+  produced global entity/event IDs; feeding stage 6 a compact story-level
+  event index instead of only the current segment's; widening the
+  per-segment extraction window to include neighboring segments), with
+  tradeoffs on cost/latency, implementation complexity, and accuracy risk.
+- Produce a design recommendation, not an implementation — mirroring how
+  WI-EVENT-0025's investigation preceded WI-EVENT-0024's implementation
+  decision.
+
+## Prior Art Check
+
+### Duplication search
+- In-repo: No existing cross-segment relation extraction or story-level
+  relation-context design exists in `lcats/`. `schema.reconcile_story_annotations`
+  (WI-EVENT-0026) performs story-level entity alias reconciliation and
+  relation ID qualification, but explicitly does not attempt cross-segment
+  relation discovery — see its "Known limitation" docstring note.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found beyond the review comment and Known-Follow-up note
+  that prompted this workstream.
+- Proposals: None found beyond the governing Event-Role-World extractor
+  proposal, which this workstream extends.
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Work Items
+
+- **WI-EVENT-0028** — investigation (not implementation): determines whether
+  cross-segment causal relations are needed for the paper's analysis, and if
+  so, evaluates and recommends an architecture for giving stage 6 broader
+  context. Produces a design recommendation only.
+
+## Exit Criteria
+
+(see frontmatter `exit_criteria:` above)
+
+## Non-Goals
+
+- Does not implement any chosen architecture — that is deferred to a
+  follow-up deliverable work item once a recommendation exists.
+- Does not reopen or modify WS-EVENT-ROLE-WORLD or any of its resolved work
+  items (WI-EVENT-0024 through WI-EVENT-0027).
+- Does not choose the Worldcon paper's final statistical method.
+
+## Relationship to Design
+
+- Design proposal: `project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`


### PR DESCRIPTION
## Summary
Scopes the cross-segment causal relation extraction follow-up raised during WI-EVENT-0026's review (PR #150) and recorded on the now-closed WS-EVENT-ROLE-WORLD as a "Known Follow-up."

Adds a new workstream, WS-EVENT-CROSS-SEGMENT-RELATIONS, and its first work item, WI-EVENT-0028 (investigation): determine whether the Worldcon paper's analysis actually needs causal relations spanning segment boundaries - something the current per-segment stage-6 relation pass cannot represent - and if so, evaluate architecture options and recommend one. This is investigation-only, mirroring how WI-EVENT-0025's investigation preceded WI-EVENT-0024's implementation decision; no implementation is scoped here.

A new workstream (rather than reopening WS-EVENT-ROLE-WORLD) was chosen deliberately: this represents new scope beyond what that workstream's exit criteria covered, and its history should stay clean.

## Acceptance criteria (WI-EVENT-0028)
- A clear yes/no determination on whether cross-segment causal relations are needed, grounded in the paper's actual claims
- If needed, at least two candidate architectures evaluated with tradeoffs
- Recorded as a design doc under project/design/, following WI-EVENT-0025's precedent
- lrh validate reports 0 errors

## Test plan
- [x] lrh validate - 0 errors (37 warnings, all pre-existing owner-field pattern)
- [x] This is a planning-artifact-only PR - no code changes; no test suite run needed beyond lrh validate

Generated with Claude Code
