### PR TITLE
Abort pilot run on fatal API errors (quota/credit exhaustion)

### DIFF
--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -114,17 +114,21 @@ GENRES = (
 # "skip this one story": bad/expired credentials or an exhausted account
 # balance/quota. Every remaining candidate would fail identically, so
 # continuing just burns time (and, with real credentials, still-billable
-# request attempts) for no new information. Matches both providers' actual
+# request attempts) for no new information. Deliberately as broad as
+# lcats.analysis.llm_extractor.JSONPromptExtractor._classify_api_error's own
+# quota/auth checks (not narrower) - a fatal-error detector that's too
+# narrow silently degrades back into per-story exclusions, which is exactly
+# the failure mode this exists to prevent. Covers both providers' actual
 # wording: Anthropic's "Your credit balance is too low..." (a 400
-# invalid_request_error, not the OpenAI-shaped insufficient_quota/402 that
-# lcats.analysis.llm_extractor.LLMExtractor._classify_api_error already
-# recognized) and common auth-failure phrasing.
+# invalid_request_error, not the OpenAI-shaped insufficient_quota/402 the
+# classifier was originally written for) and common auth-failure phrasing
+# ("authentication failed", "Incorrect API key provided").
 _FATAL_ERROR_SUBSTRINGS = (
     "credit balance",
     "insufficient_quota",
-    "invalid x-api-key",
-    "invalid api key",
-    "authentication_error",
+    "quota",
+    "api key",
+    "authentication",
 )
 
 
@@ -136,15 +140,33 @@ class FatalPilotError(RuntimeError):
     that convention and previously had no equivalent, so a single exhausted
     API key/balance silently produced a full sample of "excluded" stories
     with no top-level indication of why.
+
+    Carries `usage_rows`: PassUsage records (in the same tagged shape as
+    pilot_usage.jsonl rows) already accumulated for the current story before
+    the abort. A quota/auth failure can happen partway through a
+    multi-segment story after several earlier passes already succeeded and
+    spent real tokens - raising bare would silently drop that cost/latency
+    data. Defaults to empty; callers with nothing accumulated yet (genre
+    detection, segmentation) leave it unset.
     """
 
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.usage_rows: List[Dict[str, Any]] = []
 
-def _check_fatal(message: str, context: str) -> None:
+
+def _check_fatal(
+    message: str,
+    context: str,
+    usage_rows: Optional[List[Dict[str, Any]]] = None,
+) -> None:
     """Raise FatalPilotError if `message` names a fatal, account-level
     failure rather than a per-story problem."""
     lowered = message.lower()
     if any(s in lowered for s in _FATAL_ERROR_SUBSTRINGS):
-        raise FatalPilotError(f"{context}: {message}")
+        exc = FatalPilotError(f"{context}: {message}")
+        exc.usage_rows = list(usage_rows or [])
+        raise exc
 
 
 def _build_backend(backend_name: str, model: Optional[str]):
@@ -409,6 +431,18 @@ def _run_erw_pipeline(
         annotations.append(annotation)
         all_usage.extend(usage_records)
 
+        # Check after every segment, not after the whole story: entity/
+        # event/relation/discourse extraction all run unconditionally per
+        # segment (process_segment has no early-exit of its own), so a
+        # multi-segment story would otherwise issue several more doomed
+        # requests per remaining segment before this function ever returns.
+        for err in annotation.extraction_errors:
+            _check_fatal(
+                str(err),
+                context=f"pipeline {story_id} segment {segment.get('segment_id')}",
+                usage_rows=[u.to_dict() for u in all_usage],
+            )
+
     story = erw_schema.reconcile_story_annotations(story_id, annotations)
 
     segment_ids_with_events = {
@@ -429,6 +463,11 @@ def _run_erw_pipeline(
         if story_relation_error:
             story.extraction_errors.append(
                 f"story relation extraction failed: {story_relation_error}"
+            )
+            _check_fatal(
+                str(story_relation_error),
+                context=f"pipeline {story_id} story-relation",
+                usage_rows=[u.to_dict() for u in all_usage],
             )
         cross_segment_relations, weakly_inferred_cross_segment_relations = (
             erw_story_relation.build_story_relations(
@@ -511,19 +550,32 @@ def run_story(
             # seg_error may be the classified api_error dict (see
             # LLMExtractor._classify_api_error) or a plain string, depending
             # on where in extract() the failure occurred.
+            seg_error_dict = seg_error if isinstance(seg_error, dict) else None
             seg_error_text = (
-                seg_error.get("message", str(seg_error))
-                if isinstance(seg_error, dict)
+                seg_error_dict.get("message", str(seg_error))
+                if seg_error_dict is not None
                 else str(seg_error)
             )
+            if seg_error_dict is not None and seg_error_dict.get("should_abort_batch"):
+                # Trust the classifier's own normalized flag directly when
+                # it's available, rather than re-deriving fatality from
+                # message text (which can miss wordings the classifier
+                # already recognizes - see _FATAL_ERROR_SUBSTRINGS).
+                raise FatalPilotError(f"segmentation {path.name}: {seg_error_text}")
             _check_fatal(seg_error_text, context=f"segmentation {path.name}")
             row["excluded"] = True
             row["exclude_reason"] = f"segmentation failed: {seg_error_text}"
             return row, []
 
-    pipeline_result = _run_erw_pipeline(
-        body, segments, extractors, nlp_backend, nlp_backend_name, path.stem
-    )
+    try:
+        pipeline_result = _run_erw_pipeline(
+            body, segments, extractors, nlp_backend, nlp_backend_name, path.stem
+        )
+    except FatalPilotError as exc:
+        exc.usage_rows = [
+            {"story_id": path.stem, "genre": genre, **usage} for usage in exc.usage_rows
+        ]
+        raise
     usage_rows = [
         {"story_id": path.stem, "genre": genre, **usage}
         for usage in pipeline_result["usage"]
@@ -532,7 +584,7 @@ def run_story(
     extraction_errors = _has_extraction_errors(pipeline_result)
     if extraction_errors:
         for err in extraction_errors:
-            _check_fatal(err, context=f"pipeline {path.name}")
+            _check_fatal(err, context=f"pipeline {path.name}", usage_rows=usage_rows)
         row["excluded"] = True
         row["exclude_reason"] = "; ".join(extraction_errors)
         return row, usage_rows
@@ -702,6 +754,10 @@ def main() -> int:
                     dry_run=args.dry_run,
                 )
             except FatalPilotError as exc:
+                # Preserve cost/latency for any passes that succeeded on
+                # this story before the fatal failure - see
+                # FatalPilotError's docstring.
+                usage_rows.extend(exc.usage_rows)
                 print(f"\nfatal: {exc}", file=sys.stderr)
                 print(
                     "Aborting - this looks like a bad/expired API key or an "

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -68,6 +68,9 @@ Exit codes:
     0   pilot completed (individual story exclusions are noted, not fatal)
     1   prerequisite check failed (missing install, missing key)
     2   could not fill every genre stratum before exhausting --max-candidates
+    3   aborted early on a fatal API error (bad credentials or exhausted
+        account balance/quota) - see FatalPilotError below. Any story
+        results gathered before the abort are still written out.
 """
 
 from __future__ import annotations
@@ -106,6 +109,42 @@ from lcats.utils.secrets import load_secrets
 GENRES = (
     corpus_assess.VALID_GENRES
 )  # ("science fiction", "horror", "western", "romance")
+
+# Substrings of an API error message that mean "stop the whole run", not
+# "skip this one story": bad/expired credentials or an exhausted account
+# balance/quota. Every remaining candidate would fail identically, so
+# continuing just burns time (and, with real credentials, still-billable
+# request attempts) for no new information. Matches both providers' actual
+# wording: Anthropic's "Your credit balance is too low..." (a 400
+# invalid_request_error, not the OpenAI-shaped insufficient_quota/402 that
+# lcats.analysis.llm_extractor.LLMExtractor._classify_api_error already
+# recognized) and common auth-failure phrasing.
+_FATAL_ERROR_SUBSTRINGS = (
+    "credit balance",
+    "insufficient_quota",
+    "invalid x-api-key",
+    "invalid api key",
+    "authentication_error",
+)
+
+
+class FatalPilotError(RuntimeError):
+    """Raised to abort the whole run on a non-retryable, account-level API
+    error, mirroring the should_abort_batch convention already used by
+    lcats.analysis.corpus.processing.process_corpus_directory (see
+    api_error.get("should_abort_batch") there) - this pilot script predates
+    that convention and previously had no equivalent, so a single exhausted
+    API key/balance silently produced a full sample of "excluded" stories
+    with no top-level indication of why.
+    """
+
+
+def _check_fatal(message: str, context: str) -> None:
+    """Raise FatalPilotError if `message` names a fatal, account-level
+    failure rather than a per-story problem."""
+    lowered = message.lower()
+    if any(s in lowered for s in _FATAL_ERROR_SUBSTRINGS):
+        raise FatalPilotError(f"{context}: {message}")
 
 
 def _build_backend(backend_name: str, model: Optional[str]):
@@ -171,6 +210,19 @@ def build_stratified_sample(
             result = corpus_assess.assess_story(path, backend=backend, model=model)
         except Exception as exc:  # noqa: BLE001 - skip this candidate on failure
             print(f"  [genre-detect] {path}: failed ({exc}), skipping", file=sys.stderr)
+            continue
+        if result.error:
+            # assess_story() catches API exceptions internally and reports
+            # them via AssessmentResult.error rather than raising, so a
+            # fatal error here would otherwise never reach the except above
+            # - it would just silently fail to classify every remaining
+            # candidate (detected_genre defaults to "other", which isn't in
+            # GENRES, so nothing prints and nothing is added to any bucket).
+            _check_fatal(result.error, context=f"genre-detect {path.name}")
+            print(
+                f"  [genre-detect] {path.name}: failed ({result.error}), skipping",
+                file=sys.stderr,
+            )
             continue
         genre = result.detected_genre
         if genre in sample and len(sample[genre]) < sample_size:
@@ -456,8 +508,17 @@ def run_story(
     else:
         segments, seg_error = _segment_story(body, backend, model)
         if seg_error or not segments:
+            # seg_error may be the classified api_error dict (see
+            # LLMExtractor._classify_api_error) or a plain string, depending
+            # on where in extract() the failure occurred.
+            seg_error_text = (
+                seg_error.get("message", str(seg_error))
+                if isinstance(seg_error, dict)
+                else str(seg_error)
+            )
+            _check_fatal(seg_error_text, context=f"segmentation {path.name}")
             row["excluded"] = True
-            row["exclude_reason"] = f"segmentation failed: {seg_error}"
+            row["exclude_reason"] = f"segmentation failed: {seg_error_text}"
             return row, []
 
     pipeline_result = _run_erw_pipeline(
@@ -470,6 +531,8 @@ def run_story(
 
     extraction_errors = _has_extraction_errors(pipeline_result)
     if extraction_errors:
+        for err in extraction_errors:
+            _check_fatal(err, context=f"pipeline {path.name}")
         row["excluded"] = True
         row["exclude_reason"] = "; ".join(extraction_errors)
         return row, usage_rows
@@ -574,15 +637,25 @@ def main() -> int:
             return 1
 
     print(f"Building stratified sample (target {args.sample_size} per genre)...")
-    sample, scanned = build_stratified_sample(
-        data_dir,
-        backend,
-        model,
-        args.sample_size,
-        args.max_candidates,
-        args.seed,
-        args.dry_run,
-    )
+    try:
+        sample, scanned = build_stratified_sample(
+            data_dir,
+            backend,
+            model,
+            args.sample_size,
+            args.max_candidates,
+            args.seed,
+            args.dry_run,
+        )
+    except FatalPilotError as exc:
+        print(f"\nfatal: {exc}", file=sys.stderr)
+        print(
+            "Aborting - this looks like a bad/expired API key or an "
+            "exhausted account balance/quota, not a per-story problem. "
+            "Every remaining candidate would fail identically.",
+            file=sys.stderr,
+        )
+        return 3
     print(f"Scanned {scanned} candidates.")
 
     incomplete_genres = [g for g in GENRES if len(sample[g]) < args.sample_size]
@@ -610,20 +683,35 @@ def main() -> int:
 
     rows: List[Dict[str, Any]] = []
     usage_rows: List[Dict[str, Any]] = []
+    aborted = False
     for genre in GENRES:
+        if aborted:
+            break
         for path in sample[genre]:
             print(f"Running pipeline: [{genre}] {path.name}")
             t0 = time.monotonic()
-            row, story_usage_rows = run_story(
-                path,
-                genre,
-                backend,
-                model,
-                extractors,
-                nlp_backend,
-                args.nlp_backend,
-                dry_run=args.dry_run,
-            )
+            try:
+                row, story_usage_rows = run_story(
+                    path,
+                    genre,
+                    backend,
+                    model,
+                    extractors,
+                    nlp_backend,
+                    args.nlp_backend,
+                    dry_run=args.dry_run,
+                )
+            except FatalPilotError as exc:
+                print(f"\nfatal: {exc}", file=sys.stderr)
+                print(
+                    "Aborting - this looks like a bad/expired API key or an "
+                    "exhausted account balance/quota, not a per-story "
+                    "problem. Every remaining story would fail identically. "
+                    "Results gathered so far are still written out below.",
+                    file=sys.stderr,
+                )
+                aborted = True
+                break
             row["elapsed_seconds"] = time.monotonic() - t0
             rows.append(row)
             usage_rows.extend(story_usage_rows)
@@ -671,6 +759,8 @@ def main() -> int:
     print(f"Wrote {usage_path}")
     print(f"Wrote {summary_path}")
 
+    if aborted:
+        return 3
     if incomplete_genres and not args.dry_run:
         return 2
     return 0

--- a/lcats/lcats/analysis/llm_extractor.py
+++ b/lcats/lcats/analysis/llm_extractor.py
@@ -186,7 +186,12 @@ class JSONPromptExtractor:
         suggested_action = "inspect_and_decide"
 
         # Quota/billing — abort batch
-        if "insufficient_quota" in code or "quota" in message or status == 402:
+        if (
+            "insufficient_quota" in code
+            or "quota" in message
+            or "credit balance" in message
+            or status == 402
+        ):
             category = "quota_exceeded"
             should_abort_batch = True
             suggested_action = "stop_job_fix_billing"

--- a/lcats/project/executions/AD_HOC/2026_07_26_23_24_58_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_23_24_58_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING.md
@@ -1,0 +1,89 @@
+---
+execution_id: 2026_07_26_23_24_58_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING)[2026-07-26T23:24:50-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of:
+pr:
+commit:
+agent: claude_app
+instruction_source: chat session (live dogfooding of WI-EVENT-0030's run_pilot.py, Step 4)
+session_transcript: pending
+created_at: 2026-07-26T23:24:58-04:00
+---
+
+# Summary
+
+Real Step-4 dogfooding of `run_pilot.py` hit an exhausted Anthropic account
+balance mid-run (400 `invalid_request_error`, "Your credit balance is too
+low"). The script had no concept of a fatal, account-level API error - it
+treated the credit exhaustion as a per-story exclusion and burned through
+every remaining candidate/story making the same doomed call, producing a
+confusing `included=0` report for every genre with no top-level indication
+of why. Add fatal-error detection and a clean early abort, reusing the
+`should_abort_batch` convention already established in
+`lcats/analysis/corpus/processing.py`.
+
+# Result
+
+- `lcats/lcats/analysis/llm_extractor.py`'s `_classify_api_error` only
+  recognized OpenAI's billing-error shape (`insufficient_quota` code, HTTP
+  402). Anthropic's actual "credit balance too low" error is a 400
+  `invalid_request_error` with neither of those markers, so it fell through
+  to `category="unknown"`, `should_abort_batch=False`. Added a
+  `"credit balance" in message` check to the existing quota branch so it now
+  classifies as `category="quota_exceeded"`, `should_abort_batch=True`.
+- `experiments/03_cross_segment_relation_pilot/run_pilot.py` had no
+  equivalent check at any of its three API call sites (genre-detection via
+  `assess_story`, segmentation, and the ERW extractor pipeline). Added a new
+  `FatalPilotError` exception and a `_check_fatal()` helper matching
+  substrings for exhausted quota/credit and bad/expired credentials, wired
+  into all three call sites. `main()` now catches `FatalPilotError` at both
+  the sample-building stage and the per-story loop, prints a clear
+  "aborting - bad credentials or exhausted balance" message, and still
+  writes out `pilot_stories.jsonl`/`pilot_usage.jsonl`/`pilot_summary.json`
+  for whatever partial results were gathered before the abort (new exit
+  code 3), instead of silently grinding through the whole remaining sample.
+- Fixed a small pre-existing type wrinkle noticed while doing this:
+  `_segment_story`'s error could be the classified `api_error` dict rather
+  than a string, so `row["exclude_reason"] = f"segmentation failed:
+  {seg_error}"` was dumping the raw dict repr into the exclusion reason.
+  Now extracts `.get("message", str(seg_error))` first.
+- Did not add an LCATS-level retry loop for `can_retry=True` responses
+  (rate limits/5xx): the Anthropic Python SDK already retries these
+  automatically (2 retries with exponential backoff, driven by the
+  server-supplied `x-should-retry` response header - confirmed directly in
+  a live `ANTHROPIC_LOG=debug` capture, where every 400 in that run carried
+  `x-should-retry: false` and was correctly not retried). A second, bespoke
+  retry layer on top would risk conflicting with that; the SDK's own
+  `max_retries` client option is the correct extension point if more
+  resilience is ever wanted.
+
+# Validation
+
+- `scripts/format --check --diff` / `scripts/lint` on both changed files -
+  clean.
+- `scripts/test` - 1436 tests pass.
+- `lrh validate` - 0 errors, 43 pre-existing unrelated warnings.
+- Manual check: `_check_fatal()` raises on Anthropic's real "credit balance
+  too low" message and on OpenAI's `insufficient_quota`, and does not raise
+  on an ordinary per-story message ("segmentation produced no segments").
+- Manual check: `JSONPromptExtractor._classify_api_error()` on a payload
+  shaped exactly like the real captured error (`status=400,
+  type=invalid_request_error, message="Your credit balance is too low..."`)
+  now returns `category="quota_exceeded"`, `should_abort_batch=True`.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- The original "stall then resume" during genre-detection (reported before
+  the credit exhaustion was found) is still unresolved - the
+  `ANTHROPIC_LOG=debug` capture available so far covers only a later run
+  where every call failed identically and fast (non-retryable), so it never
+  exercised the SDK's retry path. Re-run with credits restored (and
+  `ANTHROPIC_LOG=debug` still on) to settle it.
+- Still pending: WI-EVENT-0030's actual real run (Step 4), results
+  write-up (Step 6), and closeout to `resolved/` (Step 7) - none of this
+  PR's changes complete those, they only make a future attempt fail loud
+  and fast instead of silently.

--- a/lcats/project/executions/AD_HOC/2026_07_26_23_24_58_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_23_24_58_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING.md
@@ -4,8 +4,8 @@ prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING)[2026-07-26T23
 work_item: AD_HOC
 status: in_progress
 rerun_of:
-pr:
-commit:
+pr: https://github.com/xenotaur/LCATS/pull/166
+commit: 50ef2c2b
 agent: claude_app
 instruction_source: chat session (live dogfooding of WI-EVENT-0030's run_pilot.py, Step 4)
 session_transcript: pending

--- a/lcats/project/executions/AD_HOC/2026_07_26_23_35_59_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_23_35_59_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_REVIEW.md
@@ -1,0 +1,74 @@
+---
+execution_id: 2026_07_26_23_35_59_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_REVIEW)[2026-07-26T23:35:32-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_23_24_58_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING
+pr: https://github.com/xenotaur/LCATS/pull/166
+commit: a6b768ff
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/166
+session_transcript: pending
+created_at: 2026-07-26T23:35:59-04:00
+---
+
+# Summary
+
+Address PR #166 review feedback: two chatgpt-codex-connector comments (P1
+auth-detection gap, P2 late abort/dropped usage) and one
+copilot-pull-request-reviewer comment (missing unit test coverage).
+
+# Result
+
+- **P1 (chatgpt-codex-connector): auth failures not fully matched.**
+  `_FATAL_ERROR_SUBSTRINGS` used narrow phrases (`"invalid api key"`,
+  `"authentication_error"`) that miss real wordings like "authentication
+  failed" or "Incorrect API key provided". Widened to `"api key"` /
+  `"authentication"` (matching `_classify_api_error`'s own broader auth
+  check) and `"quota"` (matching its quota check). Additionally, for the
+  segmentation call site - which has the classified `api_error` dict
+  available, not just a message string - now trusts
+  `seg_error.get("should_abort_batch")` directly instead of re-deriving
+  fatality from text.
+- **P2 (chatgpt-codex-connector): fatal check happens too late in the ERW
+  pipeline.** `_run_erw_pipeline`'s per-segment loop previously ran
+  entity/event/relation/discourse extraction for every segment
+  unconditionally before `run_story` ever inspected the aggregated
+  `extraction_errors`. Moved the fatal check inside the per-segment loop
+  (checked right after each `process_segment()` call) and into the
+  story-relation block, so a multi-segment story aborts after the first
+  fatal failure instead of issuing several more doomed requests per
+  remaining segment.
+- **P2 (chatgpt-codex-connector): usage records dropped on abort.**
+  Raising `FatalPilotError` from inside `_run_erw_pipeline` previously
+  prevented `run_story` from returning any of `pipeline_result["usage"]`
+  for the passes that succeeded before the abort. `FatalPilotError` now
+  carries a `usage_rows` attribute; `_run_erw_pipeline` populates it with
+  usage accumulated so far before raising, `run_story` tags those rows with
+  `story_id`/`genre` when re-raising, and `main()`'s per-story except
+  handler extends its `usage_rows` list with them before writing
+  `pilot_usage.jsonl`.
+- **copilot-pull-request-reviewer: missing test coverage.** Added a
+  table-driven case (`anthropic_credit_balance`) and a dedicated
+  `test_anthropic_credit_balance_sets_abort_batch` test asserting Anthropic's
+  real error shape (`status=400`, `type=invalid_request_error`, "credit
+  balance" message) classifies as `category="quota_exceeded"`,
+  `should_abort_batch=True`.
+
+# Validation
+
+- `scripts/format --check --diff` / `scripts/lint` - clean (black
+  reformatted two files after edits; re-verified clean after).
+- `scripts/test` - 1438 tests pass (2 new).
+- Manual check: `_check_fatal()` now raises on "authentication failed" and
+  "Incorrect API key provided" (the exact reviewer-cited wordings), and
+  correctly carries a supplied `usage_rows` list through to the raised
+  exception.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/166`
+  to verify fixes against the current diff and resolve review threads, then
+  the merge gate, then closeout.

--- a/lcats/project/executions/AD_HOC/2026_07_26_23_38_55_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_26_23_38_55_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_CONFIRM.md
@@ -1,0 +1,61 @@
+---
+execution_id: 2026_07_26_23_38_55_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_CONFIRM)[2026-07-26T23:38:47-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_26_23_35_59_WI_EVENT_0030_PILOT_QUOTA_ABORT_HANDLING_REVIEW
+pr: https://github.com/xenotaur/LCATS/pull/166
+commit: afddfd42
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/166
+session_transcript: pending
+created_at: 2026-07-26T23:38:55-04:00
+---
+
+# Summary
+
+Confirm PR #166's review fixes against the current diff and resolve
+threads before merge.
+
+# Result
+
+Fetched threads via `lrh github threads <pr-url> --mode raw --state all`:
+4 total, all unresolved before this round. Verified each against the
+pushed fix at `afddfd42`:
+
+- P1 (auth substrings too narrow) - confirmed `_FATAL_ERROR_SUBSTRINGS` now
+  uses `"api key"`/`"authentication"`/`"quota"` (broad, matching the exact
+  reviewer-cited wordings "authentication failed" and "Incorrect API key
+  provided"), and the segmentation call site trusts
+  `seg_error.get("should_abort_batch")` directly when a structured dict is
+  available.
+- P2 (late abort in the ERW pipeline) - confirmed `_run_erw_pipeline`'s
+  per-segment loop now checks `annotation.extraction_errors` right after
+  each `process_segment()` call (and the story-relation block checks its
+  own error), rather than only after the whole story completes.
+- P2 (usage records dropped) - confirmed `FatalPilotError.usage_rows` is
+  populated with accumulated usage before raising in `_run_erw_pipeline`,
+  tagged with `story_id`/`genre` in `run_story`'s except block, and
+  extended into `main()`'s `usage_rows` list in its per-story except
+  handler.
+- copilot test-coverage request - confirmed
+  `test_anthropic_credit_balance_sets_abort_batch` and the
+  `anthropic_credit_balance` table-driven case exist in
+  `llm_extractor_test.py` and pass.
+
+Resolved all 4 threads via `gh api graphql resolveReviewThread`. Confirmed
+CI green (coverage/lint/test x2 all SUCCESS) at commit `afddfd42`.
+
+# Validation
+
+- `lrh github threads https://github.com/xenotaur/LCATS/pull/166 --mode raw --state all`
+  - 0 unresolved threads remain after resolution.
+- `gh pr checks https://github.com/xenotaur/LCATS/pull/166` -
+  coverage/lint/test x2 all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Merge gate: summarize PR #166 for the user and wait for explicit approval
+  before merging.

--- a/lcats/tests/analysis_tests/llm_extractor_test.py
+++ b/lcats/tests/analysis_tests/llm_extractor_test.py
@@ -323,6 +323,17 @@ class TestClassifyApiError(unittest.TestCase):
                 "quota_exceeded",
             ),
             ("status_402", {"status": 402}, "quota_exceeded"),
+            (
+                "anthropic_credit_balance",
+                {
+                    "status": 400,
+                    "type": "invalid_request_error",
+                    "message": "Your credit balance is too low to access "
+                    "the Anthropic API. Please go to Plans & Billing to "
+                    "upgrade or purchase credits.",
+                },
+                "quota_exceeded",
+            ),
             ("rate_limit_code", {"code": "rate_limit_exceeded"}, "rate_limit"),
             ("rate_limit_message", {"message": "rate limit reached"}, "rate_limit"),
             ("status_429", {"status": 429}, "rate_limit"),
@@ -362,6 +373,17 @@ class TestClassifyApiError(unittest.TestCase):
         result = self._classify(code="insufficient_quota")
         self.assertTrue(result["should_abort_batch"])
         self.assertFalse(result["can_retry"])
+
+    def test_anthropic_credit_balance_sets_abort_batch(self):
+        """Anthropic's "credit balance too low" 400 (not OpenAI's
+        insufficient_quota/402 shape) should also abort the batch."""
+        result = self._classify(
+            status=400,
+            type="invalid_request_error",
+            message="Your credit balance is too low to access the " "Anthropic API.",
+        )
+        self.assertEqual(result["category"], "quota_exceeded")
+        self.assertTrue(result["should_abort_batch"])
 
     def test_rate_limit_sets_can_retry(self):
         """Rate-limit errors should set can_retry=True."""


### PR DESCRIPTION
## Summary

- Live dogfooding of WI-EVENT-0030's `run_pilot.py` (Step 4, real run) hit an exhausted Anthropic account balance mid-run: every remaining API call failed with a non-retryable 400 `invalid_request_error` ("Your credit balance is too low..."), but the script had no way to distinguish that from an ordinary per-story failure — it burned through the whole remaining sample making the same doomed call and reported `included=0` for every genre with no top-level explanation.
- `lcats/analysis/llm_extractor.py`'s `_classify_api_error` only recognized OpenAI's billing-error shape (`insufficient_quota`/402); added a `"credit balance" in message` check so Anthropic's real error now classifies as `category="quota_exceeded"`, `should_abort_batch=True`.
- `run_pilot.py` now has a `FatalPilotError`/`_check_fatal()` mechanism wired into all three of its API call sites (genre-detection, segmentation, ERW pipeline), reusing the `should_abort_batch` convention already established in `lcats/analysis/corpus/processing.py:68-73`. On a fatal error it aborts cleanly (new exit code 3) with a clear message, while still writing out whatever partial results were gathered.
- Also fixed a small pre-existing wrinkle: `_segment_story`'s error could be a classified dict rather than a string, which was getting dumped raw into `exclude_reason`.

## Test plan

- [x] `scripts/format --check --diff` / `scripts/lint` — clean
- [x] `scripts/test` — 1436 tests pass
- [x] `lrh validate` — 0 errors, 43 pre-existing unrelated warnings
- [x] Manual check: `_check_fatal()` raises on the real captured Anthropic/OpenAI billing messages, not on ordinary per-story errors
- [x] Manual check: `_classify_api_error()` on a payload shaped like the real captured error now returns `should_abort_batch=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
