### PR TITLE
Enable strict tool use to prevent malformed tool-result crashes

### DIFF
--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -323,9 +323,54 @@ def _compute_story_metrics(
     }
 
 
+def _close_schema_objects(node: Any) -> Any:
+    """Recursively return a deep copy of a JSON Schema fragment with
+    additionalProperties: false set on every object (top-level and
+    nested) - required by Anthropic's strict tool use before strict: true
+    takes effect. See _strict_tool_schema()'s docstring for why this is
+    needed."""
+    if isinstance(node, dict):
+        closed = {key: _close_schema_objects(value) for key, value in node.items()}
+        if closed.get("type") == "object":
+            closed.setdefault("additionalProperties", False)
+        return closed
+    if isinstance(node, list):
+        return [_close_schema_objects(item) for item in node]
+    return node
+
+
+def _strict_tool_schema(tool_schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a deep copy of `tool_schema` with strict: true enabled.
+
+    Without strict: true, Anthropic's tool use does not guarantee the
+    model's tool_use input matches input_schema - "Claude might return
+    incompatible types ... or omit required fields, breaking your
+    functions and causing runtime errors" (Anthropic docs, Strict tool
+    use). This is exactly what happened live: a relations array item came
+    back as a plain string instead of the required object, crashing
+    relation_extractor.build_relations()'s `raw.get("quote", ...)` with
+    AttributeError. Enabling strict: true constrains the model's token
+    sampling to schema-valid output via grammar-constrained sampling,
+    which would have prevented that malformed item outright.
+
+    strict: true additionally requires additionalProperties: false on
+    every object in the schema, including nested ones inside array items
+    (Anthropic docs, JSON Schema limitations) - none of the ERW tool
+    schemas set this today, so _close_schema_objects() adds it here rather
+    than editing each schema's module (forbidden by this work item; see
+    _build_erw_extractors()'s docstring for the same constraint applied to
+    default_model).
+    """
+    schema = _close_schema_objects(tool_schema)
+    schema["strict"] = True
+    return schema
+
+
 def _build_erw_extractors(backend: Any, model: str) -> Dict[str, Any]:
     """Build the Event-Role-World extractors, with `model` overriding each
-    factory's own hardcoded default_model (e.g. "gpt-4o").
+    factory's own hardcoded default_model (e.g. "gpt-4o") and each
+    extractor's tool_schema upgraded to strict: true (see
+    _strict_tool_schema()).
 
     processor.process_segments() has no model parameter - it builds these
     same extractors internally with each factory's hardcoded default,
@@ -344,6 +389,8 @@ def _build_erw_extractors(backend: Any, model: str) -> Dict[str, Any]:
     story_relation = erw_story_relation.make_story_relation_extractor(backend)
     for extractor in (entity, event, relation, discourse, story_relation):
         extractor.default_model = model
+        if extractor.tool_schema is not None:
+            extractor.tool_schema = _strict_tool_schema(extractor.tool_schema)
     return {
         "entity": entity,
         "event": event,

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -328,11 +328,23 @@ def _close_schema_objects(node: Any) -> Any:
     additionalProperties: false set on every object (top-level and
     nested) - required by Anthropic's strict tool use before strict: true
     takes effect. See _strict_tool_schema()'s docstring for why this is
-    needed."""
+    needed.
+
+    Sets additionalProperties unconditionally (not via setdefault) so an
+    existing, looser value (e.g. additionalProperties: true, or a schema
+    rather than a bare bool) can't silently defeat the requirement this
+    exists to enforce. Also matches "object" inside a union `type` list
+    (e.g. `type: ["object", "null"]`), not just a bare `type: "object"`
+    string, since JSON Schema permits either form.
+    """
     if isinstance(node, dict):
         closed = {key: _close_schema_objects(value) for key, value in node.items()}
-        if closed.get("type") == "object":
-            closed.setdefault("additionalProperties", False)
+        node_type = closed.get("type")
+        is_object = node_type == "object" or (
+            isinstance(node_type, list) and "object" in node_type
+        )
+        if is_object:
+            closed["additionalProperties"] = False
         return closed
     if isinstance(node, list):
         return [_close_schema_objects(item) for item in node]
@@ -366,11 +378,13 @@ def _strict_tool_schema(tool_schema: Dict[str, Any]) -> Dict[str, Any]:
     return schema
 
 
-def _build_erw_extractors(backend: Any, model: str) -> Dict[str, Any]:
+def _build_erw_extractors(
+    backend: Any, model: str, backend_name: str
+) -> Dict[str, Any]:
     """Build the Event-Role-World extractors, with `model` overriding each
-    factory's own hardcoded default_model (e.g. "gpt-4o") and each
-    extractor's tool_schema upgraded to strict: true (see
-    _strict_tool_schema()).
+    factory's own hardcoded default_model (e.g. "gpt-4o") and, for
+    --backend anthropic only, each extractor's tool_schema upgraded to
+    strict: true (see _strict_tool_schema()).
 
     processor.process_segments() has no model parameter - it builds these
     same extractors internally with each factory's hardcoded default,
@@ -381,6 +395,15 @@ def _build_erw_extractors(backend: Any, model: str) -> Dict[str, Any]:
     extractor instances) per segment ourselves, fixes this without
     touching processor.py or any event_role_world module (forbidden by
     this work item).
+
+    The strict-schema override is gated to backend_name == "anthropic"
+    because it is not a no-op for OpenAI: AnthropicBackend.complete()
+    forwards the whole tool dict verbatim, so an added top-level `strict`
+    key is inert there unless read, but OpenAIBackend.complete() forwards
+    `tool["input_schema"]` directly as its function `parameters` - the
+    `additionalProperties: false` this same override adds to input_schema
+    would reach OpenAI's schema too and could change its behavior in ways
+    this fix was never intended to touch or test.
     """
     entity = erw_entity.make_entity_extractor(backend)
     event = erw_event.make_event_extractor(backend)
@@ -389,7 +412,7 @@ def _build_erw_extractors(backend: Any, model: str) -> Dict[str, Any]:
     story_relation = erw_story_relation.make_story_relation_extractor(backend)
     for extractor in (entity, event, relation, discourse, story_relation):
         extractor.default_model = model
-        if extractor.tool_schema is not None:
+        if backend_name == "anthropic" and extractor.tool_schema is not None:
             extractor.tool_schema = _strict_tool_schema(extractor.tool_schema)
     return {
         "entity": entity,
@@ -775,7 +798,7 @@ def main() -> int:
     # per-story timer starts below, so per-story elapsed_seconds no longer
     # includes it - print an explicit confirmation instead, since spaCy
     # (unlike Stanza) prints no loading banner of its own.
-    extractors = _build_erw_extractors(backend, model)
+    extractors = _build_erw_extractors(backend, model, args.backend)
     print(f"Loading NLP backend: {args.nlp_backend}...")
     nlp_backend = _make_nlp_backend(args.nlp_backend)
     print(f"NLP backend ready: {args.nlp_backend}")

--- a/lcats/project/executions/AD_HOC/2026_07_27_03_18_44_WI_EVENT_0030_STRICT_TOOL_SCHEMAS.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_03_18_44_WI_EVENT_0030_STRICT_TOOL_SCHEMAS.md
@@ -1,0 +1,102 @@
+---
+execution_id: 2026_07_27_03_18_44_WI_EVENT_0030_STRICT_TOOL_SCHEMAS
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_STRICT_TOOL_SCHEMAS)[2026-07-27T03:18:35-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of:
+pr:
+commit:
+agent: claude_app
+instruction_source: chat session (real Step-4 run, second crash after PR #167 landed)
+session_transcript: pending
+created_at: 2026-07-27T03:18:44-04:00
+---
+
+# Summary
+
+A real pilot run crashed again, this time during the ERW pipeline stage:
+`AttributeError: 'str' object has no attribute 'get'` in
+`relation_extractor.build_relations()` at
+`evidence = cursor.resolve(raw.get("quote", ""), segment_text)`. The
+model returned a plain string as one item of the `relations` array
+instead of the required object, and `build_relations()` has no defensive
+type check.
+
+# Result
+
+Root-caused via Anthropic's own documentation: by default, tool use does
+not guarantee the model's `tool_use` input strictly matches the declared
+`input_schema` - "Claude might return incompatible types ... or omit
+required fields, breaking your functions and causing runtime errors"
+(Strict tool use docs). Schema conformance is only *guaranteed* when
+`strict: true` is set on the tool definition, which none of the 5
+Event-Role-World tool schemas (entity/event/relation/discourse/
+story_relation) do. `strict: true` additionally requires
+`additionalProperties: false` on every object in the schema, including
+nested ones inside array items (JSON Schema limitations docs) - none of
+these schemas set that either.
+
+Cannot edit the schemas' own modules
+(`lcats/analysis/event_role_world/*.py`) directly - forbidden by this
+work item's `forbidden_actions: modify_event_role_world_extractor`, the
+same constraint that shaped `_build_erw_extractors()`'s existing
+`default_model` override. Applied the identical pattern for schemas:
+added `_close_schema_objects()` (recursively adds
+`additionalProperties: false` to every object, top-level and nested) and
+`_strict_tool_schema()` (applies that closure, then sets `strict: true`)
+to `run_pilot.py`, and call it on each extractor's `.tool_schema` in
+`_build_erw_extractors()` right after the existing `default_model`
+override - a deep copy assigned to the extractor instance, leaving each
+module's own `*_TOOL_SCHEMA` constant untouched.
+
+Confirmed the fix actually reaches the API: `AnthropicBackend.complete()`
+forwards the whole tool dict verbatim as `tools=[tool]`, so the injected
+`strict`/`additionalProperties` keys pass through unmodified.
+`OpenAIBackend.complete()` explicitly picks only `name`/`description`/
+`input_schema` when building its own function-call dict, so this change
+has no effect (and no risk of breaking anything) for `--backend openai`.
+
+Did not touch `scene_analysis.make_segment_extractor` (the Stage-1
+segmentation extractor that crashed in the *previous* PR #167 fix) -
+that extractor does not use `tool_schema=` at all (plain JSON-in-text
+parsing instead), so strict tool use doesn't apply to it.
+
+# Validation
+
+- `scripts/format --check --diff` / `scripts/lint` - clean.
+- `scripts/test` - 1439 tests pass (no regressions; no new test file added
+  since `experiments/03_cross_segment_relation_pilot/` has no existing
+  test suite of its own, consistent with the rest of this pilot script).
+- `lrh validate` - 0 errors, 43 pre-existing unrelated warnings.
+- Manual check: `_strict_tool_schema()` applied to the real
+  `RELATION_TOOL_SCHEMA` produces `additionalProperties: false` at both
+  the top-level `input_schema` and the nested `relations` array's item
+  object, plus `strict: true` alongside `name`/`description` - matching
+  Anthropic's own documented example shape exactly.
+- Manual check: confirmed the original module-level `RELATION_TOOL_SCHEMA`
+  dict is unmodified after calling `_strict_tool_schema()` on it (deep
+  copy, not in-place mutation).
+- Ran `--dry-run --sample-size 1 --data-dir corpora` end to end - all 4
+  genres complete with 0 exclusions, no regression to existing control
+  flow (FakeBackend ignores `tool=` entirely, so this only verifies
+  `_build_erw_extractors()` and the rest of the pipeline still run
+  cleanly with the new schema-copy step in place).
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- This does not eliminate every possible crash from a malformed tool
+  result (strict mode is Anthropic-specific and this pilot also supports
+  `--backend openai`), but it addresses the actual, reproduced failure
+  mode using the mechanism Anthropic's own docs recommend for exactly
+  this class of bug.
+- Worth raising outside this work item's scope: the ERW extractor
+  modules' own tool schemas (`entity_extractor.py`,
+  `event_extractor.py`, etc.) could set `strict: true` +
+  `additionalProperties: false` permanently at the source, benefiting
+  every caller, not just this pilot script's runtime override - out of
+  scope here due to `forbidden_actions: modify_event_role_world_extractor`.
+- The user's real run is still not complete - Steps 5-7 (results
+  write-up, WI-EVENT-0030 closeout) still need a clean re-run after this
+  lands.

--- a/lcats/project/executions/AD_HOC/2026_07_27_03_18_44_WI_EVENT_0030_STRICT_TOOL_SCHEMAS.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_03_18_44_WI_EVENT_0030_STRICT_TOOL_SCHEMAS.md
@@ -4,8 +4,8 @@ prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_STRICT_TOOL_SCHEMAS)[2026-07-27T03:18:35-
 work_item: AD_HOC
 status: in_progress
 rerun_of:
-pr:
-commit:
+pr: https://github.com/xenotaur/LCATS/pull/168
+commit: 2771fcd5
 agent: claude_app
 instruction_source: chat session (real Step-4 run, second crash after PR #167 landed)
 session_transcript: pending

--- a/lcats/project/executions/AD_HOC/2026_07_27_03_51_25_WI_EVENT_0030_STRICT_TOOL_SCHEMAS_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_03_51_25_WI_EVENT_0030_STRICT_TOOL_SCHEMAS_REVIEW.md
@@ -1,0 +1,67 @@
+---
+execution_id: 2026_07_27_03_51_25_WI_EVENT_0030_STRICT_TOOL_SCHEMAS_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_STRICT_TOOL_SCHEMAS_REVIEW)[2026-07-27T03:50:59-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_27_03_18_44_WI_EVENT_0030_STRICT_TOOL_SCHEMAS
+pr: https://github.com/xenotaur/LCATS/pull/168
+commit: 98dcd6cf
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/168
+session_transcript: pending
+created_at: 2026-07-27T03:51:25-04:00
+---
+
+# Summary
+
+Address PR #168 review feedback: two copilot-pull-request-reviewer
+comments, both real correctness gaps in the strict-schema override logic
+itself.
+
+# Result
+
+- **`_close_schema_objects()` used `setdefault` for `additionalProperties`,
+  and only matched a bare `type: "object"` string.** A pre-existing looser
+  value (e.g. `additionalProperties: true`) would have silently survived,
+  defeating the exact requirement strict mode depends on; a union type
+  like `type: ["object", "null"]` would also have been missed. Fixed to
+  set `additionalProperties` unconditionally, and to detect "object"
+  inside a type list as well as a bare string. None of the 5 real ERW
+  schemas currently trigger either case, but the fix closes a latent gap
+  rather than relying on that being permanently true.
+- **The PR's own write-up claimed the strict-schema override was a no-op
+  for `--backend openai`, which was wrong.** `AnthropicBackend.complete()`
+  does forward the tool dict verbatim (so an added top-level `strict` key
+  is inert unless read), but `OpenAIBackend.complete()` forwards
+  `tool["input_schema"]` directly as its function `parameters` - the
+  `additionalProperties: false` this same code injects into `input_schema`
+  would have reached OpenAI's schema too, an untested and unintended
+  behavior change. Rather than just correcting the prose, gated the whole
+  override to `backend_name == "anthropic"` in `_build_erw_extractors()`
+  (now takes a `backend_name` parameter, threaded from `main()`'s
+  `args.backend`), removing the risk entirely instead of merely
+  documenting it.
+
+# Validation
+
+- `scripts/format --check --diff` / `scripts/lint` - clean (black
+  reformatted one function signature; re-verified clean after).
+- `scripts/test` - 1439 tests pass, no regressions.
+- `lrh validate` - 0 errors, 43 pre-existing unrelated warnings.
+- Manual checks: union-type schema (`type: ["object", "null"]`) now
+  closes correctly; a schema with pre-existing `additionalProperties: true`
+  is now forced to `False`; `--backend openai` extractors are confirmed to
+  have neither `strict` nor `additionalProperties` injected, while
+  `--backend anthropic` extractors still get both; the module-level
+  `RELATION_TOOL_SCHEMA` constant remains unmutated after building
+  extractors for both backends.
+- Re-ran `--dry-run --sample-size 1 --data-dir corpora` end to end after
+  the fix - still completes cleanly, 0 exclusions.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Proceed to `/lrh-confirm-fixes https://github.com/xenotaur/LCATS/pull/168`
+  to verify fixes against the current diff and resolve review threads, then
+  the merge gate, then closeout.

--- a/lcats/project/executions/AD_HOC/2026_07_27_03_54_05_WI_EVENT_0030_STRICT_TOOL_SCHEMAS_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_03_54_05_WI_EVENT_0030_STRICT_TOOL_SCHEMAS_CONFIRM.md
@@ -1,0 +1,55 @@
+---
+execution_id: 2026_07_27_03_54_05_WI_EVENT_0030_STRICT_TOOL_SCHEMAS_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0030_STRICT_TOOL_SCHEMAS_CONFIRM)[2026-07-27T03:53:55-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_27_03_51_25_WI_EVENT_0030_STRICT_TOOL_SCHEMAS_REVIEW
+pr: https://github.com/xenotaur/LCATS/pull/168
+commit: 183582d3
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/168
+session_transcript: pending
+created_at: 2026-07-27T03:54:05-04:00
+---
+
+# Summary
+
+Confirm PR #168's review fixes against the current diff and resolve
+threads before merge.
+
+# Result
+
+Fetched threads via `lrh github threads <pr-url> --mode raw --state all`:
+2 total, both unresolved before this round. Verified each against the
+pushed fix at `183582d3`:
+
+- `additionalProperties` unconditional-set + union-type fix - confirmed
+  `_close_schema_objects()` no longer uses `setdefault`, and checks both
+  a bare `type: "object"` string and `"object"` inside a `type` list.
+- OpenAI no-op claim - confirmed `_build_erw_extractors()` now takes
+  `backend_name` and only applies `_strict_tool_schema()` when it equals
+  `"anthropic"`, with `main()` passing `args.backend` through.
+
+Resolved both threads via `gh api graphql resolveReviewThread`. Confirmed
+CI green (coverage/lint/test x2 all SUCCESS) at commit `183582d3`.
+
+# Validation
+
+- `lrh github threads https://github.com/xenotaur/LCATS/pull/168 --mode raw --state all`
+  - 0 unresolved threads remain after resolution.
+- `gh pr checks https://github.com/xenotaur/LCATS/pull/168` -
+  coverage/lint/test x2 all SUCCESS.
+
+# Follow-up
+
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after this session ends.
+- Merge gate: summarize PR #168 for the user and wait for explicit approval
+  before merging.
+- Reminder (per user, 2026-07-27): after this lands, come back and
+  properly fix the ERW extractor schemas at the source (add
+  `strict: true` + `additionalProperties: false` directly in
+  `entity_extractor.py`/`event_extractor.py`/`relation_extractor.py`/
+  `discourse_extractor.py`/`story_relation_extractor.py`), via a new,
+  properly scoped work item outside WI-EVENT-0030 - see
+  `project_erw_extractor_schemas_strict_mode_followup` memory.


### PR DESCRIPTION
## Summary

- A real Step-4 pilot run crashed again after PR #167 landed: `AttributeError: 'str' object has no attribute 'get'` inside `relation_extractor.build_relations()` - the model returned a plain string as one item of the `relations` array instead of the required object.
- Per Anthropic's docs, tool use does **not** guarantee the model's `tool_use` input strictly matches the declared `input_schema` unless `strict: true` is set: *"Claude might return incompatible types ... or omit required fields, breaking your functions and causing runtime errors"* (Strict tool use docs). None of the 5 Event-Role-World tool schemas (entity/event/relation/discourse/story_relation) set `strict: true`, and none set the `additionalProperties: false` it additionally requires on every object (including nested ones inside array items - JSON Schema limitations docs).
- Can't edit the schemas' own modules directly - forbidden by WI-EVENT-0030's `forbidden_actions: modify_event_role_world_extractor`, the same constraint that already shaped `_build_erw_extractors()`'s existing `default_model` runtime override.
- Applied the identical pattern for schemas: `run_pilot.py` now deep-copies each extractor's `.tool_schema`, recursively closes every object with `additionalProperties: false`, and sets `strict: true` - all as a per-instance runtime override, leaving each module's own `*_TOOL_SCHEMA` constant untouched.
- Confirmed this actually reaches the API: `AnthropicBackend.complete()` forwards the whole tool dict verbatim; `OpenAIBackend.complete()` only picks specific keys, so this is a no-op (not a regression) for `--backend openai`.

## Test plan

- [x] `scripts/format --check --diff` / `scripts/lint` — clean
- [x] `scripts/test` — 1439 tests pass, no regressions
- [x] `lrh validate` — 0 errors, 43 pre-existing unrelated warnings
- [x] Manual check: `_strict_tool_schema()` on the real `RELATION_TOOL_SCHEMA` produces the exact shape from Anthropic's own docs example (`additionalProperties: false` at both levels, `strict: true` alongside `name`/`description`)
- [x] Manual check: original module-level schema constant is unmodified (deep copy, not in-place mutation)
- [x] `--dry-run --sample-size 1 --data-dir corpora` completes cleanly end to end, 0 exclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
