### PR TITLE
Add pilot dogfood playbook, make --dry-run zero-dependency

### DIFF
--- a/experiments/03_cross_segment_relation_pilot/README.md
+++ b/experiments/03_cross_segment_relation_pilot/README.md
@@ -87,6 +87,11 @@ python experiments/03_cross_segment_relation_pilot/run_pilot.py \
     --output experiments/03_cross_segment_relation_pilot/results
 ```
 
+Defaults to `--data-dir lcats/data` — populate it first via `lcats gather`
+if your checkout doesn't have it yet, or pass `--data-dir corpora` to use
+the released snapshot instead (see `running_the_pilot.md` for full
+environment-setup detail).
+
 Full flag reference is documented in `run_pilot.py`'s module docstring
 (`python experiments/03_cross_segment_relation_pilot/run_pilot.py --help`).
 Key flags:
@@ -106,17 +111,22 @@ Key flags:
 
 ```bash
 python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
-    --sample-size 2 --output /tmp/pilot_dry_run
+    --data-dir corpora --sample-size 2 --output /tmp/pilot_dry_run
 ```
 
+(`--data-dir corpora` is needed on a fresh checkout — `lcats/data`, the
+default, is gitignored working-corpus state and won't exist until you
+generate it. See `running_the_pilot.md` for details.)
+
 This exercises the full script — sample selection, a stubbed single-segment
-stage-1 segmentation, the actual Event-Role-World pipeline invocation, and
+stage-1 segmentation (stages 2-7 of the Event-Role-World pipeline), and
 output writing — with fake LLM and NLP backends and **no real API calls or
 extra dependencies**, so you can confirm the script runs end to end in your
-environment before installing anything or spending real cost. Dry-run
-stories are not excluded, so you'll see real output rows with zero counts
-everywhere — the point is verifying the control flow and output files, not
-producing real numbers.
+environment before installing anything or spending real cost. It does
+**not** exercise the story-level cross-segment relation pass, which needs
+events in at least 2 distinct segments. Dry-run stories are not excluded,
+so you'll see real output rows with zero counts everywhere — the point is
+verifying the control flow and output files, not producing real numbers.
 
 **For the full developer runbook** — environment setup, smoke-testing a
 real spaCy or Stanza install with zero API cost, the real run, and closing

--- a/experiments/03_cross_segment_relation_pilot/README.md
+++ b/experiments/03_cross_segment_relation_pilot/README.md
@@ -10,8 +10,9 @@ convenience sample with a properly stratified measurement.
 script and this usage doc. No results exist yet: the session that wrote this
 tooling had no `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` configured, and this
 pilot's headline findings require real LLM pipeline output, not a fake
-backend. Whoever runs this pilot for real should append a "Results"
-section below this one, following the format sketched in
+backend. Whoever runs this pilot for real should follow
+[`running_the_pilot.md`](running_the_pilot.md)'s step-by-step runbook and
+append a "Results" section below this one, following the format sketched in
 [Expected Results Format](#expected-results-format).
 
 ## Purpose
@@ -98,8 +99,8 @@ Key flags:
 | `--seed` | 42 | Shuffle seed for candidate scan order (reproducibility) |
 | `--backend` | `anthropic` | `anthropic` or `openai` |
 | `--model` | provider default | Model string |
-| `--nlp-backend` | `spacy` | Stage-2 surface-feature NLP backend |
-| `--dry-run` | off | Zero-cost smoke test using a fake backend — produces meaningless (empty) results, never a real finding |
+| `--nlp-backend` | `spacy` (`fake` under `--dry-run`) | Stage-2 surface-feature NLP backend: `spacy`, `stanza`, or `fake` (zero dependencies) |
+| `--dry-run` | off | Zero-cost smoke test using fake LLM and (by default) fake NLP backends — produces meaningless (empty) results, never a real finding |
 
 ### Try it with zero API cost first
 
@@ -110,13 +111,19 @@ python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
 
 This exercises the full script — sample selection, a stubbed single-segment
 stage-1 segmentation, the actual Event-Role-World pipeline invocation, and
-output writing — with a `FakeBackend` and **no real API calls**, so you can
-confirm the script runs end to end in your environment before spending
-real cost on the full sample. Dry-run stories are not excluded (a fake
-backend's fixed response parses as valid-but-empty extraction output at
-every stage), so you'll see real output rows with zero counts everywhere —
-the point is verifying the control flow and output files, not producing
-real numbers.
+output writing — with fake LLM and NLP backends and **no real API calls or
+extra dependencies**, so you can confirm the script runs end to end in your
+environment before installing anything or spending real cost. Dry-run
+stories are not excluded, so you'll see real output rows with zero counts
+everywhere — the point is verifying the control flow and output files, not
+producing real numbers.
+
+**For the full developer runbook** — environment setup, smoke-testing a
+real spaCy or Stanza install with zero API cost, the real run, and closing
+out `WI-EVENT-0030` — see
+[`running_the_pilot.md`](running_the_pilot.md) in this directory. This
+README is the reference for what the pilot measures and how to interpret
+its output; that runbook is for actually executing it.
 
 ## Cost note
 

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -25,12 +25,17 @@ Optional flags:
     --output DIR            Results directory (default: ./results next to this script)
     --dry-run               Skip real genre detection and use a FakeBackend for the
                             whole pipeline (including a stubbed single-segment
-                            stage-1 segmentation, so the Event-Role-World pipeline
-                            itself is genuinely invoked), so the script's control
-                            flow and output files can be exercised with zero API
-                            cost. Produces meaningless (empty) extraction results -
-                            never use its output as a real finding. Defaults
-                            --nlp-backend to "fake" (see above) unless overridden.
+                            stage-1 segmentation, so stages 2-7 of the
+                            Event-Role-World pipeline run for real). Does NOT
+                            exercise the story-level cross-segment relation
+                            pass - that needs events in >= 2 distinct
+                            segments, which a single stubbed segment with an
+                            empty fake LLM response can never produce.
+                            Exercises the script's control flow and output
+                            files with zero API cost. Produces meaningless
+                            (empty) extraction results - never use its output
+                            as a real finding. Defaults --nlp-backend to
+                            "fake" (see above) unless overridden.
 
 Genre strata are fixed to the four genres lcats assess --genre actually
 classifies (science fiction, horror, western, romance - see
@@ -402,10 +407,13 @@ def run_story(
     In --dry-run mode, real stage-1 segmentation is skipped (a FakeBackend
     cannot produce one - its single fixed response can't satisfy the
     segmentation extractor's JSON-text parsing) and a single dummy segment
-    spanning the whole body is used instead, so _run_erw_pipeline() (and
-    thus the Event-Role-World pipeline itself) is genuinely exercised end
-    to end even in the zero-cost smoke test, rather than every dry-run
-    story returning early at segmentation.
+    spanning the whole body is used instead, so _run_erw_pipeline()'s
+    stages 2-7 run for real in the zero-cost smoke test, rather than every
+    dry-run story returning early at segmentation. This does NOT reach the
+    story-level cross-segment relation pass: that pass only fires when
+    events exist in >= 2 distinct segments, and a single stubbed segment
+    with an empty fake LLM response never produces any events at all - see
+    running_the_pilot.md's Step 2a for the same caveat.
     """
     row: Dict[str, Any] = {
         "path": str(path),

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -15,7 +15,13 @@ Optional flags:
     --seed N                Shuffle seed for candidate order (default: 42)
     --backend NAME          "anthropic" (default) or "openai"
     --model NAME            Model string (default: claude-opus-4-8 / gpt-4o)
-    --nlp-backend NAME      "spacy" (default) or "stanza", for stage-2 surface features
+    --nlp-backend NAME      "spacy", "stanza", or "fake", for stage-2 surface
+                            features. Defaults to "spacy" for a real run, or
+                            "fake" (nlp_backend.FakeNLPBackend - zero
+                            dependencies, no spacy/stanza import at all) for
+                            --dry-run. Pass --nlp-backend spacy/stanza
+                            explicitly alongside --dry-run to smoke-test a
+                            real NLP toolkit install with zero API cost.
     --output DIR            Results directory (default: ./results next to this script)
     --dry-run               Skip real genre detection and use a FakeBackend for the
                             whole pipeline (including a stubbed single-segment
@@ -23,7 +29,8 @@ Optional flags:
                             itself is genuinely invoked), so the script's control
                             flow and output files can be exercised with zero API
                             cost. Produces meaningless (empty) extraction results -
-                            never use its output as a real finding.
+                            never use its output as a real finding. Defaults
+                            --nlp-backend to "fake" (see above) unless overridden.
 
 Genre strata are fixed to the four genres lcats assess --genre actually
 classifies (science fiction, horror, western, romance - see
@@ -81,6 +88,7 @@ from lcats.analysis.corpus import assess as corpus_assess
 from lcats.analysis.event_role_world import discourse_extractor as erw_discourse
 from lcats.analysis.event_role_world import entity_extractor as erw_entity
 from lcats.analysis.event_role_world import event_extractor as erw_event
+from lcats.analysis.event_role_world import nlp_backend as erw_nlp_backend
 from lcats.analysis.event_role_world import processor as erw_processor
 from lcats.analysis.event_role_world import relation_extractor as erw_relation
 from lcats.analysis.event_role_world import schema as erw_schema
@@ -266,6 +274,23 @@ def _build_erw_extractors(backend: Any, model: str) -> Dict[str, Any]:
     }
 
 
+def _make_nlp_backend(nlp_backend_name: str) -> Any:
+    """Construct the stage-2 NLP backend, including the "fake" pseudo-name.
+
+    "fake" (nlp_backend.FakeNLPBackend, zero dependencies - no spacy/stanza
+    import at all) is this script's own addition on top of
+    erw_surface.make_nlp_backend()'s "spacy"/"stanza" - main() defaults
+    --nlp-backend to "fake" under --dry-run so the zero-cost smoke test
+    also needs zero extra dependencies installed, but an explicit
+    --nlp-backend spacy/stanza (even combined with --dry-run) still
+    selects the real backend, so a real NLP-toolkit install can be
+    smoke-tested with zero API cost. See running_the_pilot.md.
+    """
+    if nlp_backend_name == "fake":
+        return erw_nlp_backend.FakeNLPBackend()
+    return erw_surface.make_nlp_backend(nlp_backend_name)
+
+
 def _run_erw_pipeline(
     body: str,
     segments: List[Dict[str, Any]],
@@ -291,7 +316,7 @@ def _run_erw_pipeline(
     counts/densities computed from them).
     """
     extractors = _build_erw_extractors(backend, model)
-    nlp_backend = erw_surface.make_nlp_backend(nlp_backend_name)
+    nlp_backend = _make_nlp_backend(nlp_backend_name)
 
     annotations: List[erw_schema.SegmentWorldAnnotation] = []
     all_usage: List[erw_processor.PassUsage] = []
@@ -482,13 +507,27 @@ def main() -> int:
         "--backend", choices=["anthropic", "openai"], default="anthropic"
     )
     parser.add_argument("--model", default=None)
-    parser.add_argument("--nlp-backend", choices=["spacy", "stanza"], default="spacy")
+    parser.add_argument(
+        "--nlp-backend",
+        choices=["spacy", "stanza", "fake"],
+        default=None,
+        help=(
+            "Stage-2 surface-feature NLP backend. Defaults to 'spacy' for a "
+            "real run, or 'fake' (zero-dependency, no spacy/stanza import at "
+            "all) for --dry-run. Pass --nlp-backend spacy/stanza explicitly "
+            "with --dry-run to test a real NLP backend install with zero "
+            "API cost (LLM calls still use a FakeBackend)."
+        ),
+    )
     parser.add_argument(
         "--output",
         default=str(pathlib.Path(__file__).resolve().parent / "results"),
     )
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
+
+    if args.nlp_backend is None:
+        args.nlp_backend = "fake" if args.dry_run else "spacy"
 
     load_secrets()
 

--- a/experiments/03_cross_segment_relation_pilot/running_the_pilot.md
+++ b/experiments/03_cross_segment_relation_pilot/running_the_pilot.md
@@ -35,22 +35,34 @@ segmentation, and the full Event-Role-World pipeline), so nothing in this
 step costs money or requires API credentials. It's split into three
 scenarios depending on what you want to verify.
 
+On a fresh checkout, `lcats/data` (the script's default `--data-dir`) does
+not exist yet — it's gitignored working-corpus state, not tracked in git
+(see `.gitignore`'s `lcats/data` entry). `corpora/` is the tracked,
+released snapshot and is always present, so every command below passes
+`--data-dir corpora` explicitly. (If you'd rather use `lcats/data`,
+generate it first via `lcats gather` — see
+`lcats/docs/reference/prepare-corpora-release.md`.)
+
 ### 2a. Zero-dependency smoke test (recommended first)
 
 ```bash
 cd ..   # repo root, if you're still in lcats/
 python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
-    --sample-size 2 --output /tmp/pilot_dry_run
+    --data-dir corpora --sample-size 2 --output /tmp/pilot_dry_run
 ```
 
 `--dry-run` alone defaults `--nlp-backend` to `"fake"`
 (`nlp_backend.FakeNLPBackend`) — this genuinely needs **nothing** beyond
 the base `lcats` install from Step 1: no `spacy`, no `stanza`, no model
 downloads. It confirms the script's control flow (sample selection, the
-stubbed single-segment stage-1 segmentation, the full pipeline invocation
-including the story-level cross-segment pass, and output-file writing) all
+stubbed single-segment stage-1 segmentation, and output-file writing) all
 work in your environment before you touch any NLP toolkit or spend a
-dollar.
+dollar. It does **not** exercise the story-level cross-segment relation
+pass specifically — that pass only runs when events exist in at least 2
+distinct segments (see `_run_erw_pipeline`'s guard in `run_pilot.py`), and
+the dry-run's single stubbed segment with a fake (empty) LLM response
+never produces any events at all. Treat this step as a control-flow and
+output-format smoke test, not coverage of every pipeline stage.
 
 Expect every row to show `excluded: false` with all-zero counts (a fake
 backend can't produce real content) — that's correct, not a bug:
@@ -69,10 +81,10 @@ run), verify the toolkit itself works — still with zero API cost, by
 combining `--dry-run` with an explicit `--nlp-backend spacy`:
 
 ```bash
-pip install -e ".[dev,nlp]"
-python -m spacy download en_core_web_sm
+cd lcats && pip install -e ".[dev,nlp]" && python -m spacy download en_core_web_sm && cd ..
 python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
-    --nlp-backend spacy --sample-size 2 --output /tmp/pilot_dry_run_spacy
+    --data-dir corpora --nlp-backend spacy --sample-size 2 \
+    --output /tmp/pilot_dry_run_spacy
 ```
 
 An explicit `--nlp-backend spacy` overrides the `--dry-run` default of
@@ -91,10 +103,10 @@ rm -rf /tmp/pilot_dry_run_spacy
 Same idea, for Stanza:
 
 ```bash
-pip install -e ".[dev,nlp]"   # if not already done in 2b
-python -c "import stanza; stanza.download('en')"
+cd lcats && pip install -e ".[dev,nlp]" && python -c "import stanza; stanza.download('en')" && cd ..
 python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
-    --nlp-backend stanza --sample-size 2 --output /tmp/pilot_dry_run_stanza
+    --data-dir corpora --nlp-backend stanza --sample-size 2 \
+    --output /tmp/pilot_dry_run_stanza
 ```
 
 ```bash
@@ -120,6 +132,13 @@ committed. A real shell-exported key (e.g. a CI secrets manager) always
 takes precedence over `.secrets/` files.
 
 ## 4. The real run
+
+This defaults to `--data-dir lcats/data`, the live working corpus — not
+`corpora/`, the frozen release snapshot used for the smoke tests in Step 2.
+If `lcats/data` isn't populated yet in your checkout, generate it first
+(`lcats/docs/reference/prepare-corpora-release.md`'s "Regenerate" step,
+`lcats gather`), or pass `--data-dir corpora` here too if the released
+snapshot is sufficient for your purposes.
 
 ```bash
 python experiments/03_cross_segment_relation_pilot/run_pilot.py \
@@ -212,9 +231,11 @@ This happens if you run a real (non-`--dry-run`) pilot, or `--dry-run
 extra first:
 
 ```bash
+cd lcats   # pyproject.toml lives here, not at the repo root
 pip install -e ".[dev,nlp]"
 python -m spacy download en_core_web_sm      # if using spaCy
 python -c "import stanza; stanza.download('en')"   # if using Stanza
+cd ..
 ```
 
 Root cause: `lcats/pyproject.toml`'s `[project.optional-dependencies]`

--- a/experiments/03_cross_segment_relation_pilot/running_the_pilot.md
+++ b/experiments/03_cross_segment_relation_pilot/running_the_pilot.md
@@ -1,0 +1,250 @@
+# Running the cross-segment relation density pilot
+
+This is a manual runbook for a developer/dogfooder actually executing
+`run_pilot.py`, not a viewer deciding whether to trust its output — see
+`README.md` in this directory for the pilot's purpose, genre strata, metric
+definitions, and output-file formats. This runbook is about getting the
+script to actually run in your environment, smoke-testing it safely before
+spending real API cost, and closing out `WI-EVENT-0030` once you have real
+findings.
+
+Every command below is meant to be copy-pasted into a plain terminal — it
+does not assume Claude, an agent, or any tool beyond a shell and this repo
+checked out locally. If a step doesn't produce the output shown, stop and
+check the Troubleshooting section before continuing.
+
+**Directory:** all commands below run from the repo root unless stated
+otherwise.
+
+## 1. Environment setup
+
+```bash
+cd lcats
+scripts/develop
+```
+
+This installs `lcats` in editable mode (`pip install -e ".[dev]"`). Note
+that the `dev` extra does **not** include `spacy`/`stanza` — those live in
+a separate `nlp` extra (`lcats/pyproject.toml`'s
+`[project.optional-dependencies]`). You do not need them yet; see Step 2.
+
+## 2. Smoke-test before spending real API cost
+
+`--dry-run` uses a `FakeBackend` for every LLM call (genre detection,
+segmentation, and the full Event-Role-World pipeline), so nothing in this
+step costs money or requires API credentials. It's split into three
+scenarios depending on what you want to verify.
+
+### 2a. Zero-dependency smoke test (recommended first)
+
+```bash
+cd ..   # repo root, if you're still in lcats/
+python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
+    --sample-size 2 --output /tmp/pilot_dry_run
+```
+
+`--dry-run` alone defaults `--nlp-backend` to `"fake"`
+(`nlp_backend.FakeNLPBackend`) — this genuinely needs **nothing** beyond
+the base `lcats` install from Step 1: no `spacy`, no `stanza`, no model
+downloads. It confirms the script's control flow (sample selection, the
+stubbed single-segment stage-1 segmentation, the full pipeline invocation
+including the story-level cross-segment pass, and output-file writing) all
+work in your environment before you touch any NLP toolkit or spend a
+dollar.
+
+Expect every row to show `excluded: false` with all-zero counts (a fake
+backend can't produce real content) — that's correct, not a bug:
+
+```bash
+cat /tmp/pilot_dry_run/pilot_stories.jsonl
+cat /tmp/pilot_dry_run/pilot_summary.json
+cat /tmp/pilot_dry_run/pilot_usage.jsonl
+rm -rf /tmp/pilot_dry_run   # cleanup, this was just a smoke test
+```
+
+### 2b. Test your spaCy install
+
+If the real run will use `--nlp-backend spacy` (the default for a real
+run), verify the toolkit itself works — still with zero API cost, by
+combining `--dry-run` with an explicit `--nlp-backend spacy`:
+
+```bash
+pip install -e ".[dev,nlp]"
+python -m spacy download en_core_web_sm
+python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
+    --nlp-backend spacy --sample-size 2 --output /tmp/pilot_dry_run_spacy
+```
+
+An explicit `--nlp-backend spacy` overrides the `--dry-run` default of
+`"fake"`, so this run genuinely calls spaCy's real tokenizer/tagger/parser
+on real segment text (LLM calls are still faked). If this fails with
+`ModuleNotFoundError: No module named 'spacy'`, see Troubleshooting below.
+
+```bash
+cat /tmp/pilot_dry_run_spacy/pilot_stories.jsonl   # word_count should be
+                                                     # nonzero and real now
+rm -rf /tmp/pilot_dry_run_spacy
+```
+
+### 2c. Test your Stanza install
+
+Same idea, for Stanza:
+
+```bash
+pip install -e ".[dev,nlp]"   # if not already done in 2b
+python -c "import stanza; stanza.download('en')"
+python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
+    --nlp-backend stanza --sample-size 2 --output /tmp/pilot_dry_run_stanza
+```
+
+```bash
+cat /tmp/pilot_dry_run_stanza/pilot_stories.jsonl
+rm -rf /tmp/pilot_dry_run_stanza
+```
+
+You only need one of 2b/2c working for Step 4 (whichever `--nlp-backend`
+you plan to use for real) — running both is just extra confidence.
+
+## 3. API credentials
+
+```bash
+mkdir -p .secrets
+echo "ANTHROPIC_API_KEY=sk-ant-..." > .secrets/anthropic_api_keys.env
+```
+
+(Swap in `openai_api_keys.env` / `OPENAI_API_KEY` if you're running with
+`--backend openai` instead — the script defaults to `--backend anthropic`.)
+Full explanation of the `.secrets/` pattern: `lcats/docs/secrets-setup.md`.
+`.secrets/` is gitignored at the repo root; nothing here risks being
+committed. A real shell-exported key (e.g. a CI secrets manager) always
+takes precedence over `.secrets/` files.
+
+## 4. The real run
+
+```bash
+python experiments/03_cross_segment_relation_pilot/run_pilot.py \
+    --sample-size 5 \
+    --output experiments/03_cross_segment_relation_pilot/results
+```
+
+Read the README's **Cost note** section before running this — real LLM API
+calls happen for genre detection (one call per candidate story scanned,
+which can exceed 4 × 5 = 20 depending on the corpus's genre distribution),
+segmentation (one call per sampled story), and the Event-Role-World
+pipeline itself (4 calls per segment + 1 story-level cross-segment call per
+story). `--sample-size 5` (the low end of `WI-EVENT-0030`'s 5–10 range) is
+the right place to start.
+
+The script prints progress as it runs (`[genre-detect] ... -> <genre>`
+during sampling, then `Running pipeline: [<genre>] <file>` per story, with
+`excluded: <reason>` inline for any story that fails). It exits `0` on
+success, `1` on a missing/broken backend, `2` if it couldn't fill every
+genre stratum before exhausting `--max-candidates` (default 200 — raise
+this if a stratum comes up short).
+
+## 5. Inspect the results
+
+```bash
+cat experiments/03_cross_segment_relation_pilot/results/pilot_summary.json
+```
+
+Use `mean_cross_segment_density_per_1000_words` — **not**
+`mean_folded_relations_per_1000_words`, which mixes in same-segment
+relations too and can't isolate the cross-segment effect. See the README's
+"Metric definitions" section if the distinction isn't clear.
+
+```bash
+cat experiments/03_cross_segment_relation_pilot/results/pilot_stories.jsonl
+```
+
+Check for `excluded: true` rows and their `exclude_reason` before trusting
+the aggregate — a genre with a high exclusion rate deserves a second look
+(or a re-run with a fresh `--seed`) before treating its mean as reliable.
+
+```bash
+cat experiments/03_cross_segment_relation_pilot/results/pilot_usage.jsonl
+```
+
+Cost/latency detail per pipeline pass, if you want to report actual token
+spend alongside the findings.
+
+## 6. Write up the finding
+
+Copy the README's "Expected Results Format" table structure into a new
+`## Results (YYYY-MM-DD)` section in `README.md`, fill it in with the real
+`pilot_summary.json` numbers, and write the **Finding** paragraph: does the
+real run confirm, weaken, or contradict `WI-EVENT-0028`'s smaller-sample
+finding that science fiction/horror shows materially more long-range
+cross-segment causal chains than the other strata? Ground the claim in the
+actual numbers, not just "yes it matches."
+
+## 7. Close out WI-EVENT-0030
+
+```bash
+cd lcats
+lrh validate
+```
+
+Confirm 0 errors. Then update the work item's frontmatter
+(`project/work_items/proposed/WI-EVENT-0030.md`): `status: proposed` →
+`resolved`, `resolution: null` → a one-line summary quoting the real
+finding and commit, then move the file:
+
+```bash
+mkdir -p project/work_items/resolved
+git mv project/work_items/proposed/WI-EVENT-0030.md project/work_items/resolved/WI-EVENT-0030.md
+lrh validate   # re-confirm after the frontmatter edit
+```
+
+If this happens on a feature branch via a PR (the pattern the rest of this
+project's Event-Role-World work has followed), push and open the PR as
+usual, then run the review-response → confirm-fixes → merge → closeout
+cycle (`/lrh-review-response`, `/lrh-confirm-fixes`, `/lrh-closeout`)
+rather than committing straight to `main`. See `project/work_items/README.md`
+for the work-item lifecycle conventions.
+
+## Troubleshooting
+
+### `ModuleNotFoundError: No module named 'spacy'` (or `'stanza'`)
+
+This happens if you run a real (non-`--dry-run`) pilot, or `--dry-run
+--nlp-backend spacy`/`stanza` (Step 2b/2c), without installing the `nlp`
+extra first:
+
+```bash
+pip install -e ".[dev,nlp]"
+python -m spacy download en_core_web_sm      # if using spaCy
+python -c "import stanza; stanza.download('en')"   # if using Stanza
+```
+
+Root cause: `lcats/pyproject.toml`'s `[project.optional-dependencies]`
+puts `spacy`/`stanza` in a separate `nlp` extra, not in `dev` — a standard
+`scripts/develop` setup (Step 1) never installs them. This is why Step 2a
+(the zero-dependency smoke test) exists and should be your first check —
+it isolates whether a failure is this dependency gap versus something
+else in the script or your credentials.
+
+Grounding: [spaCy's install docs](https://spacy.io/usage) show the same
+two-step shape (`pip install -U spacy`, then a separate
+`python -m spacy download en_core_web_sm`) — trained pipelines are their
+own installable packages, not bundled into the base `spacy` wheel.
+[Stanza's docs](https://stanfordnlp.github.io/stanza/getting_started.html)
+work the same way: `pip install stanza`, then
+`stanza.download('en')` to fetch the model separately.
+
+### Script exits with code `2`
+
+A genre stratum couldn't be filled before `--max-candidates` (default 200)
+candidates were scanned. Either the corpus is thin for that genre, or the
+classifier is disagreeing with your expectation — re-run with a higher
+`--max-candidates`, or check `lcats assess --genre <genre> <file>
+--format human` directly on a story you expected to match
+(`lcats/docs/how-to/run-assess.md` has more on manual prompt validation).
+
+### High exclusion rate in `pilot_stories.jsonl`
+
+Check `exclude_reason` per excluded row. A `segmentation failed: ...`
+reason with real API credentials configured usually means a transient
+backend error (safe to re-run) — this pilot deliberately excludes rather
+than silently zero-filling these, so a re-run with a fresh `--seed` is the
+right move, not editing the results by hand.

--- a/lcats/docs/index.md
+++ b/lcats/docs/index.md
@@ -21,6 +21,7 @@ cd LCATS/lcats
 - [Set up API keys](secrets-setup.md)
 - [Run `lcats assess`](how-to/run-assess.md) — modes, manual prompt validation, and dry-run guidance
 - [Prepare a corpora release](reference/prepare-corpora-release.md) — manual, agent-free runbook: clear, regenerate, verify, and promote `data/` into `corpora/`
+- [Run the cross-segment relation density pilot](../../experiments/03_cross_segment_relation_pilot/running_the_pilot.md) — manual runbook: environment setup, zero-cost smoke testing (including spaCy/Stanza), the real run, and closing out the work item
 
 ### Reference
 

--- a/lcats/project/executions/AD_HOC/2026_07_26_14_55_34_WI_EVENT_0030_DOGFOOD_PLAYBOOK.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_14_55_34_WI_EVENT_0030_DOGFOOD_PLAYBOOK.md
@@ -1,0 +1,35 @@
+---
+execution_id: 2026_07_26_14_55_34_WI_EVENT_0030_DOGFOOD_PLAYBOOK
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_DOGFOOD_PLAYBOOK)[2026-07-26T14:52:57-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/164
+commit: 960f26ed
+agent: claude_app
+instruction_source: ad-hoc user request to save the WI-EVENT-0030 dogfood playbook and expand its smoke-test step into zero-dependency/spaCy/Stanza subsections
+session_transcript: pending
+created_at: 2026-07-26T14:55:34-04:00
+---
+
+# Summary
+
+Save the WI-EVENT-0030 pilot dogfood playbook as a proper Diátaxis how-to runbook, split its smoke-test step into three subsections (zero-dependency, spaCy, Stanza), and fix the real bug found while writing the zero-dependency subsection: `--dry-run` still required a real spaCy/stanza install.
+
+# Result
+
+- Created `experiments/03_cross_segment_relation_pilot/running_the_pilot.md` — a developer runbook (env setup, 3-way smoke test, real run, results write-up, WI-EVENT-0030 closeout, troubleshooting), structured like `docs/reference/prepare-corpora-release.md`, per the earlier session decision to use this location + one link from `docs/index.md` rather than folding it into the pilot's own viewer-facing README.
+- Found and fixed a real bug: `_run_erw_pipeline` unconditionally called `erw_surface.make_nlp_backend(nlp_backend_name)` for stage-2 surface features even under `--dry-run`, reproducing the exact `ModuleNotFoundError: No module named 'spacy'` the user hit — PR #158's FakeBackend fix only covered LLM calls, not this separate NLP-toolkit dependency. Fixed by adding `"fake"` as a real `--nlp-backend` choice (`nlp_backend.FakeNLPBackend`, already existed in the codebase but was unused), defaulted under `--dry-run` unless the user explicitly overrides it with `spacy`/`stanza` — enabling the playbook's 2b/2c subsections to smoke-test a real NLP toolkit install with zero API cost.
+- Trimmed `README.md`'s dry-run section to point to the new runbook; linked the runbook from `lcats/docs/index.md`'s "How-to guides" section.
+
+# Validation
+
+- `black --check`/`ruff check` on `run_pilot.py` — clean.
+- `scripts/test` — 1436 tests pass. `lrh validate` — 0 errors, 43 pre-existing unrelated warnings.
+- Scripted assertion that `--dry-run`'s default path never calls `make_nlp_backend` (patched it to raise if called; confirmed never hit).
+- Real end-to-end runs of `--dry-run --nlp-backend spacy` and `--dry-run --nlp-backend stanza` (both installed in this environment), producing real non-zero word counts with zero LLM API cost.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Wait for reviewer comments and run `/lrh-review-response https://github.com/xenotaur/LCATS/pull/164` to address them, then `/lrh-confirm-fixes` before merge. After merging, run `/lrh-closeout` to land this record.

--- a/lcats/project/executions/AD_HOC/2026_07_26_15_06_26_WI_EVENT_0030_DOGFOOD_PLAYBOOK_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_15_06_26_WI_EVENT_0030_DOGFOOD_PLAYBOOK_REVIEW.md
@@ -1,0 +1,38 @@
+---
+execution_id: 2026_07_26_15_06_26_WI_EVENT_0030_DOGFOOD_PLAYBOOK_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_DOGFOOD_PLAYBOOK_REVIEW)[2026-07-26T15:06:01-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_14_55_34_WI_EVENT_0030_DOGFOOD_PLAYBOOK
+pr: https://github.com/xenotaur/LCATS/pull/164
+commit: 8701c6f8
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/164
+session_transcript: pending
+created_at: 2026-07-26T15:06:26-04:00
+---
+
+# Summary
+
+Address PR #164 review feedback on the dogfood playbook and its `run_pilot.py` docstrings.
+
+# Result
+
+Three P2 comments addressed (all chatgpt-codex-connector):
+
+- **`lcats/data` (the script's default `--data-dir`) is gitignored and absent on a fresh checkout.** Confirmed via `.gitignore` (`lcats/data` entry) and `git ls-files lcats/data` (0 tracked files). Fixed by having every Step 2 (smoke test) command pass `--data-dir corpora` explicitly — `corpora/` is the tracked, always-present release snapshot (confirmed via `git ls-files corpora`, 1880 files). Added a note to Step 4 (the real run) and the README's Usage section too, since the real run's default `lcats/data` target has the same gap unless the reader has already generated it via `lcats gather`.
+- **Directory-mismatch bug**: Step 2a's `cd ..` leaves the reader at the repo root, but Steps 2b/2c/Troubleshooting then ran `pip install -e ".[dev,nlp]"` from there — `pyproject.toml` lives in `lcats/`, not the repo root. Fixed by making each of those command blocks self-contained (`cd lcats && pip install ... && cd ..`), so no step depends on directory state left over from a previous one.
+- **False claim that the dry-run exercises the story-level cross-segment pass.** `run_story()`'s dry-run path creates exactly one stubbed segment with an empty fake LLM response, so `_run_erw_pipeline()`'s cross-segment guard (events in >= 2 distinct segments) never fires — the story-relation pass is never invoked. Corrected this claim in `running_the_pilot.md` (Step 2a), `README.md`'s dry-run section, and both affected docstrings in `run_pilot.py` (`main`'s `--dry-run` help text and `run_story`'s docstring), all now stating plainly that dry-run covers stages 2-7 only, not the cross-segment pass.
+
+Verified the corrected `--data-dir corpora` command actually works: ran `run_pilot.py --dry-run --data-dir corpora --sample-size 2` for real, producing 2 included (non-excluded) stories per genre.
+
+# Validation
+
+- `black --check`/`ruff check` on `run_pilot.py` — clean.
+- `scripts/test` — 1436 tests pass. `lrh validate` — 0 errors, 43 pre-existing unrelated warnings.
+- Real run of the corrected `--dry-run --data-dir corpora --sample-size 2` command — succeeds, 2 included stories per genre, confirming the fix.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/164` to verify fixes against the current diff and resolve review threads, then the merge gate, then `/lrh-closeout`.

--- a/lcats/project/executions/AD_HOC/2026_07_26_15_11_14_WI_EVENT_0030_DOGFOOD_PLAYBOOK_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_15_11_14_WI_EVENT_0030_DOGFOOD_PLAYBOOK_CONFIRM.md
@@ -1,0 +1,37 @@
+---
+execution_id: 2026_07_26_15_11_14_WI_EVENT_0030_DOGFOOD_PLAYBOOK_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_DOGFOOD_PLAYBOOK_CONFIRM)[2026-07-26T15:11:05-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_15_06_26_WI_EVENT_0030_DOGFOOD_PLAYBOOK_REVIEW
+pr: https://github.com/xenotaur/LCATS/pull/164
+commit: bc5dfc86
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/164
+session_transcript: pending
+created_at: 2026-07-26T15:11:14-04:00
+---
+
+# Summary
+
+Confirm PR #164's review fixes against the current diff and resolve threads before merge.
+
+# Result
+
+Fetched threads via `lrh github threads <pr-url> --mode raw --state all`: 3 total, all unresolved before this round. Verified each against the pushed fix:
+
+- `lcats/data` availability — confirmed every Step 2 command in `running_the_pilot.md` now passes `--data-dir corpora` explicitly, and Step 4/README's Usage section both note the same gap for the real run's default.
+- Directory-mismatch — confirmed Steps 2b/2c/Troubleshooting now self-contain their `cd lcats && ... && cd ..` sequencing rather than depending on state left by a prior step.
+- Story-level pass overclaim — confirmed the claim is corrected in `running_the_pilot.md`, `README.md`, and both `run_pilot.py` docstrings (`main`'s `--dry-run` help, `run_story`'s docstring) to state dry-run covers stages 2-7 only.
+
+Resolved all 3 threads via `gh api graphql resolveReviewThread`. Confirmed CI green (coverage/lint/test x2 all SUCCESS) at commit `bc5dfc86`.
+
+# Validation
+
+- `lrh github threads https://github.com/xenotaur/LCATS/pull/164 --mode raw --state all` — 0 unresolved threads remain after resolution.
+- `gh pr checks https://github.com/xenotaur/LCATS/pull/164` — coverage/lint/test x2 all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Merge gate: summarize PR #164 for the user and wait for explicit approval before merging.


### PR DESCRIPTION
## Summary
Adds `experiments/03_cross_segment_relation_pilot/running_the_pilot.md`, a developer runbook for actually executing the WI-EVENT-0030 pilot script, following the Diátaxis how-to convention already established in `lcats/docs/index.md` (same pattern as `docs/reference/prepare-corpora-release.md`). Splits the "smoke test before spending real API cost" step into three subsections: zero-dependency, real spaCy, real Stanza.

**Real bug found and fixed while drafting the zero-dependency subsection:** `--dry-run` still unconditionally imported real spaCy/stanza for stage-2 surface features (`erw_surface.make_nlp_backend`) — reproducing the exact `ModuleNotFoundError: No module named 'spacy'` a user hit running the dry-run smoke test from earlier dogfood instructions. PR #158's FakeBackend fix only covered LLM calls, not this separate NLP-toolkit dependency.

**Fix:** added a `"fake"` `--nlp-backend` option (`nlp_backend.FakeNLPBackend` — already existed in the codebase, was just unused), defaulted under `--dry-run` unless the user explicitly overrides it. An explicit `--dry-run --nlp-backend spacy`/`stanza` now does a genuine, isolated real-toolkit smoke test with fake LLM calls — exactly what the playbook's new 2b/2c subsections document.

**Verification (zero real API cost):**
- Scripted assertion that `--dry-run`'s default path never calls `make_nlp_backend` at all (patched it to raise if called — confirmed it's never hit).
- Real end-to-end runs of `--dry-run --nlp-backend spacy` and `--dry-run --nlp-backend stanza` in this environment (both installed here), producing real non-zero word counts.

Also trimmed the pilot's `README.md` to point to the new runbook instead of duplicating dry-run detail, keeping it focused on the viewer-facing "what does this measure" content per the audience split already agreed on.

## Files changed
- `experiments/03_cross_segment_relation_pilot/running_the_pilot.md` (new)
- `experiments/03_cross_segment_relation_pilot/run_pilot.py` (`"fake"` NLP backend option)
- `experiments/03_cross_segment_relation_pilot/README.md` (trimmed, links to runbook)
- `lcats/docs/index.md` (links the new runbook under How-to guides)

Prompt ID: `PROMPT(AD_HOC:WI_EVENT_0030_DOGFOOD_PLAYBOOK)[2026-07-26T14:52:57-04:00]`

## Test plan
- [x] `black --check`/`ruff check` on `run_pilot.py` — clean
- [x] `scripts/test` — 1436 tests pass
- [x] `lrh validate` — 0 errors (43 pre-existing warnings, unrelated)
- [x] Scripted assertion: `--dry-run` never calls `make_nlp_backend`
- [x] Real `--dry-run --nlp-backend spacy` and `--dry-run --nlp-backend stanza` runs, both producing real (non-fake) tokenization output with zero LLM API cost

Generated with Claude Code
