### PR TITLE
Add work item WI-PACKAGING-0031: Bring lcats/pyproject.toml metadata up to PEP 621/639 and CI-parity

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_26_16_22_17_PR163_REVIEW_FIXES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_16_22_17_PR163_REVIEW_FIXES.md
@@ -1,0 +1,66 @@
+---
+execution_id: 2026_07_26_16_22_17_PR163_REVIEW_FIXES
+prompt_id: PROMPT(AD_HOC:PR163_REVIEW_FIXES)[2026-07-26T16:22:09-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/163
+commit: 
+created_at: 2026-07-26T16:22:17-04:00
+---
+
+# Summary
+
+Apply direct fixes to `WI-PACKAGING-0031.md` (and its cross-referenced
+files) in response to PR #163's landed automated review (Copilot + Codex),
+following the land-to-closeout skill's "apply fixes directly" path rather
+than routing through `/lrh-review-response` for the fix itself.
+
+# Result
+
+5 findings from the landed review were triaged; 4 were legitimate and
+fixed, 1 was verified and rejected as factually wrong (not applied):
+
+1. Codex — `## Validation` listed `scripts/version tools`, which does not
+   exist (`lcats/scripts/` has no `version` script; confirmed by `ls` and
+   by `lcats/AGENTS.md`'s own command list). Removed that bullet from
+   `WI-PACKAGING-0031.md`'s Validation section.
+2. Codex — `WS-PACKAGING.md` still had `work_items: []` and "not yet
+   created" prose despite this item declaring `related_workstreams:
+   WS-PACKAGING`. Added `WI-PACKAGING-0031` to `work_items:` and replaced
+   the first `*(planned)*` Work Items bullet with a resolved entry.
+3. Codex — the new item wasn't listed in
+   `project/work_items/README.md`'s `## Proposed Items` index. Added it.
+4. Copilot — `expected_actions` omitted `create_pr`, inconsistent with
+   other `run_tests`-including work items (confirmed by reading
+   `WI-EVENT-0029.md` and `WI-META-0023.md`, both of which pair
+   `run_tests` with `create_pr`). Added `create_pr`.
+5. Copilot — claimed `[tool.ruff] required-version = "==0.15.0"` mixes
+   invalid dependency-specifier syntax and is inconsistent with black's
+   plain-string form. **Rejected as factually wrong** — Ruff's own docs
+   state `required-version` "accepts a PEP 440 specifier, like `==0.3.1`
+   or `>=0.3.1`" (verified via WebSearch against
+   https://docs.astral.sh/ruff/settings/), while Black's `required-version`
+   historically only accepts a plain version string (confirmed via
+   `psf/black` issue #4406, "Allow valid version specifier..."). The
+   asymmetry in the WI is correct and matches
+   `logical_robotics_harness/pyproject.toml`'s own working config
+   (`required-version = "==0.15.12"` for ruff, `"26.3.1"` for black, no
+   `==`). Not applied — will surface as a rejected finding at
+   confirm-fixes with this rationale, not silently left unresolved.
+
+# Validation
+
+- `lrh validate` from `lcats/`: 0 errors, 43 warnings (pre-existing,
+  unrelated to this change).
+- Verified `scripts/version` doesn't exist via `ls lcats/scripts/`.
+- Verified the `create_pr` convention by reading two resolved work items
+  directly.
+- Verified the ruff/black `required-version` semantics via WebSearch
+  against Ruff's official settings docs and a `psf/black` GitHub issue.
+
+# Follow-up
+
+None — proceeding to `/lrh-confirm-fixes` to resolve the 4 legitimately
+addressed threads and surface the 5th as a rejected finding with
+rationale.

--- a/lcats/project/executions/AD_HOC/2026_07_26_16_30_41_WI_PACKAGING_0031_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_16_30_41_WI_PACKAGING_0031_CONFIRM.md
@@ -16,9 +16,10 @@ session_transcript: pending
 
 Pre-merge confirm-fixes pass for PR #163. Independently verified the fixes
 applied in `2026_07_26_16_22_17_PR163_REVIEW_FIXES` against the live PR
-diff, and classified the 5th finding (ruff `required-version` syntax) as a
-Problematic comment rather than resolving it — the reviewer's claim is
-factually wrong, verified against Ruff's own docs.
+diff, classified the 5th finding (ruff `required-version` syntax) as a
+Problematic comment (factually wrong, verified against Ruff's own docs),
+and — per explicit user direction — posted a sourced rebuttal reply and
+resolved that thread too.
 
 # Result
 
@@ -35,17 +36,14 @@ Resolved via `resolveReviewThread`.
 conflicts with verified fact (Ruff's docs explicitly document `==`-prefixed
 PEP 440 specifiers as valid `required-version` syntax; Black's
 `required-version` does not accept them, so the asymmetry in the WI is
-correct, not a bug). Presented to the user with full rationale and
-sources; user acknowledged ("confirmed") without directing a specific
-disposition for the GitHub thread itself. Left the thread **unresolved on
-GitHub** by design — not resolved via `resolveReviewThread`, since no
-reply/rebuttal was posted (posting a public PR comment was treated as
-requiring explicit user sign-off beyond "confirmed", per this session's
-established caution around visible actions) and the taxonomy does not
-authorize resolving a Problematic-comment thread without one.
+correct, not a bug). Surfaced this to the user with full rationale and
+sources rather than silently applying or silently skipping it. User
+directed: post the rebuttal, then resolve. Posted a reply on discussion
+r3653089129 (comment `3653386075`) with the same sources cited to the
+user, then resolved the thread via `resolveReviewThread`.
 
-Thread-resolution verdict: **not green** — 1 exception remains open by
-design (see above), not from an unaddressed/unverified issue.
+Thread-resolution verdict: **green** — all 5 threads resolved (4 by fix,
+1 by verified rebuttal), no exceptions remain open.
 
 # Validation
 
@@ -53,16 +51,15 @@ design (see above), not from an unaddressed/unverified issue.
   correlated to review comments 1:1 by latest-comment URL.
 - `gh pr diff 163`: confirmed the 4 fixed findings are plainly resolved in
   the diff.
-- `gh api graphql resolveReviewThread`: 4 threads confirmed `isResolved:
-  true`; the 5th intentionally left `isResolved: false`.
+- `gh api graphql resolveReviewThread`: all 5 threads confirmed
+  `isResolved: true` after mutation.
 - `lrh validate`: 0 errors, 43 pre-existing warnings unrelated to this
   change.
 - CI: provisional read showed `lint` passed, `coverage`/`test` in progress
-  on `50dac117` — re-checked against the post-push `HEAD` before the final
-  verdict (see report).
+  on `50dac117` — re-checked against the post-push `HEAD` in Step 8 before
+  the final verdict (see report).
 
 # Follow-up
 
-The unresolved GitHub thread (`required-version` syntax, discussion
-r3653089129) remains open for a human to close manually, with the
-rebuttal rationale recorded here rather than posted publicly.
+None — final readiness verdict reported to the user for the human merge
+gate.

--- a/lcats/project/executions/AD_HOC/2026_07_26_16_30_41_WI_PACKAGING_0031_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_16_30_41_WI_PACKAGING_0031_CONFIRM.md
@@ -1,0 +1,68 @@
+---
+execution_id: 2026_07_26_16_30_41_WI_PACKAGING_0031_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_PACKAGING_0031_CONFIRM)[2026-07-26T16:24:48-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_16_22_17_PR163_REVIEW_FIXES
+pr: https://github.com/xenotaur/LCATS/pull/163
+commit: 
+created_at: 2026-07-26T16:30:41-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/163
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge confirm-fixes pass for PR #163. Independently verified the fixes
+applied in `2026_07_26_16_22_17_PR163_REVIEW_FIXES` against the live PR
+diff, and classified the 5th finding (ruff `required-version` syntax) as a
+Problematic comment rather than resolving it — the reviewer's claim is
+factually wrong, verified against Ruff's own docs.
+
+# Result
+
+Gathered live state via `lrh github threads --mode raw --state all` (5
+threads). Classified against `gh pr diff 163` (`HEAD` = `50dac117`):
+
+1-4. All four legitimate findings (bogus `scripts/version tools`,
+unregistered WS `work_items:`, missing `work_items/README.md` entry,
+missing `create_pr`) — **Clear-satisfied**, diff plainly resolves each.
+Resolved via `resolveReviewThread`.
+
+5. copilot-pull-request-reviewer's `required-version` syntax claim —
+**Problematic comment**, per the confirm-fixes taxonomy: reviewer's claim
+conflicts with verified fact (Ruff's docs explicitly document `==`-prefixed
+PEP 440 specifiers as valid `required-version` syntax; Black's
+`required-version` does not accept them, so the asymmetry in the WI is
+correct, not a bug). Presented to the user with full rationale and
+sources; user acknowledged ("confirmed") without directing a specific
+disposition for the GitHub thread itself. Left the thread **unresolved on
+GitHub** by design — not resolved via `resolveReviewThread`, since no
+reply/rebuttal was posted (posting a public PR comment was treated as
+requiring explicit user sign-off beyond "confirmed", per this session's
+established caution around visible actions) and the taxonomy does not
+authorize resolving a Problematic-comment thread without one.
+
+Thread-resolution verdict: **not green** — 1 exception remains open by
+design (see above), not from an unaddressed/unverified issue.
+
+# Validation
+
+- `lrh github threads --mode raw --state all`: 5 threads found, all
+  correlated to review comments 1:1 by latest-comment URL.
+- `gh pr diff 163`: confirmed the 4 fixed findings are plainly resolved in
+  the diff.
+- `gh api graphql resolveReviewThread`: 4 threads confirmed `isResolved:
+  true`; the 5th intentionally left `isResolved: false`.
+- `lrh validate`: 0 errors, 43 pre-existing warnings unrelated to this
+  change.
+- CI: provisional read showed `lint` passed, `coverage`/`test` in progress
+  on `50dac117` — re-checked against the post-push `HEAD` before the final
+  verdict (see report).
+
+# Follow-up
+
+The unresolved GitHub thread (`required-version` syntax, discussion
+r3653089129) remains open for a human to close manually, with the
+rebuttal rationale recorded here rather than posted publicly.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -16,6 +16,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md` — Design persistence layer for corpus state and operation history
 - `proposed/WI-EVENT-0030.md` — Run stratified cross-segment relation density pilot across genres
+- `proposed/WI-PACKAGING-0031.md` — Bring lcats/pyproject.toml metadata up to PEP 621/639 and CI-parity
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-PACKAGING-0031.md
+++ b/lcats/project/work_items/proposed/WI-PACKAGING-0031.md
@@ -21,6 +21,7 @@ blocked_by: []
 expected_actions:
   - edit_file
   - run_tests
+  - create_pr
 forbidden_actions:
   - force_push
   - delete_branch
@@ -134,7 +135,6 @@ src-layout work item, per the workstream's documented ordering constraint.
 
 ## Validation
 
-- `scripts/version tools`
 - `lrh validate`
 - `scripts/format --check --diff`
 - `scripts/lint`

--- a/lcats/project/work_items/proposed/WI-PACKAGING-0031.md
+++ b/lcats/project/work_items/proposed/WI-PACKAGING-0031.md
@@ -1,0 +1,155 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-PACKAGING-0031
+title: Bring lcats/pyproject.toml metadata up to PEP 621/639 and CI-parity
+type: deliverable
+status: proposed
+owner: xenotaur
+contributors:
+  - xenotaur
+assigned_agents: []
+related_focus: []
+related_roadmap: []
+related_workstreams:
+  - WS-PACKAGING
+related_design:
+  - project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - edit_file
+  - run_tests
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - implement_lcats_src_layout_move
+  - modify_ci_pipeline
+acceptance:
+  - lcats/pyproject.toml declares license = "MIT" plus license-files = ["LICENSE"] (PEP 639 form), not the deprecated {text = "MIT"} table
+  - lcats/pyproject.toml build-system.requires pins setuptools>=77
+  - lcats/pyproject.toml has [tool.ruff] required-version = "==0.15.0" and [tool.black] required-version = "25.11.0", matching lint.yml's CI pins
+  - ruff is pinned (not left unpinned) in the test/dev optional-dependency extras, matching black's existing pin
+  - the test and dev optional-dependency lists are no longer byte-identical duplicates
+  - the gutenbergpy dependency is pinned to a commit SHA, not the mutable @LCATS/TitleFix branch ref
+  - lcats/pyproject.toml has a [project.urls] table (Repository, Issues) and additional classifiers matching logical_robotics_harness/pyproject.toml's pattern
+  - lrh validate reports 0 errors
+required_evidence:
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/pyproject.toml
+---
+
+## Summary
+
+Bring `lcats/pyproject.toml`'s metadata up to current PyPA/PEP 621/PEP 639
+best practice and CI-pin parity, as Phase 1 of `WS-PACKAGING` — license
+declaration, build-system floor, tool version self-enforcement,
+dependency-extras cleanup, and a reproducible git dependency pin. Pure
+`pyproject.toml` edits; no code, layout, or CI changes.
+
+## Problem / Context
+
+`PROP-LCATS-PACKAGING-MODERNIZATION` (merged via PR #159) identified nine
+packaging gaps versus PyPA guidance and the sibling `lrh` project's own
+setup; `WS-PACKAGING` (merged via PR #160) sequences the fix into three
+phases so tool-version self-enforcement lands before the higher-risk
+src-layout move. This item is that first phase. It must land before the
+src-layout work item, per the workstream's documented ordering constraint.
+
+### Duplication search
+- In-repo: No existing implementation found.
+- Sibling repos: `logical_robotics_harness/pyproject.toml` already
+  implements the target pattern (PEP 639 license, tool `required-version`
+  pins) — reference, not duplicate.
+- External libraries: None identified — this is project packaging
+  configuration.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found (`PROP-LCATS-PACKAGING-MODERNIZATION` is the
+  originating request, already linked via `related_design`).
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Scope
+
+- Edit `lcats/pyproject.toml` metadata only: license form, build-system
+  floor, tool `required-version` pins, extras cleanup, `gutenbergpy` pin,
+  `project.urls`/classifiers.
+- Run the standard validation sequence to confirm nothing else broke.
+
+## Required Changes
+
+1. `license = {text = "MIT"}` → `license = "MIT"` +
+   `license-files = ["LICENSE"]`.
+2. `build-system.requires`: `setuptools>=42` → `setuptools>=77` (the
+   version that added PEP 639 `license`/`license-files` support).
+3. Add `[tool.ruff] required-version = "==0.15.0"` and
+   `[tool.black] required-version = "25.11.0"`, matching `lint.yml`'s CI
+   pins.
+4. Pin `ruff` (currently unpinned) alongside the existing `black==25.11.0`
+   pin in both the `test` and `dev` extras.
+5. Deduplicate the byte-identical `test`/`dev` optional-dependency lists
+   (collapse to one `dev` extra, or confirm nothing external depends on the
+   `test` extra name before removing it).
+6. Replace
+   `gutenbergpy @ git+https://github.com/xenotaur/gutenbergpy.git@LCATS/TitleFix`
+   with a pin to that branch's current commit SHA.
+7. Add `[project.urls]` (`Repository`, `Issues`) and additional
+   classifiers, matching `logical_robotics_harness/pyproject.toml`'s
+   pattern.
+
+## Non-Goals
+
+- Does not move `lcats/lcats/` to `lcats/src/lcats/` — that is the next
+  work item in this workstream.
+- Does not add `setuptools-scm` or change `version = "0.1"` — that is the
+  third work item.
+- Does not modify CI workflow YAML.
+- Does not touch any file outside `lcats/pyproject.toml`.
+
+## Acceptance Criteria
+
+- `lcats/pyproject.toml` declares `license = "MIT"` plus
+  `license-files = ["LICENSE"]` (PEP 639 form), not the deprecated
+  `{text = "MIT"}` table.
+- `lcats/pyproject.toml` `build-system.requires` pins `setuptools>=77`.
+- `lcats/pyproject.toml` has `[tool.ruff] required-version = "==0.15.0"`
+  and `[tool.black] required-version = "25.11.0"`, matching `lint.yml`'s
+  CI pins.
+- `ruff` is pinned (not left unpinned) in the `test`/`dev`
+  optional-dependency extras, matching `black`'s existing pin.
+- The `test` and `dev` optional-dependency lists are no longer
+  byte-identical duplicates.
+- The `gutenbergpy` dependency is pinned to a commit SHA, not the mutable
+  `@LCATS/TitleFix` branch ref.
+- `lcats/pyproject.toml` has a `[project.urls]` table (`Repository`,
+  `Issues`) and additional classifiers matching
+  `logical_robotics_harness/pyproject.toml`'s pattern.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `scripts/version tools`
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `python -m pip install -e ".[dev]"`
+
+## Risk Notes
+
+- Raising `setuptools>=77` could be a stricter floor than some
+  contributors' local environments have installed — worth confirming CI's
+  `setup-python`/pip cache picks it up correctly.
+- Deduplicating `test`/`dev` extras risks breaking anything that
+  references the `test` extra by name specifically; check before removing.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-PACKAGING.md`
+- Design: `project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md`

--- a/lcats/project/workstreams/proposed/WS-PACKAGING.md
+++ b/lcats/project/workstreams/proposed/WS-PACKAGING.md
@@ -10,7 +10,8 @@ related_focus: []
 related_roadmap: []
 related_design:
   - project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md
-work_items: []
+work_items:
+  - WI-PACKAGING-0031
 exit_criteria:
   - lcats/pyproject.toml declares license via PEP 639 (license = "MIT" + license-files), pins setuptools>=77 (the version that added PEP 639 support), sets required-version for tool.ruff and tool.black, has no duplicate test/dev extras, and pins gutenbergpy to a commit SHA
   - lcats package code lives at lcats/src/lcats/ with scripts/lint, scripts/format, secrets.py, and all lcats/lcats path literals updated accordingly, and the full test suite passes against the new layout
@@ -59,12 +60,9 @@ item couldn't express.
 
 ## Work Items
 
-Not yet created; `work_items:` will be populated as each is drafted via
-`/lrh-work-item`.
-
-- *(planned)* Metadata/config fixes — PEP 639 license, `setuptools>=77`
-  build-system pin, tool `required-version` pins, dedupe extras, pin
-  `gutenbergpy` to a commit SHA, `project.urls`/classifiers.
+- **WI-PACKAGING-0031** — Metadata/config fixes: PEP 639 license,
+  `setuptools>=77` build-system pin, tool `required-version` pins, dedupe
+  extras, pin `gutenbergpy` to a commit SHA, `project.urls`/classifiers.
 - *(planned)* src-layout move — `lcats/lcats/` → `lcats/src/lcats/`, update
   `scripts/lint`/`scripts/format`, `secrets.py`, path-literal audit,
   reinstall, full test run.


### PR DESCRIPTION
## Summary
Phase 1 of `WS-PACKAGING`: metadata-only fixes to `lcats/pyproject.toml` (PEP 639 license form, `setuptools>=77` build floor, `tool.ruff`/`tool.black` `required-version` pins, dedupe `test`/`dev` extras, pin `gutenbergpy` to a commit SHA, add `project.urls`/classifiers). No code, layout, or CI changes.

- `id`: WI-PACKAGING-0031
- `type`: deliverable
- `related_workstreams`: WS-PACKAGING
- `related_design`: `project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md`

## Acceptance criteria
See the work item's `## Acceptance Criteria` section for the full list — 8 conditions covering license form, build-system floor, tool pins, extras dedup, the `gutenbergpy` pin, and `project.urls`/classifiers.

This is a planning artifact only — no implementation in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
