### PR TITLE
Implement story-level cross-segment relation pass (WI-EVENT-0029)

### DIFF
--- a/lcats/lcats/analysis/event_role_world/baseline.py
+++ b/lcats/lcats/analysis/event_role_world/baseline.py
@@ -11,7 +11,7 @@ two chunking strategies.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from lcats.analysis import story_analysis
 from lcats.analysis.event_role_world import schema
@@ -86,12 +86,22 @@ def _rate_per_1000_words(count: int, word_count: int) -> float:
 
 def summarize_annotations(
     annotations: List[schema.SegmentWorldAnnotation],
+    story: Optional[schema.StoryWorldAnnotation] = None,
 ) -> Dict[str, Any]:
     """Compute normalized rates for a list of segment/chunk annotations.
 
     Args:
         annotations: SegmentWorldAnnotation instances produced by running
             the pipeline over either scene/sequel segments or fixed chunks.
+        story: Optional StoryWorldAnnotation for the same run (WI-EVENT-0029).
+            When given, its cross_segment_relations/weakly_inferred_cross_
+            segment_relations counts are folded into relations_per_1000_words/
+            weakly_inferred_relations_per_1000_words alongside the per-segment
+            counts. Safe to combine without deduplication: cross_segment_
+            relations is populated from a disjoint source (the story-level
+            pass) and is never also present in any segment's own relations
+            list. Defaults to None for callers that only have per-segment
+            annotations (e.g. existing callers predating WI-EVENT-0029).
 
     Returns:
         A dict with unit_count, total_word_count, and per-1000-word rates
@@ -123,6 +133,11 @@ def summarize_annotations(
     total_weakly_inferred_relations = sum(
         len(a.weakly_inferred_relations) for a in annotations
     )
+    if story is not None:
+        total_relations += len(story.cross_segment_relations)
+        total_weakly_inferred_relations += len(
+            story.weakly_inferred_cross_segment_relations
+        )
     total_speech_acts = sum(len(a.speech_acts) for a in annotations)
     total_explanations = sum(len(a.explanations) for a in annotations)
     total_sf_tags = sum(len(a.sf_tags) for a in annotations)
@@ -159,6 +174,8 @@ def summarize_annotations(
 def compare_chunking_strategies(
     segment_annotations: List[schema.SegmentWorldAnnotation],
     chunk_annotations: List[schema.SegmentWorldAnnotation],
+    segment_story: Optional[schema.StoryWorldAnnotation] = None,
+    chunk_story: Optional[schema.StoryWorldAnnotation] = None,
 ) -> Dict[str, Any]:
     """Compare normalized rates between segment-based and fixed-chunk runs.
 
@@ -167,6 +184,11 @@ def compare_chunking_strategies(
             scene/sequel segments.
         chunk_annotations: Annotations from running the same pipeline over
             fixed-token chunks of the same story.
+        segment_story: Optional StoryWorldAnnotation for the segment run
+            (WI-EVENT-0029), so its cross-segment relations are folded into
+            the "segment" summary. Defaults to None.
+        chunk_story: Optional StoryWorldAnnotation for the fixed_chunk run,
+            folded into the "fixed_chunk" summary. Defaults to None.
 
     Returns:
         A dict with "segment" and "fixed_chunk" summaries (see
@@ -174,6 +196,6 @@ def compare_chunking_strategies(
         anchor rates diverge between chunking strategies.
     """
     return {
-        "segment": summarize_annotations(segment_annotations),
-        "fixed_chunk": summarize_annotations(chunk_annotations),
+        "segment": summarize_annotations(segment_annotations, segment_story),
+        "fixed_chunk": summarize_annotations(chunk_annotations, chunk_story),
     }

--- a/lcats/lcats/analysis/event_role_world/export.py
+++ b/lcats/lcats/analysis/event_role_world/export.py
@@ -73,6 +73,15 @@ def validate_artifacts(story: schema.StoryWorldAnnotation) -> List[str]:
                     f"hypothesis_type {hypothesis.hypothesis_type!r}"
                 )
 
+    for relation in (
+        story.cross_segment_relations + story.weakly_inferred_cross_segment_relations
+    ):
+        if relation.certainty not in _VALID_RELATION_CERTAINTIES:
+            errors.append(
+                f"story cross-segment relation {relation.relation_id!r} has "
+                f"invalid certainty {relation.certainty!r}"
+            )
+
     errors.extend(story.validation_errors)
 
     return errors
@@ -112,7 +121,11 @@ def build_analysis_tables(
         annotation layer (entities, events, relations, speech_acts,
         explanations, sf_tags, hypotheses, temporal_anchors,
         spatial_anchors), each row tagged with segment_id (or "story" for
-        story-level entities).
+        story-level entities and cross-segment relations). The "relations"
+        table includes both per-segment relations and the story-level
+        cross-segment relations (WI-EVENT-0029) — the two are disjoint by
+        construction (see StoryWorldAnnotation.cross_segment_relations), so
+        no deduplication is needed to combine them in one table.
     """
     tables: Dict[str, List[Dict[str, Any]]] = {
         "entities": [],
@@ -177,6 +190,13 @@ def build_analysis_tables(
             row = anchor.to_dict()
             row["segment_id"] = segment.segment_id
             tables["spatial_anchors"].append(row)
+
+    for relation in (
+        story.cross_segment_relations + story.weakly_inferred_cross_segment_relations
+    ):
+        row = relation.to_dict()
+        row["segment_id"] = "story"
+        tables["relations"].append(row)
 
     return tables
 

--- a/lcats/lcats/analysis/event_role_world/processor.py
+++ b/lcats/lcats/analysis/event_role_world/processor.py
@@ -5,7 +5,9 @@ Stage 1 (input contract) reuses the existing segment/evidence substrate
 reimplementing segmentation — this module accepts already-produced segments
 (scene/sequel, or fixed_chunk from baseline.py) and runs stages 2-8 over
 each one's sliced text, then stage 9's story-level reconciliation over the
-resulting segment annotations.
+resulting segment annotations, followed by the optional story-level
+cross-segment relation pass (WI-EVENT-0029) that runs once per story rather
+than once per segment.
 """
 
 from __future__ import annotations
@@ -29,6 +31,9 @@ from lcats.analysis.event_role_world import (
 )
 from lcats.analysis.event_role_world import schema
 from lcats.analysis.event_role_world import surface_feature_extractor
+from lcats.analysis.event_role_world import (
+    story_relation_extractor as story_relation_extractor_module,
+)
 
 
 @dataclasses.dataclass
@@ -315,6 +320,7 @@ def process_segments(
     llm_backend: Any,
     story_id: Any = None,
     include_hypotheses: bool = True,
+    include_cross_segment_relations: bool = True,
 ) -> Dict[str, Any]:
     """Run stages 2-8 over every segment in `segments`, then reconcile stage 9.
 
@@ -326,7 +332,7 @@ def process_segments(
             or baseline.make_fixed_token_chunks).
         nlp_backend_name: "stanza" or "spacy".
         llm_backend: LLMBackend for the entity/event/relation/discourse/
-            hypothesis extraction passes.
+            hypothesis/story-relation extraction passes.
         story_id: Identifier carried onto the reconciled StoryWorldAnnotation.
             Defaults to None if the caller has no natural story ID.
         include_hypotheses: Whether to run the optional stage-8 hypothesis
@@ -335,13 +341,26 @@ def process_segments(
             segment entirely (no cost/latency, no hypothesis-provider
             failures in extraction_errors) when only the extractive
             pipeline (stages 1-7 and 9) is needed.
+        include_cross_segment_relations: Whether to run the story-level
+            cross-segment relation pass (WI-EVENT-0029) after reconciliation.
+            Defaults to True; pass False to skip the extra LLM request per
+            story entirely when only per-segment relations are needed (e.g.
+            a fixed-chunk baseline run where cross-segment context is not
+            comparable to the segment run being controlled against). Even
+            when True, the pass is skipped (no LLM call, no PassUsage
+            record) if fewer than 2 events exist across every segment,
+            since a cross-segment relation needs at least two events by
+            definition.
 
     Returns:
         {"segments": [SegmentWorldAnnotation.to_dict(), ...],
          "usage": [PassUsage.to_dict(), ...],
          "story": StoryWorldAnnotation.to_dict()} — "story" is the stage-9
          story-level reconciliation (alias resolution, cross-segment
-         relation qualification) over every segment annotation produced.
+         relation qualification) over every segment annotation produced,
+         plus the story-level cross-segment relation pass's own output if
+         include_cross_segment_relations is True and at least 2 events
+         exist.
     """
     nlp_backend = surface_feature_extractor.make_nlp_backend(nlp_backend_name)
     entity_llm_extractor = entity_extractor_module.make_entity_extractor(llm_backend)
@@ -355,6 +374,11 @@ def process_segments(
     hypothesis_llm_extractor = (
         hypothesis_extractor_module.make_hypothesis_extractor(llm_backend)
         if include_hypotheses
+        else None
+    )
+    story_relation_llm_extractor = (
+        story_relation_extractor_module.make_story_relation_extractor(llm_backend)
+        if include_cross_segment_relations
         else None
     )
 
@@ -384,6 +408,45 @@ def process_segments(
         all_usage.extend(usage_records)
 
     story = schema.reconcile_story_annotations(story_id, annotations)
+
+    # Story-level cross-segment relation pass (optional, WI-EVENT-0029).
+    # Runs once per story, after reconciliation has produced the global
+    # event index the pass needs — never per segment, since the whole
+    # point is discovering links this segment loop cannot see. Skipped
+    # entirely (no LLM call, no PassUsage record) when fewer than 2 events
+    # exist across every segment — a cross-segment relation needs at least
+    # two events by definition, so calling the pass on 0 or 1 events would
+    # spend an LLM call on a result that can only ever be empty.
+    total_event_count = sum(len(segment.events) for segment in annotations)
+    if include_cross_segment_relations and total_event_count >= 2:
+        t0 = time.monotonic()
+        event_index_text = story_relation_extractor_module.build_event_index(story)
+        story_relation_result = story_relation_llm_extractor.extract(event_index_text)
+        all_usage.append(
+            _pass_usage_from_extraction(
+                "story", "story_relation", story_relation_result, t0
+            )
+        )
+        story_relation_error = story_relation_result.get(
+            "api_error"
+        ) or story_relation_result.get("extraction_error")
+        if story_relation_error:
+            # A failed story-relation pass must not silently read as "zero
+            # cross-segment relations found" — mirrors the segment-level
+            # extraction_errors/validation_errors distinction.
+            story.extraction_errors.append(
+                f"story relation extraction failed: {story_relation_error}"
+            )
+        cross_segment_relations, weakly_inferred_cross_segment_relations = (
+            story_relation_extractor_module.build_story_relations(
+                story_relation_result.get("extracted_output") or {}, story
+            )
+        )
+        story.cross_segment_relations = cross_segment_relations
+        story.weakly_inferred_cross_segment_relations = (
+            weakly_inferred_cross_segment_relations
+        )
+        story.validation_errors = schema.validate_story_annotation(story)
 
     return {
         "segments": [a.to_dict() for a in annotations],

--- a/lcats/lcats/analysis/event_role_world/processor.py
+++ b/lcats/lcats/analysis/event_role_world/processor.py
@@ -348,9 +348,9 @@ def process_segments(
             a fixed-chunk baseline run where cross-segment context is not
             comparable to the segment run being controlled against). Even
             when True, the pass is skipped (no LLM call, no PassUsage
-            record) if fewer than 2 events exist across every segment,
-            since a cross-segment relation needs at least two events by
-            definition.
+            record) unless events exist in at least 2 distinct segments,
+            since a genuinely cross-segment relation needs events from two
+            different segments by definition.
 
     Returns:
         {"segments": [SegmentWorldAnnotation.to_dict(), ...],
@@ -359,8 +359,8 @@ def process_segments(
          story-level reconciliation (alias resolution, cross-segment
          relation qualification) over every segment annotation produced,
          plus the story-level cross-segment relation pass's own output if
-         include_cross_segment_relations is True and at least 2 events
-         exist.
+         include_cross_segment_relations is True and events exist in at
+         least 2 distinct segments.
     """
     nlp_backend = surface_feature_extractor.make_nlp_backend(nlp_backend_name)
     entity_llm_extractor = entity_extractor_module.make_entity_extractor(llm_backend)
@@ -413,12 +413,17 @@ def process_segments(
     # Runs once per story, after reconciliation has produced the global
     # event index the pass needs — never per segment, since the whole
     # point is discovering links this segment loop cannot see. Skipped
-    # entirely (no LLM call, no PassUsage record) when fewer than 2 events
-    # exist across every segment — a cross-segment relation needs at least
-    # two events by definition, so calling the pass on 0 or 1 events would
-    # spend an LLM call on a result that can only ever be empty.
-    total_event_count = sum(len(segment.events) for segment in annotations)
-    if include_cross_segment_relations and total_event_count >= 2:
+    # entirely (no LLM call, no PassUsage record) unless events exist in at
+    # least 2 distinct segments — a genuinely cross-segment relation needs
+    # events from two different segments by definition, so a single-segment
+    # story (or a multi-segment story where extraction only succeeded in
+    # one segment) would guarantee every candidate relation gets discarded
+    # by build_story_relations' same-segment check, wasting an LLM call on
+    # a result that can only ever be empty.
+    segment_ids_with_events = {
+        segment.segment_id for segment in annotations if segment.events
+    }
+    if include_cross_segment_relations and len(segment_ids_with_events) >= 2:
         t0 = time.monotonic()
         event_index_text = story_relation_extractor_module.build_event_index(story)
         story_relation_result = story_relation_llm_extractor.extract(event_index_text)

--- a/lcats/lcats/analysis/event_role_world/schema.py
+++ b/lcats/lcats/analysis/event_role_world/schema.py
@@ -5,8 +5,9 @@ Implements the object responsibilities sketched in the governing proposal's
 lcats-event-role-world-extractor/00_proposal.md): entities/participants,
 events/semantic roles, temporal/spatial anchors (WI-EVENT-0024); relations,
 speech acts, explanation discourse, and SF world-model tags (WI-EVENT-0026);
-and the optional stage-8 hypothesis object (belief/uncertainty/perspective/
-emotion) (WI-EVENT-0027).
+the optional stage-8 hypothesis object (belief/uncertainty/perspective/
+emotion) (WI-EVENT-0027); and the story-level cross-segment relation pass
+(WI-EVENT-0029).
 """
 
 from __future__ import annotations
@@ -700,17 +701,20 @@ class StoryWorldAnnotation:
     reconciliation the proposal requires beyond just holding per-segment
     results in a list — see reconcile_story_annotations().
 
-    Known limitation (tracked in WS-EVENT-ROLE-WORLD as a follow-up, not
-    fixed by this WI): relation qualification here only makes segment-local
-    relations safely representable at story scope — it does not, and
-    cannot, discover genuinely cross-segment causal relations (cause in one
-    segment, effect in another). Stage 6's relation_extractor only ever
-    receives its own segment's event IDs, so a relation's source_event_id/
-    target_event_id can never actually reference a different segment's
-    event today; every relation this function qualifies is, by
-    construction, entirely local to the one segment it came from. Real
-    cross-segment relation extraction would require giving stage 6 broader
-    (multi-segment or full-story) context, which is out of this WI's scope.
+    Known limitation, now resolved by WI-EVENT-0029's story-level relation
+    pass: prior to that work item, relation qualification here only made
+    segment-local relations safely representable at story scope — it did
+    not, and could not, discover genuinely cross-segment causal relations
+    (cause in one segment, effect in another), since stage 6's
+    relation_extractor only ever receives its own segment's event IDs, so
+    a relation's source_event_id/target_event_id could never actually
+    reference a different segment's event. Every relation this function
+    qualifies is, by construction, entirely local to the one segment it
+    came from — genuinely cross-segment relations are discovered by a
+    separate story-level pass (see cross_segment_relations below) and kept
+    in their own field rather than merged into `relations`, so the two
+    lists can never collide on relation_id and no deduplication logic is
+    needed to combine their counts.
 
     Attributes:
         story_id: Identifier for the story these segments belong to.
@@ -722,10 +726,27 @@ class StoryWorldAnnotation:
         entity_alias_map: Maps "{segment_id}:{local_entity_id}" to the
             reconciled global entity_id, so callers can translate a
             per-segment entity reference into the story-level entity.
-        relations: All relations (main + weakly_inferred) across every
-            segment, with source_event_id/target_event_id re-qualified to
-            "{segment_id}:{local_event_id}" so they remain unambiguous at
-            story scope (event IDs are otherwise only unique per segment).
+        relations: All same-segment relations (main + weakly_inferred)
+            across every segment, with source_event_id/target_event_id
+            re-qualified to "{segment_id}:{local_event_id}" so they remain
+            unambiguous at story scope (event IDs are otherwise only
+            unique per segment).
+        cross_segment_relations: Genuinely cross-segment relations
+            (certainty "explicit" or "strongly_implied") discovered by the
+            story-level pass (WI-EVENT-0029), whose source_event_id and
+            target_event_id belong to two different segments. Kept
+            separate from `relations` — never merged into it — so the two
+            lists are disjoint by construction and can be summed for a
+            density metric without any relation_id deduplication.
+        weakly_inferred_cross_segment_relations: The weakly_inferred-
+            certainty counterpart to cross_segment_relations, partitioned
+            separately per the same causality tradeoff table that splits
+            `relations`/`weakly_inferred_relations` at segment scope.
+        extraction_errors: Backend/API-level failures for the story-level
+            pass (e.g. a transient provider error, an empty tool result).
+            Distinct from validation_errors: an extraction_error means the
+            story-level pass may not have run at all — its "zero results"
+            must not be read as "the pass ran and found nothing."
         validation_errors: Story-level validation failures (see
             validate_story_annotation).
     """
@@ -737,6 +758,13 @@ class StoryWorldAnnotation:
     entities: List[Entity] = dataclasses.field(default_factory=list)
     entity_alias_map: Dict[str, str] = dataclasses.field(default_factory=dict)
     relations: List[EventRelation] = dataclasses.field(default_factory=list)
+    cross_segment_relations: List[EventRelation] = dataclasses.field(
+        default_factory=list
+    )
+    weakly_inferred_cross_segment_relations: List[EventRelation] = dataclasses.field(
+        default_factory=list
+    )
+    extraction_errors: List[str] = dataclasses.field(default_factory=list)
     validation_errors: List[str] = dataclasses.field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -746,6 +774,13 @@ class StoryWorldAnnotation:
             "entities": [e.to_dict() for e in self.entities],
             "entity_alias_map": dict(self.entity_alias_map),
             "relations": [r.to_dict() for r in self.relations],
+            "cross_segment_relations": [
+                r.to_dict() for r in self.cross_segment_relations
+            ],
+            "weakly_inferred_cross_segment_relations": [
+                r.to_dict() for r in self.weakly_inferred_cross_segment_relations
+            ],
+            "extraction_errors": self.extraction_errors,
             "validation_errors": self.validation_errors,
         }
 
@@ -884,7 +919,16 @@ def validate_story_annotation(story: StoryWorldAnnotation) -> List[str]:
     relation IDs must resolve, and causal links must carry evidence and
     certainty (already enforced by EventRelation's required fields — this
     checks that every relation's referenced qualified event ID actually
-    corresponds to a real event in some segment).
+    corresponds to a real event in some segment). Also validates
+    cross_segment_relations/weakly_inferred_cross_segment_relations (the
+    story-level pass's own output, WI-EVENT-0029): endpoint ID resolution,
+    certainty/bucket consistency (mirroring validate_segment_annotation's
+    same check for segment-level relations), relation_id uniqueness against
+    every other relation on this story (defense in depth — the two fields
+    are populated from a disjoint source and should never collide), and
+    that source/target genuinely belong to different segments, since a
+    same-segment link here would indicate the story-level pass violated its
+    own scope.
 
     Args:
         story: The StoryWorldAnnotation to validate.
@@ -919,5 +963,48 @@ def validate_story_annotation(story: StoryWorldAnnotation) -> List[str]:
                 f"entity_alias_map entry {alias_key!r} references unknown "
                 f"global entity {global_id!r}"
             )
+
+    seen_relation_ids = {r.relation_id for r in story.relations}
+    cross_segment_buckets = [
+        (story.cross_segment_relations, False),
+        (story.weakly_inferred_cross_segment_relations, True),
+    ]
+    for bucket, is_weakly_inferred_bucket in cross_segment_buckets:
+        for relation in bucket:
+            if relation.relation_id in seen_relation_ids:
+                errors.append(
+                    f"cross-segment relation {relation.relation_id!r} collides "
+                    "with another relation ID on this story"
+                )
+            seen_relation_ids.add(relation.relation_id)
+
+            if relation.source_event_id not in qualified_event_ids:
+                errors.append(
+                    f"cross-segment relation {relation.relation_id!r} references "
+                    f"unknown source event {relation.source_event_id!r}"
+                )
+            if relation.target_event_id not in qualified_event_ids:
+                errors.append(
+                    f"cross-segment relation {relation.relation_id!r} references "
+                    f"unknown target event {relation.target_event_id!r}"
+                )
+
+            source_segment_id = relation.source_event_id.split(":", 1)[0]
+            target_segment_id = relation.target_event_id.split(":", 1)[0]
+            if source_segment_id == target_segment_id:
+                errors.append(
+                    f"cross-segment relation {relation.relation_id!r} has "
+                    f"source and target both in segment {source_segment_id!r} "
+                    "— not a genuine cross-segment link"
+                )
+
+            is_weakly_inferred_certainty = relation.certainty == "weakly_inferred"
+            if is_weakly_inferred_certainty != is_weakly_inferred_bucket:
+                errors.append(
+                    f"cross-segment relation {relation.relation_id!r} has "
+                    f"certainty {relation.certainty!r} but is stored in the "
+                    f"{'weakly_inferred_cross_segment_relations' if is_weakly_inferred_bucket else 'cross_segment_relations'} "
+                    "list"
+                )
 
     return errors

--- a/lcats/lcats/analysis/event_role_world/story_relation_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/story_relation_extractor.py
@@ -1,0 +1,226 @@
+"""Story-level cross-segment relation pass (WI-EVENT-0029).
+
+Runs once per story, after schema.reconcile_story_annotations has produced
+the story's global entity IDs and segment-qualified event list, to discover
+causal/enabling/preventing/temporal/motivational/explanatory relations whose
+source and target events live in *different* segments — something stage 6's
+per-segment relation_extractor structurally cannot represent, since it only
+ever receives its own segment's event IDs (see relation_extractor.py and the
+"Known limitation" this pass resolves on schema.StoryWorldAnnotation).
+
+Uses lcats.analysis.llm_extractor.JSONPromptExtractor's tool_schema
+parameter (schema-checked structured output), consistent with every other
+extraction pass in this package.
+
+Unlike the per-segment passes, this pass has no single segment text to
+ground quotes against — instead it reuses each event's own already-resolved
+EvidenceSpan (from the per-segment extraction that discovered it) as the
+relation's evidence, and works from a compact textual index of every
+story-level event rather than raw segment text. This sidesteps the hardest
+grounding problem in any cross-segment design (a fresh quote search across a
+multi-segment text blob) almost entirely.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from lcats.analysis import llm_extractor
+from lcats.analysis.event_role_world import schema
+
+STORY_RELATION_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "extract_story_relations",
+    "description": (
+        "Extract causal, enabling, preventing, temporal, motivational, and "
+        "explanatory links between events that belong to DIFFERENT segments "
+        "of the same story. Same-segment relations are already handled by a "
+        "separate pass and must not be repeated here."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "relations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "relation_id": {"type": "string"},
+                        "source_event_id": {
+                            "type": "string",
+                            "description": (
+                                'Qualified event ID ("segment_id:event_id") '
+                                "from the known events list."
+                            ),
+                        },
+                        "target_event_id": {
+                            "type": "string",
+                            "description": (
+                                'Qualified event ID ("segment_id:event_id") '
+                                "from the known events list, in a DIFFERENT "
+                                "segment than source_event_id."
+                            ),
+                        },
+                        "relation_type": {
+                            "type": "string",
+                            "description": (
+                                "e.g. causes, enables, prevents, precedes, "
+                                "motivates, explains"
+                            ),
+                        },
+                        "certainty": {
+                            "type": "string",
+                            "enum": ["explicit", "strongly_implied", "weakly_inferred"],
+                        },
+                        "confidence": {"type": "number"},
+                    },
+                    "required": [
+                        "relation_id",
+                        "source_event_id",
+                        "target_event_id",
+                        "relation_type",
+                    ],
+                },
+            }
+        },
+        "required": ["relations"],
+    },
+}
+
+STORY_RELATION_SYSTEM_PROMPT = """You are extracting cross-segment causal and
+temporal relations between events from different segments of the same story,
+for structured narrative analysis. You are given a compact list of events
+already identified across every segment, each labeled with a globally
+qualified event ID ("segment_id:event_id"), its predicate and event type,
+which segment it belongs to, and a short quote grounding it in that segment.
+Only propose relations whose source and target events belong to DIFFERENT
+segments — same-segment relations are already handled by a separate pass and
+must not be repeated here. Only use the exact qualified event IDs given; do
+not invent new ones. For each relation, classify its certainty: "explicit" if
+the text directly implies the link across the events described, "strongly_
+implied" if a careful reader would confidently infer it, or "weakly_inferred"
+if it is a plausible but speculative reading."""
+
+STORY_RELATION_USER_PROMPT_TEMPLATE = """Known events across the story
+(qualified_event_id | predicate [event_type] | segment=segment_id | "quote"):
+---
+{story_text}
+---
+
+Extract only relations whose source_event_id and target_event_id come from
+DIFFERENT segments, per the extract_story_relations tool schema. Use the
+exact qualified event IDs listed above."""
+
+
+def make_story_relation_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
+    """Create a JSONPromptExtractor configured for the story-level relation pass.
+
+    Args:
+        backend: LLMBackend satisfying lcats.llm.backend.LLMBackend Protocol.
+
+    Returns:
+        Configured JSONPromptExtractor using the tool= structured-output path.
+    """
+    return llm_extractor.JSONPromptExtractor(
+        backend,
+        system_prompt=STORY_RELATION_SYSTEM_PROMPT,
+        user_prompt_template=STORY_RELATION_USER_PROMPT_TEMPLATE,
+        default_model="gpt-4o",
+        temperature=0.2,
+        tool_schema=STORY_RELATION_TOOL_SCHEMA,
+    )
+
+
+def build_event_index(story: schema.StoryWorldAnnotation) -> str:
+    """Build a compact, qualified-event-ID-keyed text index for `story`.
+
+    Args:
+        story: A StoryWorldAnnotation whose segment_annotations' events are
+            indexed. Must be called after schema.reconcile_story_annotations
+            so segment_annotations is populated.
+
+    Returns:
+        One line per event, in segment order: "segment_id:event_id |
+        predicate [event_type] | segment=segment_id | \"quote\"" — this text
+        is passed as the pass's `story_text` argument (there is no single
+        segment text for a story-level pass; this compact index stands in
+        for it).
+    """
+    lines: List[str] = []
+    for segment in story.segment_annotations:
+        for event in segment.events:
+            qualified_id = f"{segment.segment_id}:{event.event_id}"
+            lines.append(
+                f"{qualified_id} | {event.predicate} [{event.event_type}] | "
+                f'segment={segment.segment_id} | "{event.evidence.quote}"'
+            )
+    return "\n".join(lines)
+
+
+def build_story_relations(
+    tool_result: Dict[str, Any], story: schema.StoryWorldAnnotation
+) -> Tuple[List[schema.EventRelation], List[schema.EventRelation]]:
+    """Convert a raw extract_story_relations tool result into schema objects.
+
+    Args:
+        tool_result: The dict returned by the extract_story_relations tool
+            call.
+        story: The StoryWorldAnnotation the qualified event IDs and
+            per-event evidence spans are resolved against. Must be called
+            after schema.reconcile_story_annotations.
+
+    Returns:
+        (cross_segment_relations, weakly_inferred_cross_segment_relations)
+        — relations whose source_event_id/target_event_id do not both
+        resolve to known qualified event IDs are dropped, as are relations
+        whose source and target resolve to the SAME segment (the model may
+        occasionally violate its instructions; this pass's contract is
+        cross-segment only, so such a claim is discarded rather than
+        silently accepted). Each surviving relation's relation_id is
+        qualified with a "story:" prefix so it can never collide with a
+        per-segment relation's raw ID once both appear in exported tables
+        — this pass's output is kept in its own StoryWorldAnnotation fields
+        entirely separate from `relations`, so no runtime deduplication is
+        needed to combine their counts. Evidence is reused directly from
+        the source event's own already-resolved EvidenceSpan (the
+        "already-resolved evidence spans" reuse WI-EVENT-0028's evaluation
+        recommended), not a fresh quote search — there is no single text
+        blob to search across segments against.
+    """
+    event_by_qualified_id: Dict[str, schema.Event] = {
+        f"{segment.segment_id}:{event.event_id}": event
+        for segment in story.segment_annotations
+        for event in segment.events
+    }
+
+    cross_segment_relations: List[schema.EventRelation] = []
+    weakly_inferred_cross_segment_relations: List[schema.EventRelation] = []
+
+    for raw in tool_result.get("relations") or []:
+        source_id = raw.get("source_event_id", "")
+        target_id = raw.get("target_event_id", "")
+        source_event = event_by_qualified_id.get(source_id)
+        target_event = event_by_qualified_id.get(target_id)
+        if source_event is None or target_event is None:
+            continue
+
+        source_segment_id = source_id.split(":", 1)[0]
+        target_segment_id = target_id.split(":", 1)[0]
+        if source_segment_id == target_segment_id:
+            continue
+
+        certainty = raw.get("certainty", "explicit")
+        relation = schema.EventRelation(
+            relation_id=f"story:{raw['relation_id']}",
+            source_event_id=source_id,
+            target_event_id=target_id,
+            relation_type=raw.get("relation_type", "other"),
+            evidence=source_event.evidence,
+            certainty=certainty,
+            confidence=raw.get("confidence", 1.0),
+        )
+        if certainty == "weakly_inferred":
+            weakly_inferred_cross_segment_relations.append(relation)
+        else:
+            cross_segment_relations.append(relation)
+
+    return cross_segment_relations, weakly_inferred_cross_segment_relations

--- a/lcats/lcats/analysis/event_role_world/story_relation_extractor.py
+++ b/lcats/lcats/analysis/event_role_world/story_relation_extractor.py
@@ -23,7 +23,7 @@ multi-segment text blob) almost entirely.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from lcats.analysis import llm_extractor
 from lcats.analysis.event_role_world import schema
@@ -96,9 +96,9 @@ Only propose relations whose source and target events belong to DIFFERENT
 segments — same-segment relations are already handled by a separate pass and
 must not be repeated here. Only use the exact qualified event IDs given; do
 not invent new ones. For each relation, classify its certainty: "explicit" if
-the text directly implies the link across the events described, "strongly_
-implied" if a careful reader would confidently infer it, or "weakly_inferred"
-if it is a plausible but speculative reading."""
+the text directly implies the link across the events described,
+"strongly_implied" if a careful reader would confidently infer it, or
+"weakly_inferred" if it is a plausible but speculative reading."""
 
 STORY_RELATION_USER_PROMPT_TEMPLATE = """Known events across the story
 (qualified_event_id | predicate [event_type] | segment=segment_id | "quote"):
@@ -175,16 +175,22 @@ def build_story_relations(
         whose source and target resolve to the SAME segment (the model may
         occasionally violate its instructions; this pass's contract is
         cross-segment only, so such a claim is discarded rather than
-        silently accepted). Each surviving relation's relation_id is
-        qualified with a "story:" prefix so it can never collide with a
-        per-segment relation's raw ID once both appear in exported tables
-        — this pass's output is kept in its own StoryWorldAnnotation fields
-        entirely separate from `relations`, so no runtime deduplication is
-        needed to combine their counts. Evidence is reused directly from
-        the source event's own already-resolved EvidenceSpan (the
-        "already-resolved evidence spans" reuse WI-EVENT-0028's evaluation
-        recommended), not a fresh quote search — there is no single text
-        blob to search across segments against.
+        silently accepted). The tool schema does not forbid the model from
+        returning the same relation_id more than once in a single call, so
+        a raw relation_id already seen earlier in this same tool_result is
+        also dropped — deduplicated here, before storing or counting,
+        rather than merely detected later by validate_story_annotation.
+        Each surviving relation's relation_id is qualified with a "story:"
+        prefix so it can never collide with a per-segment relation's raw ID
+        once both appear in exported tables — this pass's output is kept
+        in its own StoryWorldAnnotation fields entirely separate from
+        `relations`, so no cross-source deduplication is needed to combine
+        their counts (only the within-this-call dedup above is needed).
+        Evidence is reused directly from the source event's own
+        already-resolved EvidenceSpan (the "already-resolved evidence
+        spans" reuse WI-EVENT-0028's evaluation recommended), not a fresh
+        quote search — there is no single text blob to search across
+        segments against.
     """
     event_by_qualified_id: Dict[str, schema.Event] = {
         f"{segment.segment_id}:{event.event_id}": event
@@ -194,6 +200,7 @@ def build_story_relations(
 
     cross_segment_relations: List[schema.EventRelation] = []
     weakly_inferred_cross_segment_relations: List[schema.EventRelation] = []
+    seen_raw_relation_ids: Set[str] = set()
 
     for raw in tool_result.get("relations") or []:
         source_id = raw.get("source_event_id", "")
@@ -208,9 +215,14 @@ def build_story_relations(
         if source_segment_id == target_segment_id:
             continue
 
+        raw_relation_id = raw["relation_id"]
+        if raw_relation_id in seen_raw_relation_ids:
+            continue
+        seen_raw_relation_ids.add(raw_relation_id)
+
         certainty = raw.get("certainty", "explicit")
         relation = schema.EventRelation(
-            relation_id=f"story:{raw['relation_id']}",
+            relation_id=f"story:{raw_relation_id}",
             source_event_id=source_id,
             target_event_id=target_id,
             relation_type=raw.get("relation_type", "other"),

--- a/lcats/project/executions/AD_HOC/2026_07_25_21_56_18_WI_EVENT_0029_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_25_21_56_18_WI_EVENT_0029_REVIEW.md
@@ -1,0 +1,39 @@
+---
+execution_id: 2026_07_25_21_56_18_WI_EVENT_0029_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0029_REVIEW)[2026-07-25T21:55:53-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_25_21_08_38_WI_EVENT_0029
+pr: https://github.com/xenotaur/LCATS/pull/156
+commit: 987e4fd6
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/156
+session_transcript: pending
+created_at: 2026-07-25T21:56:18-04:00
+---
+
+# Summary
+
+Address PR #156 review feedback on the WI-EVENT-0029 story-level cross-segment relation pass implementation.
+
+# Result
+
+Three review comments addressed:
+
+- **copilot: `STORY_RELATION_SYSTEM_PROMPT` split "strongly_implied" across a newline** (`"strongly_\nimplied"`), which could reduce compliance with the tool schema's `enum` (which requires the exact unbroken string). Fixed the line wrap so the literal never breaks the label.
+- **P1 (chatgpt-codex-connector): repeated raw `relation_id`s in one tool call would inflate density.** The tool schema doesn't forbid the model returning the same `relation_id` twice; qualifying both with the same `"story:"` prefix produced duplicate entries that `validate_story_annotation` flagged as a collision but never removed, and `baseline.summarize_annotations` counted both. Fixed by deduplicating on the raw `relation_id` within `build_story_relations` itself, before storing or counting — a relation is now dropped if its raw ID was already seen earlier in the same tool_result.
+- **P2 (chatgpt-codex-connector): the pass ran even when every candidate relation would necessarily be same-segment.** The original guard only checked "at least 2 events exist across all segments" — a single-segment story with 2+ events (or a multi-segment story where extraction only succeeded in one segment) would still trigger a guaranteed-useless LLM call, since `build_story_relations` discards every same-segment claim. Fixed the guard in `processor.py` to require events in at least 2 *distinct* segments, not just 2 events total.
+
+Also added tests for both fixes: `test_deduplicates_repeated_raw_relation_id_within_one_call` and `test_cross_segment_relation_pass_skipped_for_single_segment_story` (the latter specifically exercises the case a naive "2+ events" guard would have wrongly let through).
+
+# Validation
+
+- `scripts/format --check --diff` — clean.
+- `scripts/lint` — clean.
+- `scripts/test` — 1436 tests pass.
+- `lrh validate` (run from `lcats/`) — 0 errors, 39 pre-existing warnings, unrelated to this change.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/156` to verify fixes against the current diff and resolve review threads, then the merge gate, then `/lrh-closeout`.

--- a/lcats/project/executions/AD_HOC/2026_07_25_21_58_49_WI_EVENT_0029_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_25_21_58_49_WI_EVENT_0029_CONFIRM.md
@@ -1,0 +1,37 @@
+---
+execution_id: 2026_07_25_21_58_49_WI_EVENT_0029_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0029_CONFIRM)[2026-07-25T21:58:42-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_25_21_56_18_WI_EVENT_0029_REVIEW
+pr: https://github.com/xenotaur/LCATS/pull/156
+commit: 9c1c9f34
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/156
+session_transcript: pending
+created_at: 2026-07-25T21:58:49-04:00
+---
+
+# Summary
+
+Confirm PR #156's review fixes against the current diff and resolve threads before merge.
+
+# Result
+
+Fetched threads via `lrh github threads <pr-url> --mode raw --state all`: 3 total, all unresolved before this round. Verified each against the pushed fix:
+
+- copilot newline-split label — confirmed `STORY_RELATION_SYSTEM_PROMPT` no longer breaks "strongly_implied" across a line.
+- P1 dedup — confirmed `build_story_relations` now tracks `seen_raw_relation_ids` and drops a relation whose raw ID was already seen in the same tool_result, with a new test (`test_deduplicates_repeated_raw_relation_id_within_one_call`) covering it.
+- P2 same-segment guard — confirmed `processor.py`'s guard now checks `len(segment_ids_with_events) >= 2` instead of total event count, with a new test (`test_cross_segment_relation_pass_skipped_for_single_segment_story`) covering the specific case the review flagged.
+
+Resolved all 3 threads via `gh api graphql resolveReviewThread`. Polled CI (`gh pr checks`) until settled: coverage, lint, both test jobs all SUCCESS against commit `9c1c9f34`.
+
+# Validation
+
+- `lrh github threads https://github.com/xenotaur/LCATS/pull/156 --mode raw --state all` — 0 unresolved threads remain after resolution.
+- `gh pr checks https://github.com/xenotaur/LCATS/pull/156` — coverage/lint/test x2 all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Merge gate: summarize PR #156 for the user and wait for explicit approval before merging.

--- a/lcats/project/executions/WI-EVENT-0029/2026_07_25_21_08_38_WI_EVENT_0029.md
+++ b/lcats/project/executions/WI-EVENT-0029/2026_07_25_21_08_38_WI_EVENT_0029.md
@@ -1,0 +1,39 @@
+---
+execution_id: 2026_07_25_21_08_38_WI_EVENT_0029
+prompt_id: PROMPT(WI-EVENT-0029:WI_EVENT_0029)[2026-07-25T19:04:33-04:00]
+work_item: WI-EVENT-0029
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/156
+commit: 13158e5
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-EVENT-0029.md
+session_transcript: pending
+created_at: 2026-07-25T21:08:38-04:00
+---
+
+# Summary
+
+Implement WI-EVENT-0029: option A, a post-reconciliation story-level relation pass discovering causal/enabling/preventing/temporal/motivational/explanatory relations whose source and target events live in different segments.
+
+# Result
+
+- New `lcats/lcats/analysis/event_role_world/story_relation_extractor.py`: `STORY_RELATION_TOOL_SCHEMA`, `STORY_RELATION_SYSTEM_PROMPT`/`STORY_RELATION_USER_PROMPT_TEMPLATE`, `make_story_relation_extractor`, `build_event_index` (compact qualified-event-ID text index, no single segment text exists for a story-level pass), `build_story_relations` (drops relations with unresolvable endpoints or same-segment endpoints, reuses the source event's own `EvidenceSpan` for grounding, qualifies `relation_id` with a `"story:"` prefix).
+- `schema.py`: added `StoryWorldAnnotation.cross_segment_relations` / `weakly_inferred_cross_segment_relations` / `extraction_errors` fields, kept structurally separate from `relations` so the new pass's output can never collide with per-segment relation IDs and needs no runtime deduplication. Extended `validate_story_annotation` with endpoint resolution, certainty-bucket consistency, relation-ID-collision, and same-segment-violation checks for the new fields.
+- `processor.py`: new `include_cross_segment_relations` opt-out parameter (default `True`) and `"story_relation"` `PassUsage` entry; the pass is skipped entirely (no LLM call, no usage record) when fewer than 2 events exist across all segments, since a cross-segment relation needs at least two events by definition.
+- `export.py`: `build_analysis_tables`/`validate_artifacts` include cross-segment relations in the `"relations"` table and certainty validation.
+- `baseline.py`: `summarize_annotations`/`compare_chunking_strategies` gained an optional `story` parameter folding cross-segment relation counts into `relations_per_1000_words`/`weakly_inferred_relations_per_1000_words`.
+- Corpus check (per the WI's acceptance criterion): story lengths in `lcats/data/` stay well within a single LLM call's context window (median 4,881 words, p90 7,923, p99 10,392, max 44,651, out of 1,867 stories — only 2 exceed 20k words). The hierarchical windowing mitigation the design doc flagged as a caveat is **not needed now** — documented in the PR description rather than as a separate design-doc addendum.
+- Design choice worth noting: rather than fixing `relation_id` uniqueness by qualifying every relation in the merged `relations` list (as PR #155's review literally suggested), cross-segment relations are kept in their own disjoint fields — this satisfies the same underlying concern (no double-counting, no ID collision) through a simpler mechanism.
+
+# Validation
+
+- `scripts/format --check --diff` — clean (ran `scripts/format` once to apply black's own reformatting of the new/changed files, then re-checked clean).
+- `scripts/lint` — clean.
+- `scripts/test` — 1434 tests pass (97 in `event_role_world_test.py`, including new `TestBuildEventIndex`, `TestBuildStoryRelations`, and extensions to `TestReconcileStoryAnnotations`, `TestExport`, `TestSummarizeAndCompare`, `TestProcessSegments`).
+- `lrh validate` (run from `lcats/`) — 0 errors, 39 pre-existing unrelated warnings.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Wait for reviewer comments and run `/lrh-review-response https://github.com/xenotaur/LCATS/pull/156` to address them, then `/lrh-confirm-fixes` before merge. After merging, run `/lrh-closeout` to land this record and resolve WI-EVENT-0029.

--- a/lcats/tests/analysis_tests/event_role_world_test.py
+++ b/lcats/tests/analysis_tests/event_role_world_test.py
@@ -941,6 +941,35 @@ class TestBuildStoryRelations(unittest.TestCase):
         )
         self.assertTrue(relations[0].relation_id.startswith("story:"))
 
+    def test_deduplicates_repeated_raw_relation_id_within_one_call(self):
+        """The tool schema does not forbid the model from returning the same
+        relation_id twice in one call; a naive qualify-and-store would
+        produce two "story:r1" entries, inflating the density count. This
+        must be deduplicated before storing/counting, not merely flagged
+        later by validate_story_annotation."""
+        story = self._story_with_two_segment_events()
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "2:ev1",
+                    "relation_type": "causes",
+                },
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "2:ev1",
+                    "relation_type": "causes",
+                },
+            ]
+        }
+        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+            tool_result, story
+        )
+        self.assertEqual(len(relations), 1)
+        self.assertEqual(weakly_inferred, [])
+
 
 # ---------------------------------------------------------------------------
 # Tests: schema.reconcile_story_annotations / validate_story_annotation (stage 9)
@@ -2253,6 +2282,49 @@ class TestProcessSegments(unittest.TestCase):
 
         # Exactly 5 calls - the story-level pass was never invoked despite
         # include_cross_segment_relations defaulting to True.
+        self.assertEqual(len(fake.calls), 5)
+        usage_by_pass = {u["pass_name"]: u for u in result["usage"]}
+        self.assertNotIn("story_relation", usage_by_pass)
+
+    def test_cross_segment_relation_pass_skipped_for_single_segment_story(self):
+        """Two events in the SAME segment cannot produce a genuinely
+        cross-segment relation - build_story_relations would discard every
+        candidate as same-segment, so the pass must be skipped even though
+        total event count is >= 2 (a naive "at least 2 events" guard would
+        incorrectly let this one through)."""
+        segment_text = "The machine hummed. It shut off."
+        fake = _SequencedFakeBackend(
+            [
+                {"entities": []},
+                {
+                    "events": [
+                        {
+                            "event_id": "ev1",
+                            "predicate": "hummed",
+                            "event_type": "x",
+                            "quote": "hummed",
+                        },
+                        {
+                            "event_id": "ev2",
+                            "predicate": "shut off",
+                            "event_type": "x",
+                            "quote": "shut off",
+                        },
+                    ]
+                },
+                {"relations": []},
+                {},
+                {},
+            ]
+        )
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        result = processor.process_segments(
+            segment_text, segments, nlp_backend_name="spacy", llm_backend=fake
+        )
+
+        # Exactly 5 calls - both events are in segment 1, so no distinct
+        # second segment exists for a cross-segment relation to span.
         self.assertEqual(len(fake.calls), 5)
         usage_by_pass = {u["pass_name"]: u for u in result["usage"]}
         self.assertNotIn("story_relation", usage_by_pass)

--- a/lcats/tests/analysis_tests/event_role_world_test.py
+++ b/lcats/tests/analysis_tests/event_role_world_test.py
@@ -14,6 +14,7 @@ from lcats.analysis.event_role_world import nlp_backend
 from lcats.analysis.event_role_world import processor
 from lcats.analysis.event_role_world import relation_extractor
 from lcats.analysis.event_role_world import schema
+from lcats.analysis.event_role_world import story_relation_extractor
 from lcats.analysis.event_role_world import surface_feature_extractor
 
 
@@ -746,6 +747,202 @@ class TestBuildHypotheses(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Tests: story_relation_extractor (WI-EVENT-0029, story-level cross-segment)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEventIndex(unittest.TestCase):
+    def test_builds_one_line_per_event_across_segments(self):
+        evidence1 = schema.EvidenceSpan(0, 6, "hummed")
+        evidence2 = schema.EvidenceSpan(0, 8, "shut off")
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1,
+            events=[
+                schema.Event(
+                    event_id="ev1",
+                    predicate="hummed",
+                    event_type="sound_emission",
+                    evidence=evidence1,
+                )
+            ],
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2,
+            events=[
+                schema.Event(
+                    event_id="ev1",
+                    predicate="shut off",
+                    event_type="mechanical_failure",
+                    evidence=evidence2,
+                )
+            ],
+        )
+        story = schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+        index_text = story_relation_extractor.build_event_index(story)
+
+        self.assertIn("1:ev1", index_text)
+        self.assertIn("2:ev1", index_text)
+        self.assertIn("hummed", index_text)
+        self.assertIn("shut off", index_text)
+
+    def test_empty_story_produces_empty_index(self):
+        story = schema.StoryWorldAnnotation(story_id="s1")
+        self.assertEqual(story_relation_extractor.build_event_index(story), "")
+
+
+class TestBuildStoryRelations(unittest.TestCase):
+    def _story_with_two_segment_events(self):
+        evidence1 = schema.EvidenceSpan(0, 6, "hummed")
+        evidence2 = schema.EvidenceSpan(0, 8, "shut off")
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1,
+            events=[
+                schema.Event(
+                    event_id="ev1",
+                    predicate="hummed",
+                    event_type="sound_emission",
+                    evidence=evidence1,
+                )
+            ],
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2,
+            events=[
+                schema.Event(
+                    event_id="ev1",
+                    predicate="shut off",
+                    event_type="mechanical_failure",
+                    evidence=evidence2,
+                )
+            ],
+        )
+        return schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+    def test_builds_cross_segment_relation_reusing_source_evidence(self):
+        story = self._story_with_two_segment_events()
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "2:ev1",
+                    "relation_type": "causes",
+                    "certainty": "explicit",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+
+        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+            tool_result, story
+        )
+
+        self.assertEqual(len(relations), 1)
+        self.assertEqual(relations[0].relation_id, "story:r1")
+        self.assertEqual(relations[0].source_event_id, "1:ev1")
+        self.assertEqual(relations[0].target_event_id, "2:ev1")
+        # Evidence is reused directly from the source event's own span.
+        self.assertEqual(relations[0].evidence.quote, "hummed")
+        self.assertEqual(weakly_inferred, [])
+
+    def test_partitions_weakly_inferred_relation_into_separate_list(self):
+        story = self._story_with_two_segment_events()
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "2:ev1",
+                    "relation_type": "motivates",
+                    "certainty": "weakly_inferred",
+                }
+            ]
+        }
+
+        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+            tool_result, story
+        )
+
+        self.assertEqual(relations, [])
+        self.assertEqual(len(weakly_inferred), 1)
+        self.assertEqual(weakly_inferred[0].certainty, "weakly_inferred")
+
+    def test_drops_relation_referencing_unknown_event_id(self):
+        story = self._story_with_two_segment_events()
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "9:does_not_exist",
+                    "relation_type": "causes",
+                }
+            ]
+        }
+
+        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+            tool_result, story
+        )
+
+        self.assertEqual(relations, [])
+        self.assertEqual(weakly_inferred, [])
+
+    def test_drops_relation_whose_endpoints_are_in_the_same_segment(self):
+        """This pass's contract is cross-segment only; a same-segment claim
+        (the model violating its own instructions) must be discarded rather
+        than silently accepted, since same-segment links are already
+        covered by the existing per-segment pass."""
+        story = self._story_with_two_segment_events()
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "1:ev1",
+                    "relation_type": "precedes",
+                }
+            ]
+        }
+
+        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+            tool_result, story
+        )
+
+        self.assertEqual(relations, [])
+        self.assertEqual(weakly_inferred, [])
+
+    def test_empty_tool_result_produces_no_relations(self):
+        story = self._story_with_two_segment_events()
+        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+            {}, story
+        )
+        self.assertEqual(relations, [])
+        self.assertEqual(weakly_inferred, [])
+
+    def test_relation_id_is_qualified_with_story_prefix(self):
+        """Qualifying the ID this way means cross_segment_relations can
+        never collide with a per-segment relation's raw ID once both
+        appear in the same exported table — no runtime deduplication is
+        needed (see StoryWorldAnnotation.cross_segment_relations)."""
+        story = self._story_with_two_segment_events()
+        tool_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "2:ev1",
+                    "relation_type": "causes",
+                }
+            ]
+        }
+        relations, _ = story_relation_extractor.build_story_relations(
+            tool_result, story
+        )
+        self.assertTrue(relations[0].relation_id.startswith("story:"))
+
+
+# ---------------------------------------------------------------------------
 # Tests: schema.reconcile_story_annotations / validate_story_annotation (stage 9)
 # ---------------------------------------------------------------------------
 
@@ -912,6 +1109,119 @@ class TestReconcileStoryAnnotations(unittest.TestCase):
         self.assertTrue(any("does_not_exist" in e for e in errors))
         self.assertTrue(any("also_missing" in e for e in errors))
 
+    def _story_with_two_segment_events(self):
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        seg1 = schema.SegmentWorldAnnotation(
+            segment_id=1,
+            events=[
+                schema.Event(
+                    event_id="ev1", predicate="p", event_type="x", evidence=evidence
+                )
+            ],
+        )
+        seg2 = schema.SegmentWorldAnnotation(
+            segment_id=2,
+            events=[
+                schema.Event(
+                    event_id="ev1", predicate="p", event_type="x", evidence=evidence
+                )
+            ],
+        )
+        return schema.reconcile_story_annotations("s1", [seg1, seg2])
+
+    def test_validate_story_annotation_accepts_valid_cross_segment_relation(self):
+        story = self._story_with_two_segment_events()
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        story.cross_segment_relations = [
+            schema.EventRelation(
+                relation_id="story:r1",
+                source_event_id="1:ev1",
+                target_event_id="2:ev1",
+                relation_type="causes",
+                evidence=evidence,
+            )
+        ]
+        errors = schema.validate_story_annotation(story)
+        self.assertEqual(errors, [])
+
+    def test_validate_story_annotation_flags_cross_segment_relation_dangling_endpoint(
+        self,
+    ):
+        story = self._story_with_two_segment_events()
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        story.cross_segment_relations = [
+            schema.EventRelation(
+                relation_id="story:r1",
+                source_event_id="1:ev1",
+                target_event_id="9:does_not_exist",
+                relation_type="causes",
+                evidence=evidence,
+            )
+        ]
+        errors = schema.validate_story_annotation(story)
+        self.assertTrue(any("does_not_exist" in e for e in errors))
+
+    def test_validate_story_annotation_flags_same_segment_cross_segment_relation(self):
+        """A same-segment link in cross_segment_relations would indicate the
+        story-level pass violated its own scope — this must be flagged as
+        an error, not silently accepted."""
+        story = self._story_with_two_segment_events()
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        story.cross_segment_relations = [
+            schema.EventRelation(
+                relation_id="story:r1",
+                source_event_id="1:ev1",
+                target_event_id="1:ev1",
+                relation_type="causes",
+                evidence=evidence,
+            )
+        ]
+        errors = schema.validate_story_annotation(story)
+        self.assertTrue(any("not a genuine cross-segment link" in e for e in errors))
+
+    def test_validate_story_annotation_flags_relation_id_collision(self):
+        """Defense in depth: cross_segment_relations and relations should
+        never share a relation_id (they come from disjoint sources by
+        construction), but validation still checks for it explicitly."""
+        story = self._story_with_two_segment_events()
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        story.relations = [
+            schema.EventRelation(
+                relation_id="dup",
+                source_event_id="1:ev1",
+                target_event_id="1:ev1",
+                relation_type="causes",
+                evidence=evidence,
+            )
+        ]
+        story.cross_segment_relations = [
+            schema.EventRelation(
+                relation_id="dup",
+                source_event_id="1:ev1",
+                target_event_id="2:ev1",
+                relation_type="causes",
+                evidence=evidence,
+            )
+        ]
+        errors = schema.validate_story_annotation(story)
+        self.assertTrue(any("collides" in e for e in errors))
+
+    def test_validate_story_annotation_flags_certainty_bucket_mismatch(self):
+        story = self._story_with_two_segment_events()
+        evidence = schema.EvidenceSpan(start_char=0, end_char=1, quote="x")
+        story.cross_segment_relations = [
+            schema.EventRelation(
+                relation_id="story:r1",
+                source_event_id="1:ev1",
+                target_event_id="2:ev1",
+                relation_type="causes",
+                evidence=evidence,
+                certainty="weakly_inferred",
+            )
+        ]
+        errors = schema.validate_story_annotation(story)
+        self.assertTrue(any("has certainty" in e for e in errors))
+
     def test_reconciliation_is_deterministic(self):
         seg1 = schema.SegmentWorldAnnotation(
             segment_id=1, entities=[self._entity("e1", "the machine")]
@@ -1007,6 +1317,22 @@ class TestExport(unittest.TestCase):
         errors = export.validate_artifacts(story)
         self.assertTrue(any("invalid" in e and "hypothesis_type" in e for e in errors))
 
+    def test_validate_artifacts_flags_invalid_cross_segment_relation_certainty(self):
+        story = self._story_with_one_of_everything()
+        evidence = schema.EvidenceSpan(start_char=0, end_char=7, quote="machine")
+        story.cross_segment_relations = [
+            schema.EventRelation(
+                relation_id="story:r1",
+                source_event_id="1:ev1",
+                target_event_id="1:ev1",
+                relation_type="causes",
+                evidence=evidence,
+                certainty="not_a_valid_certainty",
+            )
+        ]
+        errors = export.validate_artifacts(story)
+        self.assertTrue(any("invalid certainty" in e for e in errors))
+
     def test_to_canonical_json_is_deterministic(self):
         story = self._story_with_one_of_everything()
         self.assertEqual(
@@ -1026,6 +1352,38 @@ class TestExport(unittest.TestCase):
             "hypotheses",
         ):
             self.assertEqual(len(tables[table_name]), 1, table_name)
+
+    def test_build_analysis_tables_includes_cross_segment_relations(self):
+        story = self._story_with_one_of_everything()
+        evidence = schema.EvidenceSpan(start_char=0, end_char=7, quote="machine")
+        story.cross_segment_relations = [
+            schema.EventRelation(
+                relation_id="story:r2",
+                source_event_id="1:ev1",
+                target_event_id="1:ev1",
+                relation_type="causes",
+                evidence=evidence,
+            )
+        ]
+        story.weakly_inferred_cross_segment_relations = [
+            schema.EventRelation(
+                relation_id="story:r3",
+                source_event_id="1:ev1",
+                target_event_id="1:ev1",
+                relation_type="motivates",
+                evidence=evidence,
+                certainty="weakly_inferred",
+            )
+        ]
+        tables = export.build_analysis_tables(story)
+        # 1 per-segment relation (from _story_with_one_of_everything) + 2
+        # story-level cross-segment relations, with no deduplication needed
+        # since the two sources are disjoint by construction.
+        self.assertEqual(len(tables["relations"]), 3)
+        story_rows = [r for r in tables["relations"] if r["segment_id"] == "story"]
+        self.assertEqual(len(story_rows), 2)
+        self.assertIn("story:r2", [r["relation_id"] for r in story_rows])
+        self.assertIn("story:r3", [r["relation_id"] for r in story_rows])
 
     def test_rows_to_jsonl_produces_one_line_per_row(self):
         rows = [{"a": 1}, {"a": 2}]
@@ -1233,6 +1591,51 @@ class TestSummarizeAndCompare(unittest.TestCase):
         ]
         summary = baseline.summarize_annotations(annotations)
         self.assertEqual(summary["hypotheses_per_1000_words"], 6.0)
+
+    def test_summarize_without_story_omits_cross_segment_relations(self):
+        """Backward compatibility: omitting `story` must produce identical
+        rates to before WI-EVENT-0029 - existing callers with only
+        per-segment annotations must not be affected."""
+        annotations = [
+            self._annotation(word_count=500, n_entities=0, n_events=0, n_relations=1)
+        ]
+        summary = baseline.summarize_annotations(annotations)
+        self.assertEqual(summary["relations_per_1000_words"], 2.0)
+
+    def test_summarize_folds_cross_segment_relations_into_relations_rate(self):
+        evidence = schema.EvidenceSpan(0, 1, "x")
+        annotations = [
+            self._annotation(word_count=500, n_entities=0, n_events=0, n_relations=1)
+        ]
+        story = schema.StoryWorldAnnotation(
+            story_id="s1",
+            cross_segment_relations=[
+                schema.EventRelation("story:r1", "1:ev0", "2:ev0", "causes", evidence)
+            ],
+        )
+        summary = baseline.summarize_annotations(annotations, story)
+        # 1 per-segment relation + 1 cross-segment relation, per 500 words.
+        self.assertEqual(summary["relations_per_1000_words"], 4.0)
+
+    def test_summarize_folds_weakly_inferred_cross_segment_relations_separately(self):
+        evidence = schema.EvidenceSpan(0, 1, "x")
+        annotations = [self._annotation(word_count=500, n_entities=0, n_events=0)]
+        story = schema.StoryWorldAnnotation(
+            story_id="s1",
+            weakly_inferred_cross_segment_relations=[
+                schema.EventRelation(
+                    "story:r1",
+                    "1:ev0",
+                    "2:ev0",
+                    "motivates",
+                    evidence,
+                    certainty="weakly_inferred",
+                )
+            ],
+        )
+        summary = baseline.summarize_annotations(annotations, story)
+        self.assertEqual(summary["relations_per_1000_words"], 0.0)
+        self.assertEqual(summary["weakly_inferred_relations_per_1000_words"], 2.0)
 
     def test_compare_returns_both_strategies(self):
         seg = [self._annotation(word_count=500, n_entities=1, n_events=1)]
@@ -1716,6 +2119,188 @@ class TestProcessSegments(unittest.TestCase):
         self.assertTrue(
             any("hypothesis extraction failed" in e for e in seg["extraction_errors"]),
             seg["extraction_errors"],
+        )
+
+    def _two_segment_setup(self):
+        """Two segments, each with exactly one event, so the story-level
+        cross-segment relation pass (WI-EVENT-0029) has something to work
+        with (its guard requires at least 2 events total)."""
+        segment_text_1 = "The old machine hummed."
+        segment_text_2 = "It shut off forever."
+        story_text = segment_text_1 + " " + segment_text_2
+        segments = [
+            {"segment_id": 1, "start_char": 0, "end_char": len(segment_text_1)},
+            {
+                "segment_id": 2,
+                "start_char": len(segment_text_1) + 1,
+                "end_char": len(segment_text_1) + 1 + len(segment_text_2),
+            },
+        ]
+        seg1_results = [
+            {"entities": []},
+            {
+                "events": [
+                    {
+                        "event_id": "ev1",
+                        "predicate": "hummed",
+                        "event_type": "sound_emission",
+                        "quote": "hummed",
+                    }
+                ]
+            },
+            {"relations": []},
+            {},
+            {},
+        ]
+        seg2_results = [
+            {"entities": []},
+            {
+                "events": [
+                    {
+                        "event_id": "ev1",
+                        "predicate": "shut off",
+                        "event_type": "mechanical_failure",
+                        "quote": "shut off",
+                    }
+                ]
+            },
+            {"relations": []},
+            {},
+            {},
+        ]
+        return story_text, segments, seg1_results + seg2_results
+
+    def test_story_relation_pass_discovers_cross_segment_relation(self):
+        story_text, segments, per_segment_results = self._two_segment_setup()
+        story_relation_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "2:ev1",
+                    "relation_type": "causes",
+                    "certainty": "explicit",
+                }
+            ]
+        }
+        fake = _SequencedFakeBackend(per_segment_results + [story_relation_result])
+
+        result = processor.process_segments(
+            story_text, segments, nlp_backend_name="spacy", llm_backend=fake
+        )
+
+        # 5 calls per segment x 2 segments + 1 story-level call.
+        self.assertEqual(len(fake.calls), 11)
+        usage_by_pass = {u["pass_name"]: u for u in result["usage"]}
+        self.assertIn("story_relation", usage_by_pass)
+        self.assertTrue(usage_by_pass["story_relation"]["is_llm_backed"])
+
+        story = result["story"]
+        self.assertEqual(len(story["cross_segment_relations"]), 1)
+        relation = story["cross_segment_relations"][0]
+        self.assertEqual(relation["relation_id"], "story:r1")
+        self.assertEqual(relation["source_event_id"], "1:ev1")
+        self.assertEqual(relation["target_event_id"], "2:ev1")
+        self.assertEqual(story["weakly_inferred_cross_segment_relations"], [])
+        self.assertEqual(story["validation_errors"], [])
+
+    def test_include_cross_segment_relations_false_skips_story_pass(self):
+        story_text, segments, per_segment_results = self._two_segment_setup()
+        fake = _SequencedFakeBackend(per_segment_results)
+
+        result = processor.process_segments(
+            story_text,
+            segments,
+            nlp_backend_name="spacy",
+            llm_backend=fake,
+            include_cross_segment_relations=False,
+        )
+
+        # Exactly 10 calls (5 per segment) - no story-level call was made.
+        self.assertEqual(len(fake.calls), 10)
+        usage_by_pass = {u["pass_name"]: u for u in result["usage"]}
+        self.assertNotIn("story_relation", usage_by_pass)
+        self.assertEqual(result["story"]["cross_segment_relations"], [])
+
+    def test_cross_segment_relation_pass_skipped_when_fewer_than_two_events(self):
+        """A cross-segment relation needs at least two events by
+        definition - the pass must not spend an LLM call on a story that
+        cannot possibly produce one."""
+        segment_text = "The machine hummed."
+        fake = _SequencedFakeBackend(
+            [
+                {"entities": []},
+                {
+                    "events": [
+                        {
+                            "event_id": "ev1",
+                            "predicate": "hummed",
+                            "event_type": "x",
+                            "quote": "hummed",
+                        }
+                    ]
+                },
+                {"relations": []},
+                {},
+                {},
+            ]
+        )
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        result = processor.process_segments(
+            segment_text, segments, nlp_backend_name="spacy", llm_backend=fake
+        )
+
+        # Exactly 5 calls - the story-level pass was never invoked despite
+        # include_cross_segment_relations defaulting to True.
+        self.assertEqual(len(fake.calls), 5)
+        usage_by_pass = {u["pass_name"]: u for u in result["usage"]}
+        self.assertNotIn("story_relation", usage_by_pass)
+
+    def test_story_relation_extraction_failure_is_recorded_not_silently_empty(self):
+        """A failed story-relation pass must not read as 'no cross-segment
+        relations found'."""
+        story_text, segments, per_segment_results = self._two_segment_setup()
+
+        class _FailsOnEleventhCallBackend:
+            def __init__(self):
+                self.calls = 0
+
+            def complete(self, **kwargs):
+                self.calls += 1
+                if self.calls == 11:
+                    return llm_backend.BackendResponse(
+                        text="",
+                        tool_result=None,
+                        model="fake-1.0",
+                        input_tokens=5,
+                        output_tokens=0,
+                        raw=None,
+                    )
+                result = per_segment_results[self.calls - 1]
+                return llm_backend.BackendResponse(
+                    text="",
+                    tool_result=result,
+                    model="fake-1.0",
+                    input_tokens=5,
+                    output_tokens=2,
+                    raw=None,
+                )
+
+        backend = _FailsOnEleventhCallBackend()
+
+        result = processor.process_segments(
+            story_text, segments, nlp_backend_name="spacy", llm_backend=backend
+        )
+
+        story = result["story"]
+        self.assertEqual(story["cross_segment_relations"], [])
+        self.assertTrue(
+            any(
+                "story relation extraction failed" in e
+                for e in story["extraction_errors"]
+            ),
+            story["extraction_errors"],
         )
 
 


### PR DESCRIPTION
## Summary
Implements WI-EVENT-0029: option A, a post-reconciliation story-level relation pass discovering causal/enabling/preventing/temporal/motivational/explanatory relations whose source and target events live in different segments — resolving the "Known limitation" WI-EVENT-0028 documented on `StoryWorldAnnotation` (per-segment stage-6 `relation_extractor.py` only ever sees its own segment's event IDs).

**Design note (resolves PR #155's review comments architecturally):** cross-segment relations are kept in new, structurally separate `StoryWorldAnnotation` fields — `cross_segment_relations` / `weakly_inferred_cross_segment_relations` — rather than merged into the existing `relations` field. This means the two sources can never collide on `relation_id` and require no runtime deduplication to combine into a density metric, which satisfies the review's underlying concern (accurate, non-double-counted density) by a simpler mechanism than the "qualify + dedup" approach the planning doc originally proposed. Relation IDs from the new pass are still qualified with a `"story:"` prefix for traceability in exported tables. The `weakly_inferred`/`explicit` certainty partition is preserved end-to-end (export + baseline).

**Corpus check:** story lengths in `lcats/data/` stay well within a single LLM call's context window (median 4,881 words, p90 7,923, p99 10,392, max 44,651, out of 1,867 stories — only 2 exceed 20k words). The hierarchical/windowed mitigation the design doc flagged as a caveat for very long stories is **not needed now**.

## Files changed
- `lcats/lcats/analysis/event_role_world/story_relation_extractor.py` (new) — tool schema, system/user prompts, `make_story_relation_extractor`, `build_event_index`, `build_story_relations`
- `lcats/lcats/analysis/event_role_world/schema.py` — new `StoryWorldAnnotation` fields (`cross_segment_relations`, `weakly_inferred_cross_segment_relations`, `extraction_errors`), extended `validate_story_annotation`
- `lcats/lcats/analysis/event_role_world/processor.py` — new `include_cross_segment_relations` opt-out param, new `"story_relation"` `PassUsage`, guarded to skip the LLM call entirely when fewer than 2 events exist across all segments
- `lcats/lcats/analysis/event_role_world/export.py` — `build_analysis_tables`/`validate_artifacts` include cross-segment relations
- `lcats/lcats/analysis/event_role_world/baseline.py` — `summarize_annotations`/`compare_chunking_strategies` gain an optional `story` parameter folding cross-segment relation counts into the existing rate metrics
- `lcats/tests/analysis_tests/event_role_world_test.py` — new `TestBuildEventIndex`, `TestBuildStoryRelations`, extended `TestReconcileStoryAnnotations`, `TestExport`, `TestSummarizeAndCompare`, `TestProcessSegments`

Prompt ID: `PROMPT(WI-EVENT-0029:WI_EVENT_0029)[2026-07-25T19:04:33-04:00]`

## Acceptance criteria
- [x] Story-level relation-extraction pass implementing option A, reusing already-resolved `EvidenceSpan`s, excluding same-segment links
- [x] New `PassUsage` entry (`"story_relation"`)
- [x] Story-level relations held in `StoryWorldAnnotation`, distinct from per-segment relations
- [x] Story-level relation IDs globally unique (qualified `"story:"` prefix) before any dedup — achieved architecturally via a disjoint field rather than runtime dedup
- [x] `export.build_analysis_tables` includes story-level relations
- [x] `baseline.summarize_annotations` includes them in `relations_per_1000_words`, with the `weakly_inferred` certainty partition preserved
- [x] Corpus story-length distribution checked; windowing caveat found unnecessary, documented above
- [x] `lrh validate` reports 0 errors, `scripts/test` passes

## Test plan
- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — clean
- [x] `scripts/test` — 1434 tests pass
- [x] `lrh validate` — 0 errors, 39 pre-existing unrelated warnings

Generated with Claude Code
