### PR TITLE
Add stratified cross-segment relation density pilot script (WI-EVENT-0030)

### DIFF
--- a/experiments/03_cross_segment_relation_pilot/README.md
+++ b/experiments/03_cross_segment_relation_pilot/README.md
@@ -108,13 +108,15 @@ python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
     --sample-size 2 --output /tmp/pilot_dry_run
 ```
 
-This exercises the full script (sample selection, segmentation call sites,
-pipeline invocation, output writing) with a `FakeBackend` and **no real API
-calls**, so you can confirm the script runs end to end in your environment
-before spending real cost on the full sample. Every dry-run story will show
-up `excluded` (a fake backend can't produce a real segmentation), which is
-expected — the point is verifying the control flow and output files, not
-producing real numbers.
+This exercises the full script — sample selection, a stubbed single-segment
+stage-1 segmentation, the actual Event-Role-World pipeline invocation, and
+output writing — with a `FakeBackend` and **no real API calls**, so you can
+confirm the script runs end to end in your environment before spending
+real cost on the full sample. Dry-run stories are not excluded (a fake
+backend's fixed response parses as valid-but-empty extraction output at
+every stage), so you'll see real output rows with zero counts everywhere —
+the point is verifying the control flow and output files, not producing
+real numbers.
 
 ## Cost note
 
@@ -163,7 +165,8 @@ WI-EVENT-0030's scope).
   `included_count`, `excluded_count`,
   `mean_cross_segment_density_per_1000_words`,
   `mean_weakly_inferred_cross_segment_density_per_1000_words`,
-  `mean_folded_relations_per_1000_words`.
+  `mean_folded_relations_per_1000_words`,
+  `mean_folded_weakly_inferred_relations_per_1000_words`.
 
 ## Expected Results Format
 

--- a/experiments/03_cross_segment_relation_pilot/README.md
+++ b/experiments/03_cross_segment_relation_pilot/README.md
@@ -1,0 +1,174 @@
+# Cross-Segment Relation Density Pilot
+
+**WI-EVENT-0030** — Run a stratified, cross-genre pilot measuring
+cross-segment relation density, superseding WI-EVENT-0028's 4-story
+convenience sample with a properly stratified measurement.
+
+## Status
+
+**Tooling only — not yet run.** This directory currently contains the pilot
+script and this usage doc. No results exist yet: the session that wrote this
+tooling had no `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` configured, and this
+pilot's headline findings require real LLM pipeline output, not a fake
+backend. Whoever runs this pilot for real should append a "Results"
+section below this one, following the format sketched in
+[Expected Results Format](#expected-results-format).
+
+## Purpose
+
+WI-EVENT-0028's investigation (`project/design/event-role-world-cross-segment-relations-evaluation.md`)
+established — via a small, convenience-selected 4-story reading exercise,
+not a pipeline run — that SF/horror material exhibits more long-range
+cross-segment causal chains than mystery/general-fiction comparison
+material, and recommended the story-level relation pass WI-EVENT-0029
+shipped. This pilot runs that pass over a larger, genre-stratified sample
+to size the effect precisely enough to support a paper-facing density
+figure.
+
+## Genre strata
+
+Genre strata are fixed to the four genres `lcats assess --genre` actually
+classifies: `science fiction`, `horror`, `western`, `romance` (see
+`lcats.analysis.corpus.assess.VALID_GENRES`). WI-EVENT-0028's own informal
+comparison genres (mystery, general fiction) are **not** used here — they
+are not classifiable by the corpus's existing genre-detection tooling
+(detect mode falls back to `"other"` for both). This is a deliberate
+divergence from WI-EVENT-0028's sample, noted so a reader does not assume
+the two work items compare identical genre sets.
+
+Genre is detected per-candidate story via `assess_story()` in detect mode
+(one real LLM call per candidate scanned) — the corpus carries no
+pre-existing genre metadata, so this pilot cannot skip that step.
+
+## Metric definitions
+
+Two distinct metrics are computed and reported side by side — conflating
+them was a review-caught error in this work item's original planning doc:
+
+- **Cross-segment-only density** (the headline metric): counted directly
+  from each story's `cross_segment_relations` /
+  `weakly_inferred_cross_segment_relations` fields (all `relation_type`
+  values counted, unfiltered), normalized per 1000 words. This is the only
+  metric that can actually confirm or contradict WI-EVENT-0028's
+  cross-segment-specific claim.
+- **Folded total density**: cross-segment relations added into the same
+  total as every segment's own same-segment relations — mirrors what
+  `baseline.summarize_annotations(annotations, story)` would report, but
+  computed directly from the pipeline's own output dicts here (not by
+  calling that function, to avoid needing to reconstruct
+  `SegmentWorldAnnotation`/`StoryWorldAnnotation` dataclasses from
+  `process_segments`' already-serialized dict output). Reported for
+  context only — two genres could differ solely in same-segment links, and
+  this metric alone cannot isolate a cross-segment-specific effect.
+
+The `weakly_inferred` certainty partition is preserved throughout: a
+`weakly_inferred` relation is never mixed into the primary (`explicit`/
+`strongly_implied`) density figure for either metric.
+
+## Excluded stories
+
+Any story whose run produced a segment- or story-level `extraction_errors`
+entry (a transient API/backend failure, per
+`processor.process_segments`'s error-handling contract) is **excluded**
+from the aggregated per-genre figures, not silently counted as zero or
+partial. Excluded stories are still written to `pilot_stories.jsonl` with
+`excluded: true` and an `exclude_reason`, and their count is included in
+`pilot_summary.json`'s per-genre `excluded_count`.
+
+## Usage
+
+From the repo root, with the conda environment active and an API key
+configured (see `docs/secrets-setup.md`):
+
+```bash
+python experiments/03_cross_segment_relation_pilot/run_pilot.py \
+    --sample-size 5 \
+    --output experiments/03_cross_segment_relation_pilot/results
+```
+
+Full flag reference is documented in `run_pilot.py`'s module docstring
+(`python experiments/03_cross_segment_relation_pilot/run_pilot.py --help`).
+Key flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--data-dir` | `lcats/data` | Corpus directory to sample from |
+| `--sample-size` | 5 | Target stories per genre (WI-EVENT-0030 asks for 5-10) |
+| `--max-candidates` | 200 | Cap on genre-detection scanning before giving up on an under-filled stratum |
+| `--seed` | 42 | Shuffle seed for candidate scan order (reproducibility) |
+| `--backend` | `anthropic` | `anthropic` or `openai` |
+| `--model` | provider default | Model string |
+| `--nlp-backend` | `spacy` | Stage-2 surface-feature NLP backend |
+| `--dry-run` | off | Zero-cost smoke test using a fake backend — produces meaningless (empty) results, never a real finding |
+
+### Try it with zero API cost first
+
+```bash
+python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
+    --sample-size 2 --output /tmp/pilot_dry_run
+```
+
+This exercises the full script (sample selection, segmentation call sites,
+pipeline invocation, output writing) with a `FakeBackend` and **no real API
+calls**, so you can confirm the script runs end to end in your environment
+before spending real cost on the full sample. Every dry-run story will show
+up `excluded` (a fake backend can't produce a real segmentation), which is
+expected — the point is verifying the control flow and output files, not
+producing real numbers.
+
+## Cost note
+
+This script makes real LLM API calls for genre detection (one call per
+candidate story scanned — could be well more than the final sample size,
+depending on how the corpus's genre distribution lines up with the four
+target strata), scene/sequel segmentation (one or two calls per sampled
+story), and the full Event-Role-World pipeline (roughly 5-6 calls per
+segment, plus one story-level cross-segment-relation call per story).
+Across 4 genres x 5-10 stories each (WI-EVENT-0030's target), this is a
+real cost and latency expenditure — size toward the lower end of the
+5-10 range first if cost is a concern, and note the actual sample size
+used in the Results section rather than silently shrinking it without
+comment.
+
+## Output files
+
+- `results/pilot_stories.jsonl` — one row per sampled story: `path`,
+  `story_id`, `genre`, `word_count`, `segment_count`,
+  `cross_segment_relation_count`,
+  `weakly_inferred_cross_segment_relation_count`,
+  `cross_segment_density_per_1000_words`,
+  `weakly_inferred_cross_segment_density_per_1000_words`,
+  `folded_relations_per_1000_words`,
+  `folded_weakly_inferred_relations_per_1000_words`, `excluded`,
+  `exclude_reason`, `elapsed_seconds`.
+- `results/pilot_summary.json` — run metadata (sample size target,
+  candidates scanned, backend/model, dry-run flag) plus a `by_genre` dict:
+  `included_count`, `excluded_count`,
+  `mean_cross_segment_density_per_1000_words`,
+  `mean_weakly_inferred_cross_segment_density_per_1000_words`,
+  `mean_folded_relations_per_1000_words`.
+
+## Expected Results Format
+
+Whoever runs this pilot for real should append a section here, e.g.:
+
+```markdown
+## Results (YYYY-MM-DD)
+
+Sample: N stories per genre (actual: science fiction=N, horror=N,
+western=N, romance=N — note any genre that fell short of the target and
+why), backend=<name>, model=<name>.
+
+| Genre | Included | Excluded | Cross-segment density (mean, /1000 words) | Folded total (mean, /1000 words) |
+|---|---|---|---|---|
+| science fiction | | | | |
+| horror | | | | |
+| western | | | | |
+| romance | | | | |
+
+**Finding:** [confirms / weakens / contradicts] WI-EVENT-0028's smaller-sample
+finding that science fiction/horror shows materially more long-range
+cross-segment causal chains than the other strata. [One or two sentences
+grounding the claim in the actual numbers above, not just the raw sample
+size.]
+```

--- a/experiments/03_cross_segment_relation_pilot/README.md
+++ b/experiments/03_cross_segment_relation_pilot/README.md
@@ -121,14 +121,25 @@ producing real numbers.
 This script makes real LLM API calls for genre detection (one call per
 candidate story scanned — could be well more than the final sample size,
 depending on how the corpus's genre distribution lines up with the four
-target strata), scene/sequel segmentation (one or two calls per sampled
-story), and the full Event-Role-World pipeline (roughly 5-6 calls per
-segment, plus one story-level cross-segment-relation call per story).
-Across 4 genres x 5-10 stories each (WI-EVENT-0030's target), this is a
-real cost and latency expenditure — size toward the lower end of the
-5-10 range first if cost is a concern, and note the actual sample size
-used in the Results section rather than silently shrinking it without
-comment.
+target strata), scene/sequel segmentation (one call per sampled story),
+and the full Event-Role-World pipeline (4 calls per segment — entities,
+events, relations, discourse; the optional stage-8 hypothesis pass is
+disabled since this pilot doesn't use hypothesis data — plus one
+story-level cross-segment-relation call per story). Across 4 genres x
+5-10 stories each (WI-EVENT-0030's target), this is a real cost and
+latency expenditure — size toward the lower end of the 5-10 range first
+if cost is a concern, and note the actual sample size used in the Results
+section rather than silently shrinking it without comment.
+
+`--model` (and the `--backend`-specific default) is propagated to every
+call the script makes, including the Event-Role-World pipeline's own
+extractors — those extractors normally hardcode `default_model="gpt-4o"`
+internally when built by `processor.process_segments()`, which would send
+an invalid model ID to a non-OpenAI backend; this script instead builds
+the same extractors itself (see `_build_erw_extractors`/`_run_erw_pipeline`
+in `run_pilot.py`) so their model can be overridden, without modifying
+`processor.py` or any `event_role_world` module (forbidden by
+WI-EVENT-0030's scope).
 
 ## Output files
 
@@ -141,6 +152,12 @@ comment.
   `folded_relations_per_1000_words`,
   `folded_weakly_inferred_relations_per_1000_words`, `excluded`,
   `exclude_reason`, `elapsed_seconds`.
+- `results/pilot_usage.jsonl` — one row per pipeline `PassUsage` record
+  (model, input/output tokens, elapsed time), tagged with `story_id` and
+  `genre`, preserved even for excluded stories so cost/latency on a failed
+  paid run is never lost. This is the raw data needed for the proposal's
+  Cost and baseline reporting requirement — `pilot_summary.json` does not
+  aggregate cost, only density.
 - `results/pilot_summary.json` — run metadata (sample size target,
   candidates scanned, backend/model, dry-run flag) plus a `by_genre` dict:
   `included_count`, `excluded_count`,

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -18,10 +18,12 @@ Optional flags:
     --nlp-backend NAME      "spacy" (default) or "stanza", for stage-2 surface features
     --output DIR            Results directory (default: ./results next to this script)
     --dry-run               Skip real genre detection and use a FakeBackend for the
-                            whole pipeline, so the script's control flow and output
-                            files can be exercised with zero API cost. Produces
-                            meaningless (empty) extraction results - never use its
-                            output as a real finding.
+                            whole pipeline (including a stubbed single-segment
+                            stage-1 segmentation, so the Event-Role-World pipeline
+                            itself is genuinely invoked), so the script's control
+                            flow and output files can be exercised with zero API
+                            cost. Produces meaningless (empty) extraction results -
+                            never use its output as a real finding.
 
 Genre strata are fixed to the four genres lcats assess --genre actually
 classifies (science fiction, horror, western, romance - see
@@ -280,21 +282,27 @@ def _run_erw_pipeline(
     story-level cross-segment relation pass gated on events existing in at
     least 2 distinct segments) but built from extractors this script
     constructs itself, so their default_model can be overridden - see
-    _build_erw_extractors(). Returns the same
-    {"segments": [...], "usage": [...], "story": {...}} shape
-    process_segments() returns, so downstream code needs no changes.
+    _build_erw_extractors(). Returns
+    {"segments": [...], "usage": [...], "story": {...},
+    "processed_segment_count": int} - the last key is the number of
+    segments actually processed (process_segments() silently skips any
+    segment missing start_char/end_char, so `len(segments)` alone can
+    overstate how many were really run and disagree with relation
+    counts/densities computed from them).
     """
     extractors = _build_erw_extractors(backend, model)
     nlp_backend = erw_surface.make_nlp_backend(nlp_backend_name)
 
     annotations: List[erw_schema.SegmentWorldAnnotation] = []
     all_usage: List[erw_processor.PassUsage] = []
+    processed_segment_count = 0
 
     for segment in segments:
         start_char = segment.get("start_char")
         end_char = segment.get("end_char")
         if start_char is None or end_char is None:
             continue
+        processed_segment_count += 1
         segment_text = body[start_char:end_char]
         annotation, usage_records = erw_processor.process_segment(
             segment.get("segment_id"),
@@ -347,6 +355,7 @@ def _run_erw_pipeline(
         "segments": [a.to_dict() for a in annotations],
         "usage": [u.to_dict() for u in all_usage],
         "story": story.to_dict(),
+        "processed_segment_count": processed_segment_count,
     }
 
 
@@ -356,6 +365,7 @@ def run_story(
     backend: Any,
     model: str,
     nlp_backend_name: str,
+    dry_run: bool = False,
 ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
     """Run the full pipeline for one story.
 
@@ -363,6 +373,14 @@ def run_story(
     pilot_stories.jsonl; usage_rows is one dict per PassUsage record (tagged
     with story_id/genre) for pilot_usage.jsonl, preserved even for excluded
     stories so cost/latency on a failed paid run is not lost.
+
+    In --dry-run mode, real stage-1 segmentation is skipped (a FakeBackend
+    cannot produce one - its single fixed response can't satisfy the
+    segmentation extractor's JSON-text parsing) and a single dummy segment
+    spanning the whole body is used instead, so _run_erw_pipeline() (and
+    thus the Event-Role-World pipeline itself) is genuinely exercised end
+    to end even in the zero-cost smoke test, rather than every dry-run
+    story returning early at segmentation.
     """
     row: Dict[str, Any] = {
         "path": str(path),
@@ -388,11 +406,16 @@ def run_story(
         row["exclude_reason"] = "empty story body"
         return row, []
 
-    segments, seg_error = _segment_story(body, backend, model)
-    if seg_error or not segments:
-        row["excluded"] = True
-        row["exclude_reason"] = f"segmentation failed: {seg_error}"
-        return row, []
+    if dry_run:
+        segments: List[Dict[str, Any]] = [
+            {"segment_id": 1, "start_char": 0, "end_char": len(body)}
+        ]
+    else:
+        segments, seg_error = _segment_story(body, backend, model)
+        if seg_error or not segments:
+            row["excluded"] = True
+            row["exclude_reason"] = f"segmentation failed: {seg_error}"
+            return row, []
 
     pipeline_result = _run_erw_pipeline(
         body, segments, backend, model, nlp_backend_name, path.stem
@@ -409,7 +432,7 @@ def run_story(
         return row, usage_rows
 
     row.update(_compute_story_metrics(pipeline_result, word_count))
-    row["segment_count"] = len(segments)
+    row["segment_count"] = pipeline_result["processed_segment_count"]
     return row, usage_rows
 
 
@@ -431,14 +454,18 @@ def summarize_by_genre(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
             mean_folded = sum(
                 r["folded_relations_per_1000_words"] for r in included
             ) / len(included)
+            mean_folded_weak = sum(
+                r["folded_weakly_inferred_relations_per_1000_words"] for r in included
+            ) / len(included)
         else:
-            mean_cross = mean_weak_cross = mean_folded = 0.0
+            mean_cross = mean_weak_cross = mean_folded = mean_folded_weak = 0.0
         summary[genre] = {
             "included_count": len(included),
             "excluded_count": len(excluded),
             "mean_cross_segment_density_per_1000_words": mean_cross,
             "mean_weakly_inferred_cross_segment_density_per_1000_words": mean_weak_cross,
             "mean_folded_relations_per_1000_words": mean_folded,
+            "mean_folded_weakly_inferred_relations_per_1000_words": mean_folded_weak,
         }
     return summary
 
@@ -519,7 +546,7 @@ def main() -> int:
             print(f"Running pipeline: [{genre}] {path.name}")
             t0 = time.monotonic()
             row, story_usage_rows = run_story(
-                path, genre, backend, model, args.nlp_backend
+                path, genre, backend, model, args.nlp_backend, dry_run=args.dry_run
             )
             row["elapsed_seconds"] = time.monotonic() - t0
             rows.append(row)
@@ -561,7 +588,8 @@ def main() -> int:
             f"excluded={stats['excluded_count']} "
             f"cross_segment={stats['mean_cross_segment_density_per_1000_words']:.3f} "
             f"weakly_inferred_cross_segment={stats['mean_weakly_inferred_cross_segment_density_per_1000_words']:.3f} "
-            f"folded_total={stats['mean_folded_relations_per_1000_words']:.3f}"
+            f"folded_total={stats['mean_folded_relations_per_1000_words']:.3f} "
+            f"folded_weakly_inferred={stats['mean_folded_weakly_inferred_relations_per_1000_words']:.3f}"
         )
     print(f"\nWrote {stories_path}")
     print(f"Wrote {usage_path}")

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -1,0 +1,429 @@
+"""Stratified cross-segment relation density pilot (WI-EVENT-0030).
+
+See README.md in this directory for full usage instructions. Quick start
+(from the repo root, conda environment active, API key configured):
+
+    python experiments/03_cross_segment_relation_pilot/run_pilot.py \
+        --sample-size 5 --output experiments/03_cross_segment_relation_pilot/results
+
+Optional flags:
+
+    --data-dir DIR          Corpus directory to sample from (default: lcats/data)
+    --sample-size N         Target stories per genre (default: 5)
+    --max-candidates N      Cap on how many candidate files to genre-scan before
+                            giving up on filling every stratum (default: 200)
+    --seed N                Shuffle seed for candidate order (default: 42)
+    --backend NAME          "anthropic" (default) or "openai"
+    --model NAME            Model string (default: claude-opus-4-8 / gpt-4o)
+    --nlp-backend NAME      "spacy" (default) or "stanza", for stage-2 surface features
+    --output DIR            Results directory (default: ./results next to this script)
+    --dry-run               Skip real genre detection and use a FakeBackend for the
+                            whole pipeline, so the script's control flow and output
+                            files can be exercised with zero API cost. Produces
+                            meaningless (empty) extraction results - never use its
+                            output as a real finding.
+
+Genre strata are fixed to the four genres lcats assess --genre actually
+classifies (science fiction, horror, western, romance - see
+lcats.analysis.corpus.assess.VALID_GENRES). Genre is detected per-candidate
+story via assess_story() in detect mode (an LLM call), not read from any
+pre-existing label, since the corpus carries no genre metadata today.
+
+Requires:
+    - lcats installed (run scripts/develop if not)
+    - ANTHROPIC_API_KEY or OPENAI_API_KEY set in environment, or present in
+      .secrets/anthropic_api_keys.env / .secrets/openai_api_keys.env
+      (see docs/secrets-setup.md) - not required for --dry-run.
+
+Cost note: this script makes real LLM API calls for genre detection (one
+call per candidate story scanned), scene/sequel segmentation (one or two
+calls per sampled story), and the full Event-Role-World pipeline (roughly
+5-6 calls per segment plus one story-level cross-segment-relation call per
+story). Across 4 genres x 5-10 stories each, this is a real cost and
+latency expenditure - see the Risk Notes in WI-EVENT-0030 and the README
+in this directory before running against the full target sample size.
+
+Exit codes:
+    0   pilot completed (individual story exclusions are noted, not fatal)
+    1   prerequisite check failed (missing install, missing key)
+    2   could not fill every genre stratum before exhausting --max-candidates
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import random
+import sys
+import time
+
+from typing import Any, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Path bootstrap - allow running as `python experiments/.../run_pilot.py` from
+# the repo root without requiring a prior `pip install -e .`.
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "lcats"))
+
+from lcats.analysis import scene_analysis
+from lcats.analysis import story_analysis
+from lcats.analysis.corpus import assess as corpus_assess
+from lcats.analysis.event_role_world import processor as erw_processor
+from lcats.utils.secrets import load_secrets
+
+GENRES = (
+    corpus_assess.VALID_GENRES
+)  # ("science fiction", "horror", "western", "romance")
+
+
+def _build_backend(backend_name: str, model: Optional[str]):
+    if backend_name == "anthropic":
+        from lcats.llm import anthropic_backend
+
+        return anthropic_backend.AnthropicBackend(), model or "claude-opus-4-8"
+    if backend_name == "openai":
+        from lcats.llm import openai_backend
+
+        return openai_backend.OpenAIBackend(), model or "gpt-4o"
+    raise ValueError(f"Unknown backend: {backend_name!r}")
+
+
+def _build_fake_backend():
+    from lcats.llm import fake_backend
+
+    return fake_backend.FakeBackend(tool_result={}), "fake-1.0"
+
+
+def _iter_candidate_files(data_dir: pathlib.Path, seed: int) -> List[pathlib.Path]:
+    files = sorted(data_dir.rglob("*.json"))
+    rng = random.Random(seed)
+    rng.shuffle(files)
+    return files
+
+
+def build_stratified_sample(
+    data_dir: pathlib.Path,
+    backend: Any,
+    model: str,
+    sample_size: int,
+    max_candidates: int,
+    seed: int,
+    dry_run: bool,
+) -> Tuple[Dict[str, List[pathlib.Path]], int]:
+    """Select up to `sample_size` stories per genre in GENRES.
+
+    Returns (genre -> list of file paths, candidates_scanned). Scans
+    candidates in shuffled order, classifying each with a real detect-mode
+    assess_story() call (skipped in --dry-run, where the first
+    len(GENRES) * sample_size candidates are round-robin assigned instead,
+    with zero API calls), stopping once every genre has sample_size stories
+    or max_candidates is exhausted.
+    """
+    sample: Dict[str, List[pathlib.Path]] = {g: [] for g in GENRES}
+    candidates = _iter_candidate_files(data_dir, seed)
+
+    if dry_run:
+        needed = sample_size * len(GENRES)
+        for i, path in enumerate(candidates[:needed]):
+            sample[GENRES[i % len(GENRES)]].append(path)
+        return sample, min(needed, len(candidates))
+
+    scanned = 0
+    for path in candidates:
+        if scanned >= max_candidates:
+            break
+        if all(len(sample[g]) >= sample_size for g in GENRES):
+            break
+        scanned += 1
+        try:
+            result = corpus_assess.assess_story(path, backend=backend, model=model)
+        except Exception as exc:  # noqa: BLE001 - skip this candidate on failure
+            print(f"  [genre-detect] {path}: failed ({exc}), skipping", file=sys.stderr)
+            continue
+        genre = result.detected_genre
+        if genre in sample and len(sample[genre]) < sample_size:
+            sample[genre].append(path)
+            print(
+                f"  [genre-detect] {path.name} -> {genre} ({len(sample[genre])}/{sample_size})"
+            )
+
+    return sample, scanned
+
+
+def _segment_story(
+    body: str, backend: Any, model: str
+) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Run scene/sequel segmentation; return (segments, error_or_None)."""
+    seg_extractor = scene_analysis.make_segment_extractor(backend)
+    seg_result = seg_extractor.extract(body, model_name=model)
+    error = seg_result.get("api_error") or seg_result.get("extraction_error")
+    segments = seg_result.get("extracted_output") or []
+    if not segments:
+        return [], error or "segmentation produced no segments"
+    return segments, error
+
+
+def _has_extraction_errors(pipeline_result: Dict[str, Any]) -> List[str]:
+    """Collect every segment- and story-level extraction_errors entry."""
+    errors: List[str] = []
+    for seg in pipeline_result["segments"]:
+        errors.extend(seg.get("extraction_errors") or [])
+    errors.extend(pipeline_result["story"].get("extraction_errors") or [])
+    return errors
+
+
+def _compute_story_metrics(
+    pipeline_result: Dict[str, Any], word_count: int
+) -> Dict[str, Any]:
+    """Compute cross-segment-only density directly from the story-level
+    cross_segment_relations/weakly_inferred_cross_segment_relations fields,
+    kept separate from the folded per-segment-plus-cross-segment total
+    reported alongside for context. Mirrors baseline.summarize_annotations'
+    certainty split without needing the SegmentWorldAnnotation/
+    StoryWorldAnnotation dataclasses themselves - process_segments already
+    returns plain dicts (via .to_dict()), and reconstructing dataclasses
+    from them would be pure overhead for this read-only aggregation.
+    """
+    story = pipeline_result["story"]
+    segments = pipeline_result["segments"]
+
+    cross_segment_count = len(story.get("cross_segment_relations") or [])
+    weakly_inferred_cross_segment_count = len(
+        story.get("weakly_inferred_cross_segment_relations") or []
+    )
+
+    folded_relations_count = cross_segment_count + sum(
+        len(seg.get("relations") or []) for seg in segments
+    )
+    folded_weakly_inferred_count = weakly_inferred_cross_segment_count + sum(
+        len(seg.get("weakly_inferred_relations") or []) for seg in segments
+    )
+
+    def per_1000(n: int) -> float:
+        return (n / word_count * 1000) if word_count else 0.0
+
+    return {
+        "word_count": word_count,
+        "cross_segment_relation_count": cross_segment_count,
+        "weakly_inferred_cross_segment_relation_count": weakly_inferred_cross_segment_count,
+        "cross_segment_density_per_1000_words": per_1000(cross_segment_count),
+        "weakly_inferred_cross_segment_density_per_1000_words": per_1000(
+            weakly_inferred_cross_segment_count
+        ),
+        "folded_relations_per_1000_words": per_1000(folded_relations_count),
+        "folded_weakly_inferred_relations_per_1000_words": per_1000(
+            folded_weakly_inferred_count
+        ),
+    }
+
+
+def run_story(
+    path: pathlib.Path,
+    genre: str,
+    backend: Any,
+    model: str,
+    nlp_backend_name: str,
+) -> Dict[str, Any]:
+    """Run the full pipeline for one story; return a result row dict."""
+    row: Dict[str, Any] = {
+        "path": str(path),
+        "story_id": path.stem,
+        "genre": genre,
+        "excluded": False,
+        "exclude_reason": "",
+    }
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        row["excluded"] = True
+        row["exclude_reason"] = f"could not read/parse story JSON: {exc}"
+        return row
+
+    body = story_analysis.coerce_text(data.get("body", ""))
+    word_count = story_analysis.word_count(body)
+    row["word_count"] = word_count
+
+    if not body.strip():
+        row["excluded"] = True
+        row["exclude_reason"] = "empty story body"
+        return row
+
+    segments, seg_error = _segment_story(body, backend, model)
+    if seg_error or not segments:
+        row["excluded"] = True
+        row["exclude_reason"] = f"segmentation failed: {seg_error}"
+        return row
+
+    pipeline_result = erw_processor.process_segments(
+        body,
+        segments,
+        nlp_backend_name=nlp_backend_name,
+        llm_backend=backend,
+        story_id=path.stem,
+        include_cross_segment_relations=True,
+    )
+
+    extraction_errors = _has_extraction_errors(pipeline_result)
+    if extraction_errors:
+        row["excluded"] = True
+        row["exclude_reason"] = "; ".join(extraction_errors)
+        return row
+
+    row.update(_compute_story_metrics(pipeline_result, word_count))
+    row["segment_count"] = len(segments)
+    return row
+
+
+def summarize_by_genre(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate mean cross-segment-only and folded densities per genre,
+    over included (non-excluded) rows only."""
+    summary: Dict[str, Any] = {}
+    for genre in GENRES:
+        included = [r for r in rows if r["genre"] == genre and not r["excluded"]]
+        excluded = [r for r in rows if r["genre"] == genre and r["excluded"]]
+        if included:
+            mean_cross = sum(
+                r["cross_segment_density_per_1000_words"] for r in included
+            ) / len(included)
+            mean_weak_cross = sum(
+                r["weakly_inferred_cross_segment_density_per_1000_words"]
+                for r in included
+            ) / len(included)
+            mean_folded = sum(
+                r["folded_relations_per_1000_words"] for r in included
+            ) / len(included)
+        else:
+            mean_cross = mean_weak_cross = mean_folded = 0.0
+        summary[genre] = {
+            "included_count": len(included),
+            "excluded_count": len(excluded),
+            "mean_cross_segment_density_per_1000_words": mean_cross,
+            "mean_weakly_inferred_cross_segment_density_per_1000_words": mean_weak_cross,
+            "mean_folded_relations_per_1000_words": mean_folded,
+        }
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--data-dir", default="lcats/data")
+    parser.add_argument("--sample-size", type=int, default=5)
+    parser.add_argument("--max-candidates", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--backend", choices=["anthropic", "openai"], default="anthropic"
+    )
+    parser.add_argument("--model", default=None)
+    parser.add_argument("--nlp-backend", choices=["spacy", "stanza"], default="spacy")
+    parser.add_argument(
+        "--output",
+        default=str(pathlib.Path(__file__).resolve().parent / "results"),
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    load_secrets()
+
+    data_dir = pathlib.Path(args.data_dir)
+    if not data_dir.exists():
+        print(f"error: data dir not found: {data_dir}", file=sys.stderr)
+        return 1
+
+    output_dir = pathlib.Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.dry_run:
+        backend, model = _build_fake_backend()
+    else:
+        try:
+            backend, model = _build_backend(args.backend, args.model)
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"error: could not construct {args.backend} backend: {exc}",
+                file=sys.stderr,
+            )
+            print(
+                "Set ANTHROPIC_API_KEY/OPENAI_API_KEY or populate .secrets/ (see docs/secrets-setup.md).",
+                file=sys.stderr,
+            )
+            return 1
+
+    print(f"Building stratified sample (target {args.sample_size} per genre)...")
+    sample, scanned = build_stratified_sample(
+        data_dir,
+        backend,
+        model,
+        args.sample_size,
+        args.max_candidates,
+        args.seed,
+        args.dry_run,
+    )
+    print(f"Scanned {scanned} candidates.")
+
+    incomplete_genres = [g for g in GENRES if len(sample[g]) < args.sample_size]
+    if incomplete_genres and not args.dry_run:
+        print(
+            f"warning: could not fill every stratum before exhausting "
+            f"--max-candidates ({args.max_candidates}): "
+            + ", ".join(
+                f"{g}={len(sample[g])}/{args.sample_size}" for g in incomplete_genres
+            ),
+            file=sys.stderr,
+        )
+
+    rows: List[Dict[str, Any]] = []
+    for genre in GENRES:
+        for path in sample[genre]:
+            print(f"Running pipeline: [{genre}] {path.name}")
+            t0 = time.monotonic()
+            row = run_story(path, genre, backend, model, args.nlp_backend)
+            row["elapsed_seconds"] = time.monotonic() - t0
+            rows.append(row)
+            if row["excluded"]:
+                print(f"  excluded: {row['exclude_reason']}")
+
+    stories_path = output_dir / "pilot_stories.jsonl"
+    with stories_path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, sort_keys=True) + "\n")
+
+    summary = summarize_by_genre(rows)
+    summary_path = output_dir / "pilot_summary.json"
+    with summary_path.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "sample_size_target": args.sample_size,
+                "candidates_scanned": scanned,
+                "backend": args.backend,
+                "model": model,
+                "dry_run": args.dry_run,
+                "by_genre": summary,
+            },
+            f,
+            indent=2,
+            sort_keys=True,
+        )
+
+    print("\nPer-genre summary (cross-segment-only density, per 1000 words):")
+    for genre, stats in summary.items():
+        print(
+            f"  {genre:16s} included={stats['included_count']} "
+            f"excluded={stats['excluded_count']} "
+            f"cross_segment={stats['mean_cross_segment_density_per_1000_words']:.3f} "
+            f"weakly_inferred_cross_segment={stats['mean_weakly_inferred_cross_segment_density_per_1000_words']:.3f} "
+            f"folded_total={stats['mean_folded_relations_per_1000_words']:.3f}"
+        )
+    print(f"\nWrote {stories_path}")
+    print(f"Wrote {summary_path}")
+
+    if incomplete_genres and not args.dry_run:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -36,12 +36,19 @@ Requires:
       (see docs/secrets-setup.md) - not required for --dry-run.
 
 Cost note: this script makes real LLM API calls for genre detection (one
-call per candidate story scanned), scene/sequel segmentation (one or two
-calls per sampled story), and the full Event-Role-World pipeline (roughly
-5-6 calls per segment plus one story-level cross-segment-relation call per
-story). Across 4 genres x 5-10 stories each, this is a real cost and
-latency expenditure - see the Risk Notes in WI-EVENT-0030 and the README
-in this directory before running against the full target sample size.
+call per candidate story scanned), scene/sequel segmentation (one call per
+sampled story), and the full Event-Role-World pipeline (4 calls per
+segment - entities, events, relations, discourse; the optional stage-8
+hypothesis pass is disabled since this pilot doesn't use hypothesis data -
+plus one story-level cross-segment-relation call per story). Across 4
+genres x 5-10 stories each, this is a real cost and latency expenditure -
+see the Risk Notes in WI-EVENT-0030 and the README in this directory
+before running against the full target sample size. --model and the
+--backend-specific default are propagated to every call, including the
+ERW pipeline's own extractors (see _build_erw_extractors/_run_erw_pipeline
+below) - processor.process_segments() itself hardcodes gpt-4o for these
+regardless of backend, which would send an invalid model ID to a
+non-OpenAI backend.
 
 Exit codes:
     0   pilot completed (individual story exclusions are noted, not fatal)
@@ -69,7 +76,16 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "lcats"))
 from lcats.analysis import scene_analysis
 from lcats.analysis import story_analysis
 from lcats.analysis.corpus import assess as corpus_assess
+from lcats.analysis.event_role_world import discourse_extractor as erw_discourse
+from lcats.analysis.event_role_world import entity_extractor as erw_entity
+from lcats.analysis.event_role_world import event_extractor as erw_event
 from lcats.analysis.event_role_world import processor as erw_processor
+from lcats.analysis.event_role_world import relation_extractor as erw_relation
+from lcats.analysis.event_role_world import schema as erw_schema
+from lcats.analysis.event_role_world import (
+    story_relation_extractor as erw_story_relation,
+)
+from lcats.analysis.event_role_world import surface_feature_extractor as erw_surface
 from lcats.utils.secrets import load_secrets
 
 GENRES = (
@@ -218,14 +234,136 @@ def _compute_story_metrics(
     }
 
 
+def _build_erw_extractors(backend: Any, model: str) -> Dict[str, Any]:
+    """Build the Event-Role-World extractors, with `model` overriding each
+    factory's own hardcoded default_model (e.g. "gpt-4o").
+
+    processor.process_segments() has no model parameter - it builds these
+    same extractors internally with each factory's hardcoded default,
+    which sends an invalid model ID whenever the caller's backend/model
+    choice differs (e.g. --backend anthropic with the default gpt-4o
+    baked into every ERW extractor). Building them here instead, then
+    driving processor.process_segment() (singular - it accepts pre-built
+    extractor instances) per segment ourselves, fixes this without
+    touching processor.py or any event_role_world module (forbidden by
+    this work item).
+    """
+    entity = erw_entity.make_entity_extractor(backend)
+    event = erw_event.make_event_extractor(backend)
+    relation = erw_relation.make_relation_extractor(backend)
+    discourse = erw_discourse.make_discourse_extractor(backend)
+    story_relation = erw_story_relation.make_story_relation_extractor(backend)
+    for extractor in (entity, event, relation, discourse, story_relation):
+        extractor.default_model = model
+    return {
+        "entity": entity,
+        "event": event,
+        "relation": relation,
+        "discourse": discourse,
+        "story_relation": story_relation,
+    }
+
+
+def _run_erw_pipeline(
+    body: str,
+    segments: List[Dict[str, Any]],
+    backend: Any,
+    model: str,
+    nlp_backend_name: str,
+    story_id: str,
+) -> Dict[str, Any]:
+    """Run stages 2-9 (+ the cross-segment pass) with `model` correctly
+    propagated to every ERW extractor.
+
+    Mirrors processor.process_segments()'s own orchestration (per-segment
+    process_segment() calls, schema.reconcile_story_annotations(), then the
+    story-level cross-segment relation pass gated on events existing in at
+    least 2 distinct segments) but built from extractors this script
+    constructs itself, so their default_model can be overridden - see
+    _build_erw_extractors(). Returns the same
+    {"segments": [...], "usage": [...], "story": {...}} shape
+    process_segments() returns, so downstream code needs no changes.
+    """
+    extractors = _build_erw_extractors(backend, model)
+    nlp_backend = erw_surface.make_nlp_backend(nlp_backend_name)
+
+    annotations: List[erw_schema.SegmentWorldAnnotation] = []
+    all_usage: List[erw_processor.PassUsage] = []
+
+    for segment in segments:
+        start_char = segment.get("start_char")
+        end_char = segment.get("end_char")
+        if start_char is None or end_char is None:
+            continue
+        segment_text = body[start_char:end_char]
+        annotation, usage_records = erw_processor.process_segment(
+            segment.get("segment_id"),
+            segment_text,
+            nlp_backend=nlp_backend,
+            nlp_backend_name=nlp_backend_name,
+            entity_llm_extractor=extractors["entity"],
+            event_llm_extractor=extractors["event"],
+            relation_llm_extractor=extractors["relation"],
+            discourse_llm_extractor=extractors["discourse"],
+            hypothesis_llm_extractor=None,
+            include_hypotheses=False,  # this pilot does not use hypothesis data
+        )
+        annotations.append(annotation)
+        all_usage.extend(usage_records)
+
+    story = erw_schema.reconcile_story_annotations(story_id, annotations)
+
+    segment_ids_with_events = {
+        segment.segment_id for segment in annotations if segment.events
+    }
+    if len(segment_ids_with_events) >= 2:
+        t0 = time.monotonic()
+        event_index_text = erw_story_relation.build_event_index(story)
+        story_relation_result = extractors["story_relation"].extract(event_index_text)
+        all_usage.append(
+            erw_processor._pass_usage_from_extraction(  # noqa: SLF001 - reuse pipeline's own usage-record logic
+                "story", "story_relation", story_relation_result, t0
+            )
+        )
+        story_relation_error = story_relation_result.get(
+            "api_error"
+        ) or story_relation_result.get("extraction_error")
+        if story_relation_error:
+            story.extraction_errors.append(
+                f"story relation extraction failed: {story_relation_error}"
+            )
+        cross_segment_relations, weakly_inferred_cross_segment_relations = (
+            erw_story_relation.build_story_relations(
+                story_relation_result.get("extracted_output") or {}, story
+            )
+        )
+        story.cross_segment_relations = cross_segment_relations
+        story.weakly_inferred_cross_segment_relations = (
+            weakly_inferred_cross_segment_relations
+        )
+        story.validation_errors = erw_schema.validate_story_annotation(story)
+
+    return {
+        "segments": [a.to_dict() for a in annotations],
+        "usage": [u.to_dict() for u in all_usage],
+        "story": story.to_dict(),
+    }
+
+
 def run_story(
     path: pathlib.Path,
     genre: str,
     backend: Any,
     model: str,
     nlp_backend_name: str,
-) -> Dict[str, Any]:
-    """Run the full pipeline for one story; return a result row dict."""
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """Run the full pipeline for one story.
+
+    Returns (row, usage_rows) - row is the per-story result dict for
+    pilot_stories.jsonl; usage_rows is one dict per PassUsage record (tagged
+    with story_id/genre) for pilot_usage.jsonl, preserved even for excluded
+    stories so cost/latency on a failed paid run is not lost.
+    """
     row: Dict[str, Any] = {
         "path": str(path),
         "story_id": path.stem,
@@ -239,7 +377,7 @@ def run_story(
     except Exception as exc:  # noqa: BLE001
         row["excluded"] = True
         row["exclude_reason"] = f"could not read/parse story JSON: {exc}"
-        return row
+        return row, []
 
     body = story_analysis.coerce_text(data.get("body", ""))
     word_count = story_analysis.word_count(body)
@@ -248,32 +386,31 @@ def run_story(
     if not body.strip():
         row["excluded"] = True
         row["exclude_reason"] = "empty story body"
-        return row
+        return row, []
 
     segments, seg_error = _segment_story(body, backend, model)
     if seg_error or not segments:
         row["excluded"] = True
         row["exclude_reason"] = f"segmentation failed: {seg_error}"
-        return row
+        return row, []
 
-    pipeline_result = erw_processor.process_segments(
-        body,
-        segments,
-        nlp_backend_name=nlp_backend_name,
-        llm_backend=backend,
-        story_id=path.stem,
-        include_cross_segment_relations=True,
+    pipeline_result = _run_erw_pipeline(
+        body, segments, backend, model, nlp_backend_name, path.stem
     )
+    usage_rows = [
+        {"story_id": path.stem, "genre": genre, **usage}
+        for usage in pipeline_result["usage"]
+    ]
 
     extraction_errors = _has_extraction_errors(pipeline_result)
     if extraction_errors:
         row["excluded"] = True
         row["exclude_reason"] = "; ".join(extraction_errors)
-        return row
+        return row, usage_rows
 
     row.update(_compute_story_metrics(pipeline_result, word_count))
     row["segment_count"] = len(segments)
-    return row
+    return row, usage_rows
 
 
 def summarize_by_genre(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -376,13 +513,17 @@ def main() -> int:
         )
 
     rows: List[Dict[str, Any]] = []
+    usage_rows: List[Dict[str, Any]] = []
     for genre in GENRES:
         for path in sample[genre]:
             print(f"Running pipeline: [{genre}] {path.name}")
             t0 = time.monotonic()
-            row = run_story(path, genre, backend, model, args.nlp_backend)
+            row, story_usage_rows = run_story(
+                path, genre, backend, model, args.nlp_backend
+            )
             row["elapsed_seconds"] = time.monotonic() - t0
             rows.append(row)
+            usage_rows.extend(story_usage_rows)
             if row["excluded"]:
                 print(f"  excluded: {row['exclude_reason']}")
 
@@ -390,6 +531,11 @@ def main() -> int:
     with stories_path.open("w", encoding="utf-8") as f:
         for row in rows:
             f.write(json.dumps(row, sort_keys=True) + "\n")
+
+    usage_path = output_dir / "pilot_usage.jsonl"
+    with usage_path.open("w", encoding="utf-8") as f:
+        for usage_row in usage_rows:
+            f.write(json.dumps(usage_row, sort_keys=True) + "\n")
 
     summary = summarize_by_genre(rows)
     summary_path = output_dir / "pilot_summary.json"
@@ -418,6 +564,7 @@ def main() -> int:
             f"folded_total={stats['mean_folded_relations_per_1000_words']:.3f}"
         )
     print(f"\nWrote {stories_path}")
+    print(f"Wrote {usage_path}")
     print(f"Wrote {summary_path}")
 
     if incomplete_genres and not args.dry_run:

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -41,3 +41,4 @@ existing experiments.
 |---|---|---|
 | 01 | `01_classify_corpora` | Classify stories across corpora by genre and quality |
 | 02 | `02_llm_backend_comparison` | Side-by-side Anthropic vs. OpenAI backend comparison on the assess pipeline |
+| 03 | `03_cross_segment_relation_pilot` | Stratified cross-genre pilot measuring Event-Role-World cross-segment relation density (WI-EVENT-0030) |

--- a/lcats/project/executions/AD_HOC/2026_07_26_01_06_05_WI_EVENT_0030_PILOT_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_01_06_05_WI_EVENT_0030_PILOT_REVIEW.md
@@ -1,0 +1,37 @@
+---
+execution_id: 2026_07_26_01_06_05_WI_EVENT_0030_PILOT_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_PILOT_REVIEW)[2026-07-26T01:05:44-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_00_56_37_WI_EVENT_0030
+pr: https://github.com/xenotaur/LCATS/pull/158
+commit: 1266b0a0
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/158
+session_transcript: pending
+created_at: 2026-07-26T01:06:05-04:00
+---
+
+# Summary
+
+Address PR #158 review feedback on the WI-EVENT-0030 pilot script implementation.
+
+# Result
+
+Two real bugs fixed (both chatgpt-codex-connector):
+
+- **P1: `--model`/`--backend` selection was never propagated into the Event-Role-World pipeline.** `processor.process_segments()` builds its 6 extractors internally, each hardcoding `default_model="gpt-4o"` with no override mechanism — so with `--backend anthropic` (the script's default), every ERW request would have sent an invalid OpenAI model ID to the Anthropic API, guaranteeing every story gets excluded and the pilot silently emits an all-zero summary. Fixed by reimplementing the pipeline orchestration in `run_pilot.py` itself (`_build_erw_extractors`/`_run_erw_pipeline`): builds the same 6 extractors the pipeline would, overrides each instance's `default_model` attribute, then drives `processor.process_segment()` (singular — accepts pre-built extractor instances) per segment plus the story-level cross-segment pass directly, mirroring `process_segments()`'s exact logic without modifying `processor.py` or any `event_role_world` module (forbidden by WI-EVENT-0030's scope). As a side benefit, disabled the unused stage-8 hypothesis pass (`include_hypotheses=False`) since this pilot never used hypothesis data, saving 1 LLM call per segment.
+- **P2: pipeline `PassUsage` cost/latency records were discarded.** Added a new `results/pilot_usage.jsonl` output file — one row per `PassUsage` record (model, tokens, elapsed time), tagged with `story_id`/`genre`, preserved even for excluded stories so cost/latency on a failed paid run is never lost.
+
+Verified both fixes with zero real API cost: a scripted fake-backend test asserted every one of 10 backend calls carried the overridden model string (previously would have silently used "gpt-4o"/"fake-1.0" defaults), confirmed 11 usage records collected (including the free surface_feature pass) and correctly written, and confirmed hypothesis calls no longer occur (10 calls instead of the prior 12).
+
+# Validation
+
+- `black --check`/`ruff check` on the modified script — clean.
+- `scripts/lint`, `scripts/test` (1436 tests), `lrh validate` (0 errors, 41 pre-existing warnings) — all clean.
+- Scripted fake-backend end-to-end test (see Result above) and `--dry-run` re-run — both zero real API cost, both pass.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/158` to verify fixes against the current diff and resolve review threads, then the merge gate, then `/lrh-closeout` (WI-EVENT-0030 should remain unresolved — the real pilot run and findings are still outstanding).

--- a/lcats/project/executions/AD_HOC/2026_07_26_01_15_41_WI_EVENT_0030_PILOT_REVIEW_2.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_01_15_41_WI_EVENT_0030_PILOT_REVIEW_2.md
@@ -1,0 +1,34 @@
+---
+execution_id: 2026_07_26_01_15_41_WI_EVENT_0030_PILOT_REVIEW_2
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_PILOT_REVIEW_2)[2026-07-26T01:15:12-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_01_06_05_WI_EVENT_0030_PILOT_REVIEW
+pr: https://github.com/xenotaur/LCATS/pull/158
+commit: 7fea7367
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/158
+session_transcript: pending
+created_at: 2026-07-26T01:15:41-04:00
+---
+
+# Summary
+
+Address a second round of PR #158 review feedback that landed after the first round's fix commit was pushed (5 new comments, all copilot-pull-request-reviewer, on top of the 2 already fixed).
+
+# Result
+
+- **`segment_count` disagreed with segments actually processed.** `processor.process_segment`-style orchestration silently skips any raw segment missing `start_char`/`end_char`, but the script recorded `len(segments)` (the raw count) — could overstate the true count and disagree with relation counts/densities computed from the processed segments. Fixed by tracking a `processed_segment_count` inside `_run_erw_pipeline` and using that for `row["segment_count"]`. Verified with a scripted test where 1 of 3 raw segments was invalid — `segment_count` now correctly reports 2, not 3.
+- **Console summary omitted the folded weakly-inferred mean.** `summarize_by_genre` computed `folded_weakly_inferred_relations_per_1000_words` per story but never aggregated it into the per-genre summary, and the printed table didn't show it either. Added `mean_folded_weakly_inferred_relations_per_1000_words` to both `summarize_by_genre`'s output and the console print, and documented the new key in the README.
+- **`--dry-run` didn't actually reach the pipeline.** The module docstring and README claimed `--dry-run` exercises "pipeline invocation," but every dry-run story was excluded at stage-1 segmentation (a `FakeBackend`'s fixed response can't produce valid segmentation JSON text), so `_run_erw_pipeline` was never called. Rather than just fix the wording (the reviewer offered either option), changed `--dry-run` to bypass real segmentation with a stubbed single-segment span and actually drive the pipeline — a genuinely more useful zero-cost smoke test. Verified: dry-run stories are no longer excluded, and produce real (zero-valued) metric rows plus non-empty `pilot_usage.jsonl` entries.
+
+# Validation
+
+- `black --check`/`ruff check` — clean.
+- `scripts/lint`, `scripts/test` (1436 tests), `lrh validate` (0 errors, 41 pre-existing warnings) — all clean.
+- `--dry-run` re-run (now reaches the pipeline, zero exclusions, populated usage file) and a scripted fake-backend test asserting `segment_count` excludes an invalid raw segment — both zero real API cost, both pass.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/158` to verify fixes against the current diff and resolve all 7 threads (the original 2 plus these 5), then the merge gate, then `/lrh-closeout` (WI-EVENT-0030 should remain unresolved — the real pilot run and findings are still outstanding).

--- a/lcats/project/executions/AD_HOC/2026_07_26_01_20_27_WI_EVENT_0030_PILOT_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_01_20_27_WI_EVENT_0030_PILOT_CONFIRM.md
@@ -1,0 +1,40 @@
+---
+execution_id: 2026_07_26_01_20_27_WI_EVENT_0030_PILOT_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_PILOT_CONFIRM)[2026-07-26T01:20:18-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_01_15_41_WI_EVENT_0030_PILOT_REVIEW_2
+pr: https://github.com/xenotaur/LCATS/pull/158
+commit: bea26502
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/158
+session_transcript: pending
+created_at: 2026-07-26T01:20:27-04:00
+---
+
+# Summary
+
+Confirm PR #158's review fixes (both rounds) against the current diff and resolve threads before merge.
+
+# Result
+
+Fetched threads via `lrh github threads <pr-url> --mode raw --state all`: 7 total across both review rounds (2 from round 1, 5 from round 2). 1 (copilot's folded-weakly-inferred-summary comment) had already auto-resolved before this check; the remaining 6 were unresolved. Confirmed the comment count was stable (7) across four checks spaced 30s apart before concluding review had fully landed and no third round was forming.
+
+Verified each fix against the pushed diff:
+- Model propagation (P1) and usage-record preservation (P2) — confirmed present from round 1, unchanged by round 2's edits.
+- `segment_count` now reflects processed (not raw) segment count — confirmed via `_run_erw_pipeline`'s `processed_segment_count`.
+- Console summary and `pilot_summary.json` both include the folded weakly-inferred mean.
+- `--dry-run` now genuinely reaches `_run_erw_pipeline` (stubbed single segment) rather than being excluded at segmentation; docstring/README updated to match.
+
+Resolved the remaining 6 threads via `gh api graphql resolveReviewThread`. Confirmed CI green (coverage/lint/test x2 all SUCCESS) at commit `bea26502`.
+
+# Validation
+
+- `lrh github threads https://github.com/xenotaur/LCATS/pull/158 --mode raw --state all` — 0 unresolved threads remain after resolution.
+- `gh pr checks https://github.com/xenotaur/LCATS/pull/158` — coverage/lint/test x2 all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Merge gate: summarize PR #158 for the user (2 review rounds) and wait for explicit approval before merging.
+- WI-EVENT-0030 should remain unresolved at closeout — the real pilot run and findings are still outstanding, this PR delivers tooling only.

--- a/lcats/project/executions/WI-EVENT-0030/2026_07_26_00_56_37_WI_EVENT_0030.md
+++ b/lcats/project/executions/WI-EVENT-0030/2026_07_26_00_56_37_WI_EVENT_0030.md
@@ -1,0 +1,37 @@
+---
+execution_id: 2026_07_26_00_56_37_WI_EVENT_0030
+prompt_id: PROMPT(WI-EVENT-0030:WI_EVENT_0030)[2026-07-26T00:44:33-04:00]
+work_item: WI-EVENT-0030
+status: in_progress
+rerun_of: 2026_07_26_00_26_09_WI_EVENT_0030
+pr: https://github.com/xenotaur/LCATS/pull/158
+commit: 1a3142aa
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-EVENT-0030.md
+session_transcript: pending
+created_at: 2026-07-26T00:56:37-04:00
+---
+
+# Summary
+
+Implement WI-EVENT-0030: build the stratified cross-segment relation density pilot tooling (script + usage README), per its acceptance criteria as fixed during PR #157's review.
+
+# Result
+
+- Created `experiments/03_cross_segment_relation_pilot/run_pilot.py`: samples 5-10 stories per genre across the four `lcats assess --genre`-supported genres (science fiction, horror, western, romance), detecting genre per-candidate via `assess_story()` in detect mode; runs each sampled story through scene/sequel segmentation + the full Event-Role-World pipeline; computes the headline cross-segment-only density metric directly from `cross_segment_relations`/`weakly_inferred_cross_segment_relations`, reported separately from the folded total; excludes and reports (not silently aggregates) stories with `extraction_errors`.
+- Created `experiments/03_cross_segment_relation_pilot/README.md` documenting usage, genre-strata rationale, metric definitions, cost notes, output file formats, and an "Expected Results Format" section for whoever runs the pilot for real.
+- Registered the new experiment in the top-level `experiments/README.md` table.
+- **Session constraint:** no `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` configured in this environment (no `.secrets/` directory, no env vars) — the pilot could not actually be run against real stories. This PR delivers tooling only; WI-EVENT-0030's acceptance criteria requiring reported findings are not yet met and the work item should not be resolved by this PR alone.
+- Verified correctness without real API calls: (1) the script's `--dry-run` mode (a `FakeBackend`) exercises the full control flow with zero cost; (2) a separate scripted fake-backend test drove the full happy path end-to-end (1 segmentation call + 5 calls/segment × 2 segments + 1 story-relation call = 12 calls), confirming correct cross-segment relation counting and density computation.
+
+# Validation
+
+- `scripts/format --check --diff`, `scripts/lint`, `scripts/test` (1436 tests), `lrh validate` (0 errors, 41 pre-existing warnings) — all clean.
+- `black`/`ruff` run directly against the new script (not covered by `scripts/format`'s default `lcats tests tools` target — matches existing `experiments/` convention, verified `01`/`02` experiment scripts are already black-clean too).
+- `--dry-run` smoke test and a scripted fake-backend end-to-end test (see Result above) — both zero real API cost.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- **Real pilot run still needed**: whoever has API credentials should run `python experiments/03_cross_segment_relation_pilot/run_pilot.py --sample-size 5` (or up to 10 per WI-EVENT-0030's range) and append a "Results" section to the README per its "Expected Results Format" template. This is the remaining acceptance criterion this PR does not satisfy.
+- Wait for reviewer comments and run `/lrh-review-response https://github.com/xenotaur/LCATS/pull/158` to address them, then `/lrh-confirm-fixes` before merge. After merging, run `/lrh-closeout` — but do **not** mark WI-EVENT-0030 `resolved` at that closeout, since the findings acceptance criterion remains open pending a real run.


### PR DESCRIPTION
## Summary
Implements the pilot infrastructure for WI-EVENT-0030: `experiments/03_cross_segment_relation_pilot/run_pilot.py` and a usage README, per the acceptance criteria fixed during PR #157's review.

**Important — this PR delivers tooling only, not results.** This session has no `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` configured, so the pilot has not been run against real stories. The script and README are ready for someone with credentials to run; the README's "Expected Results Format" section documents exactly what to append once it's run for real.

**What the script does:**
- Samples 5-10 stories per genre across the four genres `lcats assess --genre` actually classifies (`science fiction`, `horror`, `western`, `romance`), detecting genre per-candidate via `assess_story()` in detect mode (mystery/adventure are not classifiable and are correctly excluded, per PR #157's P1 review comment).
- Runs each sampled story through scene/sequel segmentation + the full Event-Role-World pipeline (`processor.process_segments`, `include_cross_segment_relations=True`).
- Computes the headline **cross-segment-only density** metric directly from `cross_segment_relations`/`weakly_inferred_cross_segment_relations` — kept separate from the folded total (which mixes cross-segment and same-segment counts), per PR #157's P1 metric-conflation fix.
- Excludes and reports (not silently aggregates) any story whose run produced `extraction_errors`, per PR #157's P2 fix.

**Verification performed (no real API calls):**
- `--dry-run` mode (a `FakeBackend`, zero API cost) exercises the full script control flow and output-file writing.
- A scripted fake-backend test verified the full happy path end-to-end: 12 calls (1 segmentation + 5 per segment × 2 segments + 1 story-relation call), correct cross-segment relation count and density computation.

No changes to `lcats/lcats/analysis/event_role_world/` — this PR only consumes the existing pipeline (per WI-EVENT-0030's `forbidden_actions`).

Prompt ID: `PROMPT(WI-EVENT-0030:WI_EVENT_0030)[2026-07-26T00:44:33-04:00]`

## Files changed
- `experiments/03_cross_segment_relation_pilot/run_pilot.py` (new)
- `experiments/03_cross_segment_relation_pilot/README.md` (new)
- `experiments/03_cross_segment_relation_pilot/results/.gitkeep` (new)
- `experiments/README.md` (registered the new experiment)

## Acceptance criteria
- [x] Stratified sample across the four `lcats assess --genre` genres, with the story-level relation pass enabled
- [x] Cross-segment-only density computed directly from `cross_segment_relations`/`weakly_inferred_cross_segment_relations`, reported separately from the folded total
- [x] Relation types counted toward the headline figure stated explicitly (all types, unfiltered)
- [~] Findings comparing against WI-EVENT-0028 — **deferred**, no real run yet; README documents the expected format
- [x] Stories with extraction errors excluded and reported separately
- [x] Results/methodology recorded under `experiments/03_cross_segment_relation_pilot/`
- [x] `lrh validate` reports 0 errors

## Test plan
- [x] `scripts/format --check --diff`, `scripts/lint`, `scripts/test` (1436 tests), `lrh validate` (0 errors) — all clean
- [x] `black`/`ruff` run directly against the new script (not covered by `scripts/format`'s default `lcats tests tools` target, matching existing `experiments/` convention)
- [x] `--dry-run` smoke test (zero API cost)
- [x] Scripted fake-backend end-to-end happy-path test (zero API cost)

Generated with Claude Code
