### PR TITLE
Reuse NLP backend/extractors across stories in the pilot script

### DIFF
--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -304,8 +304,12 @@ def _run_erw_pipeline(
     nlp_backend_name: str,
     story_id: str,
 ) -> Dict[str, Any]:
-    """Run stages 2-9 (+ the cross-segment pass) with `model` correctly
-    propagated to every ERW extractor.
+    """Run stages 2-9 (+ the cross-segment pass) for one story.
+
+    `extractors` (built by _build_erw_extractors(), with `model` already
+    overriding each extractor's own hardcoded default) and `nlp_backend`
+    are passed in already-built rather than constructed here - this
+    function itself takes no `model` parameter.
 
     Mirrors processor.process_segments()'s own orchestration (per-segment
     process_segment() calls, schema.reconcile_story_annotations(), then the
@@ -595,9 +599,14 @@ def main() -> int:
     # Built ONCE and reused across every story - constructing these per
     # story previously reloaded Stanza's full neural pipeline (~15-30s) or
     # spaCy's model (~1-5s) on every single story. See _run_erw_pipeline's
-    # docstring.
+    # docstring. Model/pipeline loading now happens here, before the
+    # per-story timer starts below, so per-story elapsed_seconds no longer
+    # includes it - print an explicit confirmation instead, since spaCy
+    # (unlike Stanza) prints no loading banner of its own.
     extractors = _build_erw_extractors(backend, model)
+    print(f"Loading NLP backend: {args.nlp_backend}...")
     nlp_backend = _make_nlp_backend(args.nlp_backend)
+    print(f"NLP backend ready: {args.nlp_backend}")
 
     rows: List[Dict[str, Any]] = []
     usage_rows: List[Dict[str, Any]] = []

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -299,8 +299,8 @@ def _make_nlp_backend(nlp_backend_name: str) -> Any:
 def _run_erw_pipeline(
     body: str,
     segments: List[Dict[str, Any]],
-    backend: Any,
-    model: str,
+    extractors: Dict[str, Any],
+    nlp_backend: Any,
     nlp_backend_name: str,
     story_id: str,
 ) -> Dict[str, Any]:
@@ -312,7 +312,13 @@ def _run_erw_pipeline(
     story-level cross-segment relation pass gated on events existing in at
     least 2 distinct segments) but built from extractors this script
     constructs itself, so their default_model can be overridden - see
-    _build_erw_extractors(). Returns
+    _build_erw_extractors(). `extractors` and `nlp_backend` are built ONCE
+    by the caller (main()) and reused across every story in the sample -
+    constructing a fresh nlp_backend per story here previously reloaded
+    Stanza's full neural pipeline (tokenize/mwt/pos/lemma/depparse, ~15-30s)
+    on every single story, since StanzaBackend.__init__ builds a real
+    stanza.Pipeline; spaCy's per-story reload was smaller (~1-5s) but the
+    same waste. Returns
     {"segments": [...], "usage": [...], "story": {...},
     "processed_segment_count": int} - the last key is the number of
     segments actually processed (process_segments() silently skips any
@@ -320,8 +326,6 @@ def _run_erw_pipeline(
     overstate how many were really run and disagree with relation
     counts/densities computed from them).
     """
-    extractors = _build_erw_extractors(backend, model)
-    nlp_backend = _make_nlp_backend(nlp_backend_name)
 
     annotations: List[erw_schema.SegmentWorldAnnotation] = []
     all_usage: List[erw_processor.PassUsage] = []
@@ -394,6 +398,8 @@ def run_story(
     genre: str,
     backend: Any,
     model: str,
+    extractors: Dict[str, Any],
+    nlp_backend: Any,
     nlp_backend_name: str,
     dry_run: bool = False,
 ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
@@ -451,7 +457,7 @@ def run_story(
             return row, []
 
     pipeline_result = _run_erw_pipeline(
-        body, segments, backend, model, nlp_backend_name, path.stem
+        body, segments, extractors, nlp_backend, nlp_backend_name, path.stem
     )
     usage_rows = [
         {"story_id": path.stem, "genre": genre, **usage}
@@ -586,6 +592,13 @@ def main() -> int:
             file=sys.stderr,
         )
 
+    # Built ONCE and reused across every story - constructing these per
+    # story previously reloaded Stanza's full neural pipeline (~15-30s) or
+    # spaCy's model (~1-5s) on every single story. See _run_erw_pipeline's
+    # docstring.
+    extractors = _build_erw_extractors(backend, model)
+    nlp_backend = _make_nlp_backend(args.nlp_backend)
+
     rows: List[Dict[str, Any]] = []
     usage_rows: List[Dict[str, Any]] = []
     for genre in GENRES:
@@ -593,7 +606,14 @@ def main() -> int:
             print(f"Running pipeline: [{genre}] {path.name}")
             t0 = time.monotonic()
             row, story_usage_rows = run_story(
-                path, genre, backend, model, args.nlp_backend, dry_run=args.dry_run
+                path,
+                genre,
+                backend,
+                model,
+                extractors,
+                nlp_backend,
+                args.nlp_backend,
+                dry_run=args.dry_run,
             )
             row["elapsed_seconds"] = time.monotonic() - t0
             rows.append(row)

--- a/experiments/03_cross_segment_relation_pilot/running_the_pilot.md
+++ b/experiments/03_cross_segment_relation_pilot/running_the_pilot.md
@@ -98,10 +98,15 @@ rm -rf /tmp/pilot_dry_run_spacy
 ```
 
 `word_count` is computed directly from the story text regardless of NLP
-backend, so it won't change from 2a — the real evidence spaCy ran for real
-is each row's `elapsed_seconds`: expect roughly 1-5 real seconds per story
-(spaCy loading the pipeline and running its tokenizer/tagger/parser),
-versus microseconds in 2a's fake-backend run.
+backend, so it won't change from 2a. The NLP backend is loaded once,
+before any story runs — look for the script's own
+`Loading NLP backend: spacy...` / `NLP backend ready: spacy` console lines
+(printed once, near the start) as confirmation, rather than inferring it
+from `elapsed_seconds`: since loading now happens outside the per-story
+timer, each row's `elapsed_seconds` reflects only real inference time
+(typically well under a second per story for spaCy), not a multi-second
+load — a small number here is expected and does **not** mean spaCy didn't
+run.
 
 ### 2c. Test your Stanza install
 
@@ -118,6 +123,11 @@ python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run \
 cat /tmp/pilot_dry_run_stanza/pilot_stories.jsonl
 rm -rf /tmp/pilot_dry_run_stanza
 ```
+
+Stanza's own "Loading these models..." banner prints once, near the start
+of the run (before any story is processed), not once per story — if you
+see it repeated once per story, something has regressed (the NLP backend
+should be built once and reused across the whole sample).
 
 You only need one of 2b/2c working for Step 4 (whichever `--nlp-backend`
 you plan to use for real) — running both is just extra confidence.

--- a/experiments/03_cross_segment_relation_pilot/running_the_pilot.md
+++ b/experiments/03_cross_segment_relation_pilot/running_the_pilot.md
@@ -93,10 +93,15 @@ on real segment text (LLM calls are still faked). If this fails with
 `ModuleNotFoundError: No module named 'spacy'`, see Troubleshooting below.
 
 ```bash
-cat /tmp/pilot_dry_run_spacy/pilot_stories.jsonl   # word_count should be
-                                                     # nonzero and real now
+cat /tmp/pilot_dry_run_spacy/pilot_stories.jsonl
 rm -rf /tmp/pilot_dry_run_spacy
 ```
+
+`word_count` is computed directly from the story text regardless of NLP
+backend, so it won't change from 2a — the real evidence spaCy ran for real
+is each row's `elapsed_seconds`: expect roughly 1-5 real seconds per story
+(spaCy loading the pipeline and running its tokenizer/tagger/parser),
+versus microseconds in 2a's fake-backend run.
 
 ### 2c. Test your Stanza install
 

--- a/lcats/project/executions/AD_HOC/2026_07_26_18_37_26_WI_EVENT_0030_PILOT_NLP_BACKEND_REUSE.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_18_37_26_WI_EVENT_0030_PILOT_NLP_BACKEND_REUSE.md
@@ -1,0 +1,36 @@
+---
+execution_id: 2026_07_26_18_37_26_WI_EVENT_0030_PILOT_NLP_BACKEND_REUSE
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_PILOT_NLP_BACKEND_REUSE)[2026-07-26T18:35:04-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/165
+commit: f991e45d
+agent: claude_app
+instruction_source: user report during live dogfooding of running_the_pilot.md Step 2c (Stanza) - "seems extremely slow, is the API reloading the models each time?"
+session_transcript: pending
+created_at: 2026-07-26T18:37:26-04:00
+---
+
+# Summary
+
+Fix a real performance bug found while dogfooding Step 2c: `_run_erw_pipeline` reconstructed the NLP backend (and the ERW extractors) fresh for every story, reloading Stanza's full neural pipeline from disk on every single story. Also fix a misleading doc comment found at the same time.
+
+# Result
+
+- Confirmed the user's suspicion was correct: `StanzaBackend.__init__` builds a real `stanza.Pipeline`, and it was being constructed once per story inside `_run_erw_pipeline` rather than once per run — the user's log showed "Loading these models..." repeated 8 times (once per story) for an 8-story dry-run sample.
+- Fixed by hoisting `_build_erw_extractors(backend, model)` and `_make_nlp_backend(args.nlp_backend)` out of `_run_erw_pipeline` into `main()`, built once before the per-story loop, and threaded through `run_story()` → `_run_erw_pipeline()` as parameters — mirrors how the real `processor.process_segments()` builds these once per corpus run.
+- Also fixed a misleading comment in `running_the_pilot.md` (`# word_count should be nonzero and real now`, from PR #164) that implied `word_count` depends on the NLP backend — it doesn't, it's computed directly from story text. Replaced with a note pointing at `elapsed_seconds` as the actual evidence a real backend ran.
+
+# Validation
+
+- `black --check`/`ruff check` on `run_pilot.py` — clean.
+- `scripts/test` — 1436 tests pass. `lrh validate` — 0 errors, 43 pre-existing unrelated warnings.
+- Scripted test: patched `FakeNLPBackend.__init__` to count constructions — confirmed exactly 1 construction across 3 stories (previously would have been 3).
+- Real run: `--dry-run --data-dir corpora --nlp-backend stanza --sample-size 2` over 8 stories — `"Done loading processors"` now appears exactly once in the log (was 8 times before the fix), and each story's `elapsed_seconds` (6.9-19.5s) is now real inference time only, roughly proportional to word count.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- User will re-run Step 2c once this PR lands, to confirm the speedup for real in their own environment.
+- Wait for reviewer comments and run `/lrh-review-response https://github.com/xenotaur/LCATS/pull/165` to address them, then `/lrh-confirm-fixes` before merge. After merging, run `/lrh-closeout` to land this record.

--- a/lcats/project/executions/AD_HOC/2026_07_26_18_46_52_WI_EVENT_0030_NLP_BACKEND_REUSE_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_18_46_52_WI_EVENT_0030_NLP_BACKEND_REUSE_REVIEW.md
@@ -1,0 +1,33 @@
+---
+execution_id: 2026_07_26_18_46_52_WI_EVENT_0030_NLP_BACKEND_REUSE_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_NLP_BACKEND_REUSE_REVIEW)[2026-07-26T18:46:25-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_18_37_26_WI_EVENT_0030_PILOT_NLP_BACKEND_REUSE
+pr: https://github.com/xenotaur/LCATS/pull/165
+commit: 786c4d51
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/165
+session_transcript: pending
+created_at: 2026-07-26T18:46:52-04:00
+---
+
+# Summary
+
+Address PR #165 review feedback — two reviewers independently flagged that this PR's own NLP-backend-reuse fix made the PR's own doc claims about `elapsed_seconds` timing stale, plus a stale docstring.
+
+# Result
+
+- **P2 (chatgpt-codex-connector + copilot, same issue from two reviewers): the "expect 1-5 real seconds per story" claim (written earlier in this same PR) became stale the moment the reuse fix landed** — model/pipeline loading now happens once in `main()`, before the per-story timer starts, so per-story `elapsed_seconds` no longer includes it and will typically be well under a second for spaCy. Fixed by: (1) adding explicit `Loading NLP backend: <name>...`/`NLP backend ready: <name>` console prints in `main()`, since spaCy has no loading banner of its own to rely on; (2) rewriting `running_the_pilot.md`'s 2b section to point at those prints as confirmation instead of `elapsed_seconds`, and to state plainly that a small `elapsed_seconds` now is expected and does not mean spaCy didn't run; (3) added a note to 2c clarifying Stanza's own loading banner should now print once total, not once per story (a regression signal if seen again).
+- **`_run_erw_pipeline`'s docstring still said "with `model` correctly propagated to every ERW extractor"** — stale after this PR removed the `model` parameter from that function's signature (model is now baked into the pre-built `extractors` passed in). Rewrote the docstring's opening to describe the actual current signature.
+
+# Validation
+
+- `black --check`/`ruff check` on `run_pilot.py` — clean.
+- `scripts/test` — 1436 tests pass. `lrh validate` — 0 errors, 43 pre-existing unrelated warnings.
+- Verified the new print statements appear exactly once, before any story, in a real `--dry-run --nlp-backend spacy` run.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/165` to verify fixes against the current diff and resolve review threads, then the merge gate, then `/lrh-closeout`.

--- a/lcats/project/executions/AD_HOC/2026_07_26_18_52_05_WI_EVENT_0030_NLP_BACKEND_REUSE_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_18_52_05_WI_EVENT_0030_NLP_BACKEND_REUSE_CONFIRM.md
@@ -1,0 +1,36 @@
+---
+execution_id: 2026_07_26_18_52_05_WI_EVENT_0030_NLP_BACKEND_REUSE_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_NLP_BACKEND_REUSE_CONFIRM)[2026-07-26T18:51:51-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_18_46_52_WI_EVENT_0030_NLP_BACKEND_REUSE_REVIEW
+pr: https://github.com/xenotaur/LCATS/pull/165
+commit: 89c22f7f
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/165
+session_transcript: pending
+created_at: 2026-07-26T18:52:05-04:00
+---
+
+# Summary
+
+Confirm PR #165's review fixes against the current diff and resolve threads before merge.
+
+# Result
+
+Fetched threads via `lrh github threads <pr-url> --mode raw --state all`: 3 total, all unresolved before this round. Verified each against the pushed fix:
+
+- Stale `elapsed_seconds` timing claim (flagged independently by both reviewers) — confirmed `main()` now prints explicit `Loading NLP backend: <name>...`/`NLP backend ready: <name>` confirmation, `running_the_pilot.md`'s 2b section now points at those prints instead of `elapsed_seconds`, and 2c notes Stanza's banner should print once total.
+- Stale `_run_erw_pipeline` docstring — confirmed its opening no longer claims `model` propagation, describing the actual current signature (pre-built `extractors`/`nlp_backend` passed in).
+
+Resolved all 3 threads via `gh api graphql resolveReviewThread`. Confirmed CI green (coverage/lint/test x2 all SUCCESS) at commit `89c22f7f`.
+
+# Validation
+
+- `lrh github threads https://github.com/xenotaur/LCATS/pull/165 --mode raw --state all` — 0 unresolved threads remain after resolution.
+- `gh pr checks https://github.com/xenotaur/LCATS/pull/165` — coverage/lint/test x2 all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>` after this session ends.
+- Merge gate: summarize PR #165 for the user and wait for explicit approval before merging.


### PR DESCRIPTION
## Summary
Found while dogfooding Step 2c (Stanza) of `running_the_pilot.md`: every story reconstructed the NLP backend from scratch inside `_run_erw_pipeline`, and `StanzaBackend.__init__` builds a real `stanza.Pipeline`, which reloads all 5 neural models (tokenize, mwt, pos, lemma, depparse) from disk on every single story — "Loading these models..." printed once per story in the log rather than once per run. spaCy's per-story reload was smaller (~1-5s) but the same waste.

**Fix:** hoisted `nlp_backend` and `extractors` construction out of `_run_erw_pipeline` into `main()`, built once and threaded through `run_story()` → `_run_erw_pipeline()` for every story in the sample — mirrors how `processor.process_segments()` itself builds these once per corpus run, not once per segment/story.

**Verification:**
- A scripted test asserting `FakeNLPBackend.__init__` is called exactly once across 3 stories (was 3 before the fix).
- A real Stanza run over 8 stories showing `"Done loading processors"` now appears once total (was 8 times), with each story's `elapsed_seconds` now reflecting only real inference time (proportional to word count).

**Also fixes a misleading doc comment** from PR #164 (`# word_count should be nonzero and real now`) that implied `word_count` depends on which NLP backend runs — it doesn't; it's computed directly from the story text independent of `nlp_backend`. Replaced with a note pointing at the actual evidence a real backend ran: `elapsed_seconds`.

## Files changed
- `experiments/03_cross_segment_relation_pilot/run_pilot.py` — hoisted extractor/NLP-backend construction to `main()`
- `experiments/03_cross_segment_relation_pilot/running_the_pilot.md` — corrected the misleading comment, added a note about `elapsed_seconds` as the real spaCy-ran-for-real signal

Prompt ID: `PROMPT(AD_HOC:WI_EVENT_0030_PILOT_NLP_BACKEND_REUSE)[2026-07-26T18:35:04-04:00]`

## Test plan
- [x] `black --check`/`ruff check` — clean
- [x] `scripts/test` — 1436 tests pass
- [x] `lrh validate` — 0 errors (43 pre-existing warnings, unrelated)
- [x] Scripted test: NLP backend constructed exactly once across multiple stories
- [x] Real Stanza run: model loaded once, not per-story

Generated with Claude Code
