### PR TITLE
Fix crash on non-JSON model output during segmentation

### DIFF
--- a/lcats/lcats/analysis/llm_extractor.py
+++ b/lcats/lcats/analysis/llm_extractor.py
@@ -439,7 +439,7 @@ class JSONPromptExtractor:
             # utils.extract_json raises plain ValueError (not just its
             # json.JSONDecodeError subclass) when raw_output has no JSON at
             # all, or has multiple/mis-fenced code blocks - see
-            # lcats/utils/compat.py's extract_json. A model response that
+            # lcats.utils.compat.extract_json. A model response that
             # ignores the requested JSON format entirely (seen in practice:
             # a cheaper model returning prose instead of the segmentation
             # tool's expected structure) must fall through to the

--- a/lcats/lcats/analysis/llm_extractor.py
+++ b/lcats/lcats/analysis/llm_extractor.py
@@ -435,7 +435,16 @@ class JSONPromptExtractor:
         parsing_error = None
         try:
             parsed = utils.extract_json(raw_output) if raw_output else None
-        except json.JSONDecodeError as exc:
+        except ValueError as exc:
+            # utils.extract_json raises plain ValueError (not just its
+            # json.JSONDecodeError subclass) when raw_output has no JSON at
+            # all, or has multiple/mis-fenced code blocks - see
+            # lcats/utils/compat.py's extract_json. A model response that
+            # ignores the requested JSON format entirely (seen in practice:
+            # a cheaper model returning prose instead of the segmentation
+            # tool's expected structure) must fall through to the
+            # parsing_error path below like any other bad response, not
+            # crash the whole batch.
             parsed = None
             parsing_error = str(exc)
 

--- a/lcats/project/executions/AD_HOC/2026_07_27_00_12_40_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_00_12_40_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH.md
@@ -1,0 +1,72 @@
+---
+execution_id: 2026_07_27_00_12_40_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH)[2026-07-27T00:12:32-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of:
+pr:
+commit:
+agent: claude_app
+instruction_source: chat session (real Step-4 run with --model haiku after PR #166 landed)
+session_transcript: pending
+created_at: 2026-07-27T00:12:40-04:00
+---
+
+# Summary
+
+A real run of `run_pilot.py` with `--model claude-haiku-4-5-20251001` (a
+cheaper model suggested for shakedown runs) crashed with an uncaught
+`ValueError: No JSON found in the string.` on the very first story's
+segmentation call, killing the whole ~$2.50 run. Root cause: a
+pre-existing gap in `JSONPromptExtractor.extract()`, unrelated to PR #166's
+quota/abort work - it only caught `json.JSONDecodeError` around
+`utils.extract_json()`, but that function raises a plain `ValueError` (a
+JSONDecodeError superclass, not a subclass) when the model's raw output has
+no JSON and no fenced code block at all - exactly what happens when a
+cheaper model ignores the requested JSON format and returns prose instead.
+
+# Result
+
+- `lcats/analysis/llm_extractor.py`'s parse step (`except
+  json.JSONDecodeError`) widened to `except ValueError` - this still catches
+  `json.JSONDecodeError` (it's a `ValueError` subclass) and additionally
+  catches the "no JSON found at all" / "multiple code blocks" / "wrong
+  fence format" cases raised by `lcats/utils/compat.py::extract_json`. A
+  bad model response now falls through to the existing `parsing_error`
+  path (already fully supported downstream - `run_story` already turns a
+  non-empty `extraction_error` into a per-story exclusion) instead of
+  crashing the whole batch.
+- Added `test_no_json_at_all_sets_parsing_error` (plus keeping the
+  existing `test_invalid_json_sets_parsing_error` for the fenced-but-invalid
+  case) to `llm_extractor_test.py`, asserting a plain-prose response
+  produces `extraction_error="parsing_error"` rather than raising.
+- Note on process: this fix was first drafted on the wrong branch (this
+  worktree's original stale branch, which predates `run_pilot.py` and
+  WI-EVENT-0030 entirely) after switching back to it post-PR-166-closeout;
+  caught immediately via `lrh validate`'s test count dropping from 1439 to
+  1347, discarded with `git checkout --`, and redone cleanly from
+  `origin/main`.
+
+# Validation
+
+- `scripts/format --check --diff` / `scripts/lint` - clean.
+- `scripts/test` - 1439 tests pass (1 new).
+- `lrh validate` - 0 errors, 43 pre-existing unrelated warnings.
+- Manual repro: constructed a `JSONPromptExtractor` with a `FakeBackend`
+  returning plain prose (no JSON/fence at all) and confirmed
+  `extract()` now returns `extraction_error="parsing_error"` instead of
+  raising `ValueError`.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- The user's real run is still not complete - this fixes the crash but the
+  actual Step-4 pilot data collection (and Steps 5-7: results write-up and
+  WI-EVENT-0030 closeout) still needs a clean re-run after this lands.
+- Worth revisiting later: whether `scene_analysis.make_segment_extractor`
+  should pass a `tool` schema (structured tool-call output) rather than
+  relying on free-text JSON parsing, which would sidestep this whole class
+  of failure for models less reliable at unprompted JSON formatting - out
+  of scope for this fix (forbidden_actions on WI-EVENT-0030 restrict
+  touching the shared extractor/processor modules beyond what's needed).

--- a/lcats/project/executions/AD_HOC/2026_07_27_00_12_40_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_00_12_40_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH.md
@@ -27,11 +27,11 @@ cheaper model ignores the requested JSON format and returns prose instead.
 
 # Result
 
-- `lcats/analysis/llm_extractor.py`'s parse step (`except
-  json.JSONDecodeError`) widened to `except ValueError` - this still catches
-  `json.JSONDecodeError` (it's a `ValueError` subclass) and additionally
-  catches the "no JSON found at all" / "multiple code blocks" / "wrong
-  fence format" cases raised by `lcats/utils/compat.py::extract_json`. A
+- `lcats.analysis.llm_extractor.JSONPromptExtractor.extract()`'s parse step
+  (`except json.JSONDecodeError`) widened to `except ValueError` - this
+  still catches `json.JSONDecodeError` (it's a `ValueError` subclass) and
+  additionally catches the "no JSON found at all" / "multiple code blocks"
+  / "wrong fence format" cases raised by `lcats.utils.compat.extract_json`. A
   bad model response now falls through to the existing `parsing_error`
   path (already fully supported downstream - `run_story` already turns a
   non-empty `extraction_error` into a per-story exclusion) instead of

--- a/lcats/project/executions/AD_HOC/2026_07_27_00_12_40_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_00_12_40_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH.md
@@ -4,8 +4,8 @@ prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH)[2026-07-27
 work_item: AD_HOC
 status: in_progress
 rerun_of:
-pr:
-commit:
+pr: https://github.com/xenotaur/LCATS/pull/167
+commit: 017346f1
 agent: claude_app
 instruction_source: chat session (real Step-4 run with --model haiku after PR #166 landed)
 session_transcript: pending

--- a/lcats/project/executions/AD_HOC/2026_07_27_00_19_27_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_00_19_27_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_REVIEW.md
@@ -1,0 +1,45 @@
+---
+execution_id: 2026_07_27_00_19_27_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_REVIEW)[2026-07-27T00:19:03-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_27_00_12_40_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH
+pr: https://github.com/xenotaur/LCATS/pull/167
+commit: e84cba83
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/167
+session_transcript: pending
+created_at: 2026-07-27T00:19:27-04:00
+---
+
+# Summary
+
+Address PR #167 review feedback: two copilot-pull-request-reviewer comments,
+both flagging the same class of mistake (wrong file-path breadcrumbs).
+
+# Result
+
+Both comments pointed out that `lcats/utils/compat.py` and
+`lcats/analysis/llm_extractor.py` are missing this repo's nested
+`lcats/lcats/...` layout (one comment in the code, one in the execution
+record's prose). Rather than just adding the missing `lcats/` segment,
+switched both to dotted-module notation (`lcats.utils.compat.extract_json`,
+`lcats.analysis.llm_extractor.JSONPromptExtractor.extract()`) - this matches
+the file's own existing cross-reference convention (e.g. `run_pilot.py`
+already references `lcats.analysis.corpus.processing.process_corpus_directory`
+the same way) and has no repo-root-relative ambiguity to get wrong in the
+first place.
+
+# Validation
+
+- `scripts/format --check --diff` / `scripts/lint` - clean.
+- `scripts/test` - 1439 tests pass.
+- `lrh validate` - 0 errors, 43 pre-existing unrelated warnings.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/167`
+  to verify fixes against the current diff and resolve review threads, then
+  the merge gate, then closeout.

--- a/lcats/project/executions/AD_HOC/2026_07_27_00_22_05_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_00_22_05_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_CONFIRM.md
@@ -1,0 +1,46 @@
+---
+execution_id: 2026_07_27_00_22_05_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_CONFIRM)[2026-07-27T00:21:54-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_27_00_19_27_WI_EVENT_0030_SEGMENTATION_JSON_PARSE_CRASH_REVIEW
+pr: https://github.com/xenotaur/LCATS/pull/167
+commit: 83e55e3e
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/167
+session_transcript: pending
+created_at: 2026-07-27T00:22:05-04:00
+---
+
+# Summary
+
+Confirm PR #167's review fixes against the current diff and resolve
+threads before merge.
+
+# Result
+
+Fetched threads via `lrh github threads <pr-url> --mode raw --state all`:
+2 total, both unresolved before this round. Verified each against the
+pushed fix at `83e55e3e`: both flagged the same missing-nested-`lcats/`
+path mistake; confirmed both references now use dotted-module notation
+(`lcats.utils.compat.extract_json`,
+`lcats.analysis.llm_extractor.JSONPromptExtractor.extract()`) instead of a
+literal filesystem path, in both the code comment and the execution
+record's prose.
+
+Resolved both threads via `gh api graphql resolveReviewThread`. Confirmed
+CI green (coverage/lint/test x2 all SUCCESS) at commit `83e55e3e`.
+
+# Validation
+
+- `lrh github threads https://github.com/xenotaur/LCATS/pull/167 --mode raw --state all`
+  - 0 unresolved threads remain after resolution.
+- `gh pr checks https://github.com/xenotaur/LCATS/pull/167` -
+  coverage/lint/test x2 all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Merge gate: summarize PR #167 for the user and wait for explicit approval
+  before merging.

--- a/lcats/tests/analysis_tests/llm_extractor_test.py
+++ b/lcats/tests/analysis_tests/llm_extractor_test.py
@@ -633,6 +633,20 @@ class TestExtractErrorPaths(unittest.TestCase):
         self.assertEqual(result["extraction_error"], "parsing_error")
         self.assertIsNone(result["extracted_output"])
 
+    def test_no_json_at_all_sets_parsing_error(self):
+        """When the model ignores the requested format entirely and returns
+        plain prose (no JSON, no fenced code block at all), extract_json
+        raises a plain ValueError rather than json.JSONDecodeError - this
+        must be caught and turned into parsing_error like any other bad
+        response, not propagate and crash the caller."""
+        ext = _make_extractor(
+            response_text="Sure, here is a summary of the story you asked about."
+        )
+        result = ext.extract("story")
+        self.assertEqual(result["extraction_error"], "parsing_error")
+        self.assertIsNone(result["extracted_output"])
+        self.assertIn("No JSON found", result["parsing_error"])
+
     def test_empty_response_text_sets_api_error(self):
         """When backend returns empty text, api_error is set."""
         ext = _make_extractor(response_text="")


### PR DESCRIPTION
## Summary

- A real Step-4 pilot run with `--model claude-haiku-4-5-20251001` (a cheaper shakedown model) crashed on the very first story's segmentation call: `ValueError: No JSON found in the string.`, killing the whole ~$2.50 run.
- Root cause: `lcats/analysis/llm_extractor.py`'s `JSONPromptExtractor.extract()` only caught `json.JSONDecodeError` around `utils.extract_json()`, but `lcats/utils/compat.py::extract_json` raises a plain `ValueError` (a superclass of `JSONDecodeError`, not a subclass) when the model's raw output has no JSON and no fenced code block at all - exactly what a cheaper model can do when it ignores the requested format and returns prose instead.
- Widened the `except` to `ValueError` (still catches `JSONDecodeError` too) so this now falls through to the existing `parsing_error` path - already fully supported downstream (`run_story` already excludes a story on any non-empty `extraction_error`) - instead of crashing the batch.
- Unrelated to PR #166's quota/abort work; this is a separate, pre-existing bug newly triggered by using a less format-reliable model.

## Test plan

- [x] `scripts/format --check --diff` / `scripts/lint` — clean
- [x] `scripts/test` — 1439 tests pass (1 new: `test_no_json_at_all_sets_parsing_error`)
- [x] `lrh validate` — 0 errors, 43 pre-existing unrelated warnings
- [x] Manual repro: a `FakeBackend` returning plain prose now yields `extraction_error="parsing_error"` instead of raising

🤖 Generated with [Claude Code](https://claude.com/claude-code)
