### PR TITLE
Add workstream WS-PACKAGING: LCATS Python Packaging Modernization

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_26_12_55_15_PR160_REVIEW_FIXES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_12_55_15_PR160_REVIEW_FIXES.md
@@ -1,0 +1,61 @@
+---
+execution_id: 2026_07_26_12_55_15_PR160_REVIEW_FIXES
+prompt_id: PROMPT(AD_HOC:PR160_REVIEW_FIXES)[2026-07-26T12:55:08-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/160
+commit: 
+created_at: 2026-07-26T12:55:15-04:00
+---
+
+# Summary
+
+Apply direct fixes to `WS-PACKAGING.md` in response to PR #160's landed
+automated review (Copilot + Codex), following the land-to-closeout skill's
+"apply fixes directly" path rather than routing through
+`/lrh-review-response` for the fix itself.
+
+# Result
+
+Four findings from the landed review were verified and corrected in
+`project/workstreams/proposed/WS-PACKAGING.md`:
+
+1. Copilot — `related_design` pointed at
+   `project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md`,
+   which did not exist in this branch's tree at review time (PR #159 was
+   still open). PR #159 has since merged to `main`
+   (`398b59ceed839999cffe93ae8bc83503156ea517`); rebased this branch onto
+   `origin/main` so the referenced path genuinely resolves within this PR's
+   own tree, rather than just editing the prose.
+2. Copilot — missing the `# Workstream: <Title>` H1 heading that every
+   other workstream doc in `project/workstreams/` has after the
+   frontmatter (confirmed by reading `WS-DOCS.md` and
+   `WS-EVENT-ROLE-WORLD.md`); added it.
+3. Codex (P2) — `setuptools>=68` is insufficient for the PEP 639
+   `license`/`license-files` metadata this workstream's Phase 1 exit
+   criterion requires (support landed in setuptools 77.0.0, per the same
+   changelog check done for PR #159's review). Raised to `setuptools>=77`
+   in both the frontmatter `exit_criteria:` list and the body `## Exit
+   Criteria` / `## Work Items` sections.
+4. Codex (P2) — same root cause as finding 1: the governing proposal
+   reference could go dangling if this workstream landed independently.
+   Resolved by the same rebase, plus updating the `## Relationship to
+   Design` section's stale "(PR #159, not yet merged)" note to reflect the
+   actual merged state.
+
+# Validation
+
+- `lrh validate` from `lcats/`: 0 errors, 41 warnings (pre-existing,
+  unrelated to this file).
+- Verified the referenced proposal path exists post-rebase:
+  `ls lcats/project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md`.
+- Verified the H1-heading convention by reading two existing workstream
+  files directly.
+- Reused the setuptools 77.0.0 PEP 639 verification from PR #159's review
+  (same changelog fact, same underlying gap).
+
+# Follow-up
+
+None — proceeding to `/lrh-confirm-fixes` to resolve the review threads
+against the rebased + fixed diff.

--- a/lcats/project/executions/AD_HOC/2026_07_26_13_05_10_WS_PACKAGING_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_13_05_10_WS_PACKAGING_CONFIRM.md
@@ -1,0 +1,66 @@
+---
+execution_id: 2026_07_26_13_05_10_WS_PACKAGING_CONFIRM
+prompt_id: PROMPT(AD_HOC:WS_PACKAGING_CONFIRM)[2026-07-26T12:57:33-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_12_55_15_PR160_REVIEW_FIXES
+pr: https://github.com/xenotaur/LCATS/pull/160
+commit: 
+created_at: 2026-07-26T13:05:10-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/160
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge confirm-fixes pass for PR #160. Independently verified the fixes
+applied in `2026_07_26_12_55_15_PR160_REVIEW_FIXES` against the live PR
+diff and thread state (never against that record's own claims), and
+resolved the review threads the diff/tree state plainly satisfies.
+
+# Result
+
+Gathered live state via `lrh github threads --mode raw --state all` (4
+threads total). Classified against `gh pr diff 160` (`HEAD` = `c46c8815`):
+
+1. copilot-pull-request-reviewer — `related_design` referenced a
+   nonexistent path → **Clear-satisfied**, but structurally rather than
+   textually: the branch was rebased onto `origin/main` (which now
+   contains `PROP-LCATS-PACKAGING-MODERNIZATION` via merged PR #159), so
+   `gh pr diff 160` no longer touches that file at all — it's already
+   present in the merge-base. Resolved.
+2. copilot-pull-request-reviewer — missing H1 heading → found already
+   `isResolved: true` in live thread state before this pass touched
+   anything, evidently auto-resolved by the bot itself on detecting the
+   fix. Skipped as already-resolved (idempotent — no `resolveReviewThread`
+   call needed).
+3. chatgpt-codex-connector (P2) — `setuptools>=68` insufficient for PEP
+   639 → **Clear-satisfied**, diff raises floor to `>=77`. Resolved.
+4. chatgpt-codex-connector (P2) — "land the governing proposal before
+   referencing it" → **Clear-satisfied** by the same rebase as finding 1.
+   Resolved.
+
+No Unaddressed / Partial / Ambiguous / Problematic threads.
+
+Thread-resolution verdict: **green**.
+
+# Validation
+
+- `lrh github threads --mode raw --state all`: 4 threads found, all
+  correlated to review comments 1:1 by latest-comment URL.
+- `gh pr diff 160`: confirmed only 2 files in the diff
+  (`WS-PACKAGING.md`, this execution record) — the proposal file is not
+  part of the diff, confirming it's already in the merge-base post-rebase.
+- `gh api graphql resolveReviewThread`: all 3 targeted threads confirmed
+  `isResolved: true` after mutation; the 4th confirmed already resolved.
+- `lrh validate`: 0 errors, 41 pre-existing warnings unrelated to this
+  change.
+- CI: provisional read at Step 2 showed `lint` passed, `coverage`/`test`
+  in progress on `c46c8815` — re-checked against the post-push `HEAD` in
+  Step 8 before the final verdict (see report).
+
+# Follow-up
+
+None — final readiness verdict reported to the user for the human merge
+gate.

--- a/lcats/project/workstreams/proposed/WS-PACKAGING.md
+++ b/lcats/project/workstreams/proposed/WS-PACKAGING.md
@@ -12,11 +12,13 @@ related_design:
   - project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md
 work_items: []
 exit_criteria:
-  - lcats/pyproject.toml declares license via PEP 639 (license = "MIT" + license-files), pins setuptools>=68, sets required-version for tool.ruff and tool.black, has no duplicate test/dev extras, and pins gutenbergpy to a commit SHA
+  - lcats/pyproject.toml declares license via PEP 639 (license = "MIT" + license-files), pins setuptools>=77 (the version that added PEP 639 support), sets required-version for tool.ruff and tool.black, has no duplicate test/dev extras, and pins gutenbergpy to a commit SHA
   - lcats package code lives at lcats/src/lcats/ with scripts/lint, scripts/format, secrets.py, and all lcats/lcats path literals updated accordingly, and the full test suite passes against the new layout
   - lcats/pyproject.toml uses dynamic = ["version"] via setuptools-scm with a cut git tag, and lcats/setup.py is removed
   - all three work items are resolved and PROP-LCATS-PACKAGING-MODERNIZATION's implementation_status is updated to implemented
 ---
+
+# Workstream: LCATS Python Packaging Modernization
 
 ## Purpose
 
@@ -60,9 +62,9 @@ item couldn't express.
 Not yet created; `work_items:` will be populated as each is drafted via
 `/lrh-work-item`.
 
-- *(planned)* Metadata/config fixes — PEP 639 license, build-system pin,
-  tool `required-version` pins, dedupe extras, pin `gutenbergpy` to a commit
-  SHA, `project.urls`/classifiers.
+- *(planned)* Metadata/config fixes — PEP 639 license, `setuptools>=77`
+  build-system pin, tool `required-version` pins, dedupe extras, pin
+  `gutenbergpy` to a commit SHA, `project.urls`/classifiers.
 - *(planned)* src-layout move — `lcats/lcats/` → `lcats/src/lcats/`, update
   `scripts/lint`/`scripts/format`, `secrets.py`, path-literal audit,
   reinstall, full test run.
@@ -72,9 +74,11 @@ Not yet created; `work_items:` will be populated as each is drafted via
 ## Exit Criteria
 
 - `lcats/pyproject.toml` declares license via PEP 639
-  (`license = "MIT"` + `license-files`), pins `setuptools>=68`, sets
-  `required-version` for `tool.ruff` and `tool.black`, has no duplicate
-  `test`/`dev` extras, and pins `gutenbergpy` to a commit SHA.
+  (`license = "MIT"` + `license-files`), pins `setuptools>=77` (the version
+  that added PEP 639 `license`/`license-files` support — `>=68` is
+  insufficient), sets `required-version` for `tool.ruff` and `tool.black`,
+  has no duplicate `test`/`dev` extras, and pins `gutenbergpy` to a commit
+  SHA.
 - `lcats` package code lives at `lcats/src/lcats/` with `scripts/lint`,
   `scripts/format`, `secrets.py`, and all `lcats/lcats` path literals updated
   accordingly, and the full test suite passes against the new layout.
@@ -96,4 +100,6 @@ Not yet created; `work_items:` will be populated as each is drafted via
 
 - Design proposal:
   `project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md`
-  (PR #159, not yet merged)
+  (merged via PR #159, commit `398b59ceed839999cffe93ae8bc83503156ea517`;
+  proposal `status` remains `proposed` on disk until this workstream closes
+  and adopts it, per LRH convention)

--- a/lcats/project/workstreams/proposed/WS-PACKAGING.md
+++ b/lcats/project/workstreams/proposed/WS-PACKAGING.md
@@ -1,0 +1,99 @@
+---
+id: WS-PACKAGING
+kind: planning_node
+title: LCATS Python Packaging Modernization
+status: proposed
+stage: designed
+origin: design_review
+summary: Coordinate the three phased work items that bring lcats/pyproject.toml up to PyPA/PEP 621/PEP 639 best practice and parity with the sibling lrh project, per PROP-LCATS-PACKAGING-MODERNIZATION.
+related_focus: []
+related_roadmap: []
+related_design:
+  - project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md
+work_items: []
+exit_criteria:
+  - lcats/pyproject.toml declares license via PEP 639 (license = "MIT" + license-files), pins setuptools>=68, sets required-version for tool.ruff and tool.black, has no duplicate test/dev extras, and pins gutenbergpy to a commit SHA
+  - lcats package code lives at lcats/src/lcats/ with scripts/lint, scripts/format, secrets.py, and all lcats/lcats path literals updated accordingly, and the full test suite passes against the new layout
+  - lcats/pyproject.toml uses dynamic = ["version"] via setuptools-scm with a cut git tag, and lcats/setup.py is removed
+  - all three work items are resolved and PROP-LCATS-PACKAGING-MODERNIZATION's implementation_status is updated to implemented
+---
+
+## Purpose
+
+This workstream coordinates the three sequential work items that implement
+`PROP-LCATS-PACKAGING-MODERNIZATION`: bringing `lcats/pyproject.toml` and its
+package layout up to current PyPA/PEP 621/PEP 639 best practice, matching the
+sibling `lrh` project's own packaging setup. It exists to track cross-item
+ordering constraints (metadata fixes must land before the layout move; the
+layout move must land before `setup.py` removal) that a single unscoped work
+item couldn't express.
+
+## Scope
+
+- Implement the three phases defined in the proposal's Implementation Plan:
+  metadata/config fixes, src-layout move, dynamic versioning + `setup.py`
+  removal.
+- Land each phase as its own work item through the standard LRH execution
+  lifecycle, in strict order.
+- Update `PROP-LCATS-PACKAGING-MODERNIZATION`'s `implementation_status` and
+  `implemented_by` once all three are resolved.
+
+## Prior Art Check
+
+### Duplication search
+- In-repo: No existing implementation found.
+- Sibling repos: `logical_robotics_harness` already implements the target
+  pattern (src-layout, `setuptools-scm`, PEP 639 license) — reference, not
+  duplicate.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found (`PROP-LCATS-PACKAGING-MODERNIZATION` itself is the
+  originating proposal, not a duplicate request).
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Work Items
+
+Not yet created; `work_items:` will be populated as each is drafted via
+`/lrh-work-item`.
+
+- *(planned)* Metadata/config fixes — PEP 639 license, build-system pin,
+  tool `required-version` pins, dedupe extras, pin `gutenbergpy` to a commit
+  SHA, `project.urls`/classifiers.
+- *(planned)* src-layout move — `lcats/lcats/` → `lcats/src/lcats/`, update
+  `scripts/lint`/`scripts/format`, `secrets.py`, path-literal audit,
+  reinstall, full test run.
+- *(planned)* Dynamic versioning + `setup.py` removal — `setuptools-scm`,
+  first git tag, delete `setup.py`.
+
+## Exit Criteria
+
+- `lcats/pyproject.toml` declares license via PEP 639
+  (`license = "MIT"` + `license-files`), pins `setuptools>=68`, sets
+  `required-version` for `tool.ruff` and `tool.black`, has no duplicate
+  `test`/`dev` extras, and pins `gutenbergpy` to a commit SHA.
+- `lcats` package code lives at `lcats/src/lcats/` with `scripts/lint`,
+  `scripts/format`, `secrets.py`, and all `lcats/lcats` path literals updated
+  accordingly, and the full test suite passes against the new layout.
+- `lcats/pyproject.toml` uses `dynamic = ["version"]` via `setuptools-scm`
+  with a cut git tag, and `lcats/setup.py` is removed.
+- All three work items are resolved and
+  `PROP-LCATS-PACKAGING-MODERNIZATION`'s `implementation_status` is updated
+  to `implemented`.
+
+## Non-Goals
+
+- Does not change LCATS's runtime dependencies or Python version floor.
+- Does not migrate build backends away from setuptools.
+- Does not fix `secrets.py`'s parent-depth-counting pattern beyond the
+  one-line bump required by the layout move.
+- Does not modify CI workflow YAML.
+
+## Relationship to Design
+
+- Design proposal:
+  `project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md`
+  (PR #159, not yet merged)


### PR DESCRIPTION
## Summary
Coordinates the three phased work items that implement `PROP-LCATS-PACKAGING-MODERNIZATION` (#159): bringing `lcats/pyproject.toml` and its package layout up to PyPA/PEP 621/PEP 639 best practice and parity with the sibling `lrh` project.

- `id`: WS-PACKAGING
- `status`: proposed
- `stage`: designed

## Work items
None created yet — `work_items:` will be populated as each of the three phases (metadata/config fixes, src-layout move, dynamic versioning + `setup.py` removal) is drafted via `/lrh-work-item`, in strict order per the cross-item ordering constraints described in the workstream body.

This is a planning artifact only — no implementation in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
