### PR TITLE
Add WS-EVENT-STORY-RELATIONS and WI-EVENT-0029: implement cross-segment relation pass

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_25_14_26_55_WS_EVENT_STORY_RELATIONS_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_25_14_26_55_WS_EVENT_STORY_RELATIONS_REVIEW.md
@@ -1,0 +1,35 @@
+---
+execution_id: 2026_07_25_14_26_55_WS_EVENT_STORY_RELATIONS_REVIEW
+prompt_id: PROMPT(AD_HOC:WS_EVENT_STORY_RELATIONS_REVIEW)[2026-07-25T14:26:25-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/155
+commit: 0f7dded
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/155
+session_transcript: pending
+created_at: 2026-07-25T14:26:55-04:00
+---
+
+# Summary
+
+Address PR #155 review feedback on `project/work_items/proposed/WI-EVENT-0029.md` (WS-EVENT-STORY-RELATIONS / WI-EVENT-0029 planning artifacts). No prior primary execution record exists for this PR — it was authored via the `/lrh-workstream` skill, which creates no execution record of its own; a backfilled primary record will be created at closeout.
+
+# Result
+
+Three review comments addressed:
+
+- **copilot: `depends_on` missing WI-EVENT-0026.** The PR description and body prose both said WI-EVENT-0029 depends on WI-EVENT-0026 and WI-EVENT-0028, but the frontmatter `depends_on` list only had WI-EVENT-0028. Added WI-EVENT-0026, since it's a real prerequisite (introduced `relation_extractor.py` and `reconcile_story_annotations`, both extended by this item).
+- **P1 (chatgpt-codex-connector): relation dedup by raw `relation_id` is unsafe.** `reconcile_story_annotations()` qualifies event endpoints but leaves `relation_id` itself unchanged, and separate segment-level LLM calls can both emit a common ID like `r1` — deduplicating on the raw ID would discard unrelated relations and silently undercount density. Added an explicit acceptance criterion and Required Changes/Scope/Risk Notes language requiring story-level relation IDs to be qualified into a globally-unique identity (e.g. `"{segment_id}:{relation_id}"`, mirroring how event IDs are already qualified) before any deduplication is attempted.
+- **P1 (chatgpt-codex-connector): weakly-inferred partition not preserved.** The doc's acceptance criteria directed all story-level relations into `relations_per_1000_words`, but `baseline.summarize_annotations()` today reports `weakly_inferred` relations in a separate `weakly_inferred_relations_per_1000_words` bucket for per-segment relations. Added acceptance criteria, Required Changes, Scope, and Risk Notes language requiring story-level relations to preserve this same certainty-based split rather than mixing speculative links into the primary density metric.
+
+# Validation
+
+- `lrh validate` (run from `lcats/`) — 0 errors, 39 pre-existing warnings, unrelated to this change.
+- Doc-only change; no code touched, so no test/lint/format run required.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/155` to verify fixes against the current diff and resolve review threads, then the merge gate, then `/lrh-closeout` (which will need to backfill a primary execution record for this PR since none exists).

--- a/lcats/project/executions/AD_HOC/2026_07_25_14_29_36_WS_EVENT_STORY_RELATIONS_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_25_14_29_36_WS_EVENT_STORY_RELATIONS_CONFIRM.md
@@ -1,0 +1,38 @@
+---
+execution_id: 2026_07_25_14_29_36_WS_EVENT_STORY_RELATIONS_CONFIRM
+prompt_id: PROMPT(AD_HOC:WS_EVENT_STORY_RELATIONS_CONFIRM)[2026-07-25T14:29:26-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_25_14_26_55_WS_EVENT_STORY_RELATIONS_REVIEW
+pr: https://github.com/xenotaur/LCATS/pull/155
+commit: e61f1f6
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/155
+session_transcript: pending
+created_at: 2026-07-25T14:29:36-04:00
+---
+
+# Summary
+
+Confirm PR #155's review fixes against the current diff and resolve threads before merge.
+
+# Result
+
+Fetched threads via `lrh github threads <pr-url> --mode raw --state all`: 3 total, all unresolved before this round. Verified each against the pushed fix in `project/work_items/proposed/WI-EVENT-0029.md`:
+
+- copilot `depends_on` gap — confirmed `depends_on:` now lists both WI-EVENT-0026 and WI-EVENT-0028.
+- P1 relation-ID dedup safety — confirmed the doc now requires globally-unique/segment-qualified relation IDs before any deduplication, in the acceptance criteria, Scope, Required Changes, and Risk Notes sections.
+- P1 weakly-inferred partition — confirmed the doc now requires story-level relations to preserve the certainty-based split into `weakly_inferred_relations_per_1000_words` vs. the primary `relations_per_1000_words`, in the same four sections.
+
+Resolved all 3 threads via `gh api graphql resolveReviewThread`. Polled CI (`gh pr checks`) until settled: coverage, lint, both test jobs all SUCCESS against commit `e61f1f6`.
+
+# Validation
+
+- `lrh github threads https://github.com/xenotaur/LCATS/pull/155 --mode raw --state all` — 0 unresolved threads remain after resolution.
+- `gh pr checks https://github.com/xenotaur/LCATS/pull/155` — coverage/lint/test x2 all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Merge gate: summarize PR #155 for the user and wait for explicit approval before merging.
+- No primary execution record exists for this PR (authored via `/lrh-workstream`, which creates none). `/lrh-closeout` will need to backfill one from PR data, surfaced to the user before pushing, per the closeout playbook's Step 6.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -15,6 +15,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md`
+- `proposed/WI-EVENT-0029.md` — Implement story-level cross-segment relation pass for Event-Role-World extractor
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-EVENT-0029.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0029.md
@@ -1,0 +1,206 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EVENT-0029
+title: Implement story-level cross-segment relation pass for Event-Role-World extractor
+type: deliverable
+status: proposed
+priority: medium
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-EVENT-STORY-RELATIONS
+related_design:
+  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+  - project/design/event-role-world-cross-segment-relations-evaluation.md
+depends_on:
+  - WI-EVENT-0028
+blocked_by: []
+expected_actions:
+  - create_file
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - implement_option_b_event_index
+  - implement_option_c_widened_window
+  - force_push
+  - delete_branch
+acceptance:
+  - A new relation-extraction pass implements option A - running once per story after schema.reconcile_story_annotations, using each event's already-resolved EvidenceSpan as one endpoint's evidence, and excluding same-segment links already covered by stage 6a
+  - A new PassUsage entry (e.g. "story_relation") records the pass's cost per the existing cost/baseline reporting pattern
+  - Story-level relations are held in StoryWorldAnnotation (or an equivalent story-level container), distinct from per-segment relations
+  - export.build_analysis_tables includes story-level relations in its "relations" table
+  - baseline.summarize_annotations includes story-level relations in relations_per_1000_words, with defensive de-duplication by relation ID against per-segment relations
+  - The corpus's actual story-length distribution is checked to decide whether option A's long-story windowing caveat (hierarchical chapter-then-story pass) must be built now, with the decision and rationale documented
+  - lrh validate reports 0 errors and scripts/test passes
+required_evidence:
+  - lrh_validate
+  - test_output
+  - manual_review
+artifacts_expected:
+  - lcats/lcats/analysis/event_role_world/relation_extractor.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/schema.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/processor.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/export.py (extended, not new)
+  - lcats/lcats/analysis/event_role_world/baseline.py (extended, not new)
+  - lcats/tests/analysis_tests/event_role_world_test.py (extended, not new)
+---
+
+## Summary
+
+Implement the architecture WI-EVENT-0028 determined is needed and
+recommended: a post-reconciliation story-level relation pass (option A)
+that discovers causal, enabling, preventing, temporal, motivational, and
+explanatory relations whose two endpoints live in different segments —
+something the current per-segment stage-6 pass
+(`relation_extractor.py`, WI-EVENT-0026) structurally cannot represent,
+since it only ever receives its own segment's event IDs and
+`RELATION_SYSTEM_PROMPT` forbids linking outside that list.
+
+## Problem / Context
+
+`WS-EVENT-STORY-RELATIONS` coordinates this implementation.
+`WI-EVENT-0028`'s investigation (`project/design/event-role-world-cross-segment-relations-evaluation.md`,
+merged PR #154) ran a direct reading-based pilot over four corpus stories
+and found a clear, genre-differentiated result: both SF/horror stories
+sampled (Lovecraft's "The Colour Out of Space" — 4 long-range causal
+links; "Cool Air" — 2) exhibited multiple long-range causal chains, while
+the mystery ("The Engineer's Thumb") and general-fiction ("After Twenty
+Years") comparison stories exhibited none. This confirmed that
+per-segment-only relation counting would undercount SF's causal density
+specifically, threatening the validity of the paper's central genre
+comparison, and recommended option A as the architecture to fix it.
+
+### Duplication search
+- In-repo: No existing story-level relation extraction exists in `lcats/`.
+  `schema.reconcile_story_annotations` (WI-EVENT-0026) performs story-level
+  entity alias reconciliation and same-segment relation ID qualification
+  only — its own docstring explicitly disclaims discovering cross-segment
+  relations.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found beyond WI-EVENT-0028's recommendation and
+  WS-EVENT-STORY-RELATIONS's exit criteria requiring this item.
+- Proposals: None found beyond the governing Event-Role-World extractor
+  proposal, which this item extends per its "cross-segment relations"
+  schema-sketch expectation.
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Scope
+
+- New relation-extraction pass (a new `relation_extractor.py` function, or
+  a second tool schema in the same module) that runs once per story, after
+  `schema.reconcile_story_annotations` has produced global entity IDs and
+  the full list of segment-qualified events.
+- Build a compact representation of every story-level event (predicate,
+  event type, segment ID, and its already-resolved `EvidenceSpan`) to pass
+  as context to this pass, reusing each event's evidence span as one
+  endpoint's evidence rather than requiring a fresh quote search across a
+  multi-segment text blob.
+- Scope this pass to same-segment-excluded, cross-segment links only, to
+  avoid double-counting relations already discovered by the existing
+  stage-6a per-segment pass.
+- Reuse `EventRelation.certainty` (`explicit`/`strongly_implied`/
+  `weakly_inferred`) unchanged for these new relations — no new schema
+  field is needed to keep speculative cross-segment links partitioned,
+  mirroring how WI-EVENT-0026 already handles same-segment ones.
+- New `PassUsage` entry (e.g. `"story_relation"`) for cost/token visibility,
+  consistent with the existing cost/baseline reporting pattern.
+- Extend `export.py`'s `build_analysis_tables()` to include story-level
+  relations in the `"relations"` table.
+- Extend `baseline.py`'s `summarize_annotations()` to include story-level
+  relations in `relations_per_1000_words`, de-duplicating defensively by
+  relation ID against relations already present in a segment's own
+  `relations` list (do not assume the same-segment-exclusion rule alone
+  prevents double-counting).
+- Check the corpus's actual story-length distribution before deciding
+  whether option A's long-story windowing caveat (a hierarchical,
+  chapter-level then story-level pass) needs to be built in this item, or
+  whether story lengths in this corpus stay well within one call's context
+  window and the caveat can remain a documented future concern.
+
+## Required Changes
+
+1. Add a story-level relation extraction function/tool schema to
+   `lcats/lcats/analysis/event_role_world/relation_extractor.py` (or a
+   sibling module, if that reads cleaner), following the existing
+   entity/event/relation/discourse/hypothesis extractor pattern (LLM
+   extraction via `JSONPromptExtractor` with a `tool_schema`).
+2. Extend `lcats/lcats/analysis/event_role_world/schema.py` to hold the
+   new story-level relations (on `StoryWorldAnnotation` or an equivalent
+   container) and validate them (ID resolution against the global entity/
+   event index, evidence-span alignment, same-segment-link exclusion).
+3. Extend `processor.py` (or the story-level orchestration point that
+   calls `reconcile_story_annotations`) to run this pass once per story,
+   after reconciliation, with its own `PassUsage`/token-tracking entry and
+   the same routed-through-`extract()` error-handling pattern as the
+   existing passes.
+4. Extend `export.py`'s `build_analysis_tables()` and `validate_artifacts()`
+   to cover story-level relations.
+5. Extend `baseline.py`'s `summarize_annotations()` to include story-level
+   relations in `relations_per_1000_words`, with de-duplication by
+   relation ID.
+6. Check story-length distribution across the corpus (`lcats/data/`) and
+   document the finding and windowing decision in the PR description or a
+   short note in this work item's execution record.
+7. Extend `lcats/tests/analysis_tests/event_role_world_test.py` covering
+   the new schema, the extraction pass, its export/validation coverage,
+   the baseline extension, same-segment exclusion, and de-duplication.
+
+## Non-Goals
+
+- Does not implement option B (growing per-story event index) or option C
+  (widened per-segment window) — option A was the recommended
+  architecture; the others are out of scope unless option A proves
+  infeasible during implementation, in which case stop and report rather
+  than switching architectures unilaterally.
+- Does not run the larger stratified pilot (5-10 stories per genre) that
+  WI-EVENT-0028 flagged as still needed before the paper publishes a
+  cross-segment relation density figure — that is a corpus/methodology
+  task for the paper, not an implementation task for this item.
+- Does not modify or reopen WS-EVENT-CROSS-SEGMENT-RELATIONS,
+  WS-EVENT-ROLE-WORLD, or any of their resolved work items.
+- Does not choose the Worldcon paper's final statistical method.
+
+## Acceptance Criteria
+
+(see frontmatter `acceptance:` above)
+
+## Validation
+
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `lrh validate`
+
+## Risk Notes
+
+- Accuracy risk: the model reasons over compact event summaries rather
+  than full original text for events outside the immediate story-level
+  prompt for cross-segment endpoints — a real limitation, mitigated by
+  keeping `EventRelation.certainty` populated so speculative links stay
+  identifiable and separately partitioned, exactly as same-segment
+  relations already are.
+- Long-story context risk: if story-length distribution shows some stories
+  exceed a practical single-call context window, this item must decide
+  whether to cap the pass to salient/high-confidence events, or build the
+  hierarchical windowing mitigation now rather than deferring it further.
+- Double-counting risk: export and baseline changes must not assume the
+  same-segment-exclusion rule alone prevents a relation from being counted
+  twice; de-duplicate defensively by relation ID.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-EVENT-STORY-RELATIONS.md`
+- Design: `project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`
+- Design: `project/design/event-role-world-cross-segment-relations-evaluation.md`

--- a/lcats/project/work_items/proposed/WI-EVENT-0029.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0029.md
@@ -19,6 +19,7 @@ related_design:
   - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
   - project/design/event-role-world-cross-segment-relations-evaluation.md
 depends_on:
+  - WI-EVENT-0026
   - WI-EVENT-0028
 blocked_by: []
 expected_actions:
@@ -36,7 +37,9 @@ acceptance:
   - A new PassUsage entry (e.g. "story_relation") records the pass's cost per the existing cost/baseline reporting pattern
   - Story-level relations are held in StoryWorldAnnotation (or an equivalent story-level container), distinct from per-segment relations
   - export.build_analysis_tables includes story-level relations in its "relations" table
-  - baseline.summarize_annotations includes story-level relations in relations_per_1000_words, with defensive de-duplication by relation ID against per-segment relations
+  - Story-level relation IDs are made globally unique (segment-qualified, e.g. "{segment_id}:{relation_id}", mirroring how reconcile_story_annotations already qualifies event IDs) before any deduplication is attempted, since raw relation_id values are not unique across segments today and reusing them for dedup would silently discard unrelated relations
+  - baseline.summarize_annotations includes story-level relations in relations_per_1000_words, with deduplication keyed on the new globally-unique relation identity against per-segment relations
+  - Story-level relations preserve the weakly_inferred/explicit/strongly_implied certainty partition into their reporting: weakly_inferred story-level relations are counted under weakly_inferred_relations_per_1000_words (as per-segment weakly_inferred relations already are), not mixed into the primary relations_per_1000_words density metric
   - The corpus's actual story-length distribution is checked to decide whether option A's long-story windowing caveat (hierarchical chapter-then-story pass) must be built now, with the decision and rationale documented
   - lrh validate reports 0 errors and scripts/test passes
 required_evidence:
@@ -112,17 +115,36 @@ comparison, and recommended option A as the architecture to fix it.
   stage-6a per-segment pass.
 - Reuse `EventRelation.certainty` (`explicit`/`strongly_implied`/
   `weakly_inferred`) unchanged for these new relations — no new schema
-  field is needed to keep speculative cross-segment links partitioned,
-  mirroring how WI-EVENT-0026 already handles same-segment ones.
+  field is needed to keep speculative cross-segment links identifiable.
+  Downstream reporting must still route `weakly_inferred` story-level
+  relations into the same separate density bucket
+  (`weakly_inferred_relations_per_1000_words`) that per-segment
+  weakly-inferred relations already use, rather than aggregating both
+  certainty layers into the primary metric.
 - New `PassUsage` entry (e.g. `"story_relation"`) for cost/token visibility,
   consistent with the existing cost/baseline reporting pattern.
 - Extend `export.py`'s `build_analysis_tables()` to include story-level
   relations in the `"relations"` table.
+- Qualify story-level relation IDs to be globally unique before any
+  deduplication is attempted — `schema.reconcile_story_annotations()`
+  today qualifies each relation's event endpoints but leaves `relation_id`
+  itself unchanged, and separate segment-level LLM calls can both emit a
+  common ID such as `r1`; deduplicating on the raw ID would discard
+  unrelated relations and silently undercount density. Extend the ID
+  qualification to relations themselves (e.g. `"{segment_id}:{relation_id}"`
+  for the story-level pass's own new relations), or use an equivalent
+  composite identity.
 - Extend `baseline.py`'s `summarize_annotations()` to include story-level
-  relations in `relations_per_1000_words`, de-duplicating defensively by
-  relation ID against relations already present in a segment's own
-  `relations` list (do not assume the same-segment-exclusion rule alone
-  prevents double-counting).
+  relations in `relations_per_1000_words`, de-duplicating by the new
+  globally-unique relation identity against relations already present in
+  a segment's own `relations` list (do not assume the same-segment-
+  exclusion rule alone prevents double-counting).
+- Preserve the `weakly_inferred`/`explicit`/`strongly_implied` certainty
+  partition for story-level relations in `baseline.py`'s output: today
+  `summarize_annotations()` reports `weakly_inferred_relations_per_1000_words`
+  separately from the primary `relations_per_1000_words` for per-segment
+  relations, and story-level relations must follow the same split rather
+  than aggregating both certainty layers into one bucket.
 - Check the corpus's actual story-length distribution before deciding
   whether option A's long-story windowing caveat (a hierarchical,
   chapter-level then story-level pass) needs to be built in this item, or
@@ -139,7 +161,11 @@ comparison, and recommended option A as the architecture to fix it.
 2. Extend `lcats/lcats/analysis/event_role_world/schema.py` to hold the
    new story-level relations (on `StoryWorldAnnotation` or an equivalent
    container) and validate them (ID resolution against the global entity/
-   event index, evidence-span alignment, same-segment-link exclusion).
+   event index, evidence-span alignment, same-segment-link exclusion,
+   globally-unique/segment-qualified relation IDs). Keep `weakly_inferred`
+   story-level relations distinguishable from `explicit`/`strongly_inferred`
+   ones (e.g. via separate buckets or certainty-based filtering) so
+   downstream reporting can preserve the existing certainty partition.
 3. Extend `processor.py` (or the story-level orchestration point that
    calls `reconcile_story_annotations`) to run this pass once per story,
    after reconciliation, with its own `PassUsage`/token-tracking entry and
@@ -148,8 +174,11 @@ comparison, and recommended option A as the architecture to fix it.
 4. Extend `export.py`'s `build_analysis_tables()` and `validate_artifacts()`
    to cover story-level relations.
 5. Extend `baseline.py`'s `summarize_annotations()` to include story-level
-   relations in `relations_per_1000_words`, with de-duplication by
-   relation ID.
+   relations in `relations_per_1000_words`, with de-duplication by the new
+   globally-unique relation identity, and route `weakly_inferred`
+   story-level relations into `weakly_inferred_relations_per_1000_words`
+   rather than the primary density metric, matching how per-segment
+   relations are already reported.
 6. Check story-length distribution across the corpus (`lcats/data/`) and
    document the finding and windowing decision in the PR description or a
    short note in this work item's execution record.
@@ -197,7 +226,15 @@ comparison, and recommended option A as the architecture to fix it.
   hierarchical windowing mitigation now rather than deferring it further.
 - Double-counting risk: export and baseline changes must not assume the
   same-segment-exclusion rule alone prevents a relation from being counted
-  twice; de-duplicate defensively by relation ID.
+  twice; raw `relation_id` values are not globally unique across segments
+  today, so dedup must key on a qualified, globally-unique relation
+  identity, not the raw ID.
+- Certainty-partition risk: `weakly_inferred` story-level relations must
+  not be silently merged into the primary `relations_per_1000_words`
+  metric — they need the same separate-bucket treatment
+  `weakly_inferred_relations_per_1000_words` already gives per-segment
+  weakly-inferred relations, or the paper's primary density figure would
+  be contaminated with speculative links.
 
 ## Related Workstream and Designs
 

--- a/lcats/project/workstreams/proposed/WS-EVENT-STORY-RELATIONS.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-STORY-RELATIONS.md
@@ -1,0 +1,125 @@
+---
+id: WS-EVENT-STORY-RELATIONS
+kind: planning_node
+title: Story-Level Cross-Segment Relation Extraction for Event-Role-World
+status: proposed
+stage: planned
+origin: design_review
+summary: Implement the recommended post-reconciliation story-level causal relation pass (option A) for the Event-Role-World extractor, so genuinely cross-segment causal/explanatory relations are captured for the Worldcon paper's analysis.
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_design:
+  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+  - project/design/event-role-world-cross-segment-relations-evaluation.md
+work_items:
+  - WI-EVENT-0029
+exit_criteria:
+  - A story-level relation pass implementing option A is merged, producing cross-segment EventRelation entries with no double-counting against same-segment relations
+  - export.build_analysis_tables and baseline.summarize_annotations both include story-level relations in their outputs
+  - All work items under this workstream resolved and lrh validate reports 0 errors
+---
+
+# Workstream: Story-Level Cross-Segment Relation Extraction for Event-Role-World
+
+## Purpose
+
+This workstream implements the architecture that WI-EVENT-0028 determined
+is needed and recommended: a post-reconciliation story-level relation pass
+(option A) that discovers causal, enabling, preventing, temporal,
+motivational, and explanatory relations whose two endpoints live in
+different segments. The current per-segment stage-6 pass
+(`relation_extractor.py`, implemented in WI-EVENT-0026) cannot represent
+this today — it only ever receives its own segment's event IDs, and
+`RELATION_SYSTEM_PROMPT` forbids linking outside that list.
+
+## Origin
+
+WI-EVENT-0028's investigation (`project/design/event-role-world-cross-segment-relations-evaluation.md`,
+merged PR #154) ran a direct reading-based pilot over four corpus stories
+and found a clear, genre-differentiated result: both SF/horror stories
+sampled (Lovecraft's "The Colour Out of Space" and "Cool Air") exhibited
+multiple long-range causal chains, while the mystery and general-fiction
+comparison stories exhibited none. This confirmed — not merely
+hypothesized — that per-segment-only relation counting would undercount
+SF's causal density specifically, threatening the validity of the paper's
+central genre comparison. The investigation recommended option A over
+options B and C as the cheapest architecture that targets this phenomenon
+directly, reusing already-resolved evidence spans rather than requiring
+new cross-segment text-search or `event_ids` machinery.
+
+WS-EVENT-CROSS-SEGMENT-RELATIONS (which coordinated WI-EVENT-0028) has
+since closed — its own scope and Non-Goals were explicitly
+investigation-only ("Does not implement any chosen architecture — that is
+deferred to a follow-up deliverable work item once a recommendation
+exists"). This workstream is that follow-up, created fresh rather than
+reopening the closed one, mirroring how WS-EVENT-CROSS-SEGMENT-RELATIONS
+itself was created fresh after WS-EVENT-ROLE-WORLD closed.
+
+## Scope
+
+- Implement option A: a new relation-extraction pass that runs once per
+  story after `schema.reconcile_story_annotations` has produced global
+  entity IDs and the full list of segment-qualified events, discovering
+  relations between events in different segments.
+- Reuse each event's already-resolved `EvidenceSpan` as one endpoint's
+  evidence rather than requiring a fresh quote search across a
+  multi-segment text blob.
+- Extend `export.build_analysis_tables` and `baseline.summarize_annotations`
+  to include these newly-discovered story-level relations in their
+  respective outputs, without double-counting relations already present in
+  a segment's own `relations` list.
+- Check the corpus's actual story-length distribution to decide whether
+  option A's long-story windowing caveat (a hierarchical, chapter-level
+  then story-level pass) needs to be built now, or can remain deferred if
+  story lengths in this corpus stay well within one call's context window.
+
+## Prior Art Check
+
+### Duplication search
+- In-repo: No existing story-level relation extraction exists in `lcats/`.
+  `schema.reconcile_story_annotations` (WI-EVENT-0026) performs story-level
+  entity alias reconciliation and same-segment relation ID qualification
+  only — its own docstring explicitly disclaims discovering cross-segment
+  relations, and WI-EVENT-0028's investigation confirmed this gap is real
+  via direct textual evidence.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found beyond WI-EVENT-0028's recommendation.
+- Proposals: None found beyond the governing Event-Role-World extractor
+  proposal, which this workstream extends per its "cross-segment
+  relations" schema-sketch expectation.
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Work Items
+
+- **WI-EVENT-0029** — deliverable: implements option A's story-level
+  relation pass, extends `export.py` and `baseline.py` to consume it, and
+  checks corpus story-length distribution to size the windowing caveat.
+
+## Exit Criteria
+
+(see frontmatter `exit_criteria:` above)
+
+## Non-Goals
+
+- Does not implement option B (growing per-story event index) or option C
+  (widened per-segment window) — option A was the recommended
+  architecture; the other two are not pursued unless option A proves
+  infeasible.
+- Does not run the larger stratified pilot (5-10 stories per genre) that
+  WI-EVENT-0028 flagged as still needed before the paper publishes a
+  cross-segment relation density figure — that is a corpus/methodology
+  task for the paper, not an implementation task for this workstream.
+- Does not reopen or modify WS-EVENT-CROSS-SEGMENT-RELATIONS,
+  WS-EVENT-ROLE-WORLD, or any of their resolved work items.
+- Does not choose the Worldcon paper's final statistical method.
+
+## Relationship to Design
+
+- Design proposal: `project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`
+- Design doc: `project/design/event-role-world-cross-segment-relations-evaluation.md`


### PR DESCRIPTION
## Summary
Adds the follow-up planning artifacts to implement WI-EVENT-0028's recommended architecture (option A: post-reconciliation story-level relation pass) for cross-segment causal relation extraction in the Event-Role-World extractor.

- **New workstream:** `WS-EVENT-STORY-RELATIONS` (status: proposed, stage: planned) — coordinates implementation now that WI-EVENT-0028 determined the need is real ("yes") and recommended option A. Created fresh rather than reopening the closed, investigation-only WS-EVENT-CROSS-SEGMENT-RELATIONS, per its own Non-Goals ("Does not implement any chosen architecture").
- **New work item:** `WI-EVENT-0029` (type: deliverable, depends_on: WI-EVENT-0026, WI-EVENT-0028) — implements option A: a new relation-extraction pass run once per story after `reconcile_story_annotations`, reusing already-resolved `EvidenceSpan`s, extending `export.py`/`baseline.py` to include story-level relations, and checking corpus story-length distribution to size the long-story windowing caveat.

No code changes — planning artifacts only.

## Files changed
- `lcats/project/workstreams/proposed/WS-EVENT-STORY-RELATIONS.md` (new)
- `lcats/project/work_items/proposed/WI-EVENT-0029.md` (new)
- `lcats/project/work_items/README.md` (updated Proposed Items list)

## Test plan
- [x] `lrh validate` — 0 errors (39 warnings, all pre-existing owner-field pattern)
- [x] Planning-only PR — no code changes, no test suite run needed

Generated with Claude Code
