### PR TITLE
Detect max_tokens truncation in tool-use responses

### DIFF
--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -110,6 +110,17 @@ GENRES = (
     corpus_assess.VALID_GENRES
 )  # ("science fiction", "horror", "western", "romance")
 
+# JSONPromptExtractor's own default (4096) is far below what a content-dense
+# segment can need for entity/event/relation extraction, and silently
+# truncating mid-tool-call now raises TruncatedResponseError (see
+# lcats.llm.backend) instead of returning malformed JSON - so a request that
+# used to fail data-integrity checks downstream now fails loudly and
+# immediately unless given real headroom. 16384 is well under
+# claude-opus-4-8's 128k output ceiling and costs nothing extra for calls
+# that finish early (Anthropic bills actual output tokens generated, not
+# this ceiling).
+_ERW_MAX_TOKENS = 16384
+
 # Substrings of an API error message that mean "stop the whole run", not
 # "skip this one story": bad/expired credentials or an exhausted account
 # balance/quota. Every remaining candidate would fail identically, so
@@ -382,9 +393,11 @@ def _build_erw_extractors(
     backend: Any, model: str, backend_name: str
 ) -> Dict[str, Any]:
     """Build the Event-Role-World extractors, with `model` overriding each
-    factory's own hardcoded default_model (e.g. "gpt-4o") and, for
-    --backend anthropic only, each extractor's tool_schema upgraded to
-    strict: true (see _strict_tool_schema()).
+    factory's own hardcoded default_model (e.g. "gpt-4o"), max_tokens raised
+    to _ERW_MAX_TOKENS (each factory's own default of 4096 is too low for
+    content-dense segments and risks TruncatedResponseError - see
+    lcats.llm.backend), and, for --backend anthropic only, each extractor's
+    tool_schema upgraded to strict: true (see _strict_tool_schema()).
 
     processor.process_segments() has no model parameter - it builds these
     same extractors internally with each factory's hardcoded default,
@@ -412,6 +425,7 @@ def _build_erw_extractors(
     story_relation = erw_story_relation.make_story_relation_extractor(backend)
     for extractor in (entity, event, relation, discourse, story_relation):
         extractor.default_model = model
+        extractor.max_tokens = _ERW_MAX_TOKENS
         if backend_name == "anthropic" and extractor.tool_schema is not None:
             extractor.tool_schema = _strict_tool_schema(extractor.tool_schema)
     return {

--- a/lcats/lcats/analysis/llm_extractor.py
+++ b/lcats/lcats/analysis/llm_extractor.py
@@ -226,6 +226,14 @@ class JSONPromptExtractor:
             can_retry = True
             suggested_action = "retry_with_backoff"
 
+        # Truncated tool-use output — max_tokens hit mid-generation. Not
+        # retryable with the same request (would truncate identically);
+        # the caller must raise max_tokens and retry.
+        elif code == "truncated_output":
+            category = "truncated_output"
+            can_retry = False
+            suggested_action = "retry_with_higher_max_tokens"
+
         return {
             **payload,
             "category": category,
@@ -244,6 +252,19 @@ class JSONPromptExtractor:
         Returns:
             A normalized error dict.
         """
+        if isinstance(exc, llm_backend.TruncatedResponseError):
+            payload = {
+                "status": None,
+                "code": "truncated_output",
+                "type": "truncated_output",
+                "message": str(exc),
+                "raw": {
+                    "stop_reason": exc.stop_reason,
+                    "max_tokens": exc.max_tokens,
+                },
+            }
+            return self._classify_api_error(payload)
+
         # Best-effort defaults
         status = getattr(exc, "status_code", None) or getattr(exc, "http_status", None)
         code = getattr(exc, "code", None)

--- a/lcats/lcats/analysis/llm_extractor.py
+++ b/lcats/lcats/analysis/llm_extractor.py
@@ -262,6 +262,12 @@ class JSONPromptExtractor:
                     "stop_reason": exc.stop_reason,
                     "max_tokens": exc.max_tokens,
                 },
+                # The provider already billed these output tokens despite
+                # the call failing - surfaced so callers with usage/cost
+                # tracking (e.g. event_role_world.processor) don't silently
+                # record zero tokens for a truncated-but-charged call.
+                "input_tokens": exc.input_tokens,
+                "output_tokens": exc.output_tokens,
             }
             return self._classify_api_error(payload)
 
@@ -371,13 +377,19 @@ class JSONPromptExtractor:
 
         except Exception as exc:
             api_error = self._normalize_api_error(exc)
+            usage = None
+            if "input_tokens" in api_error and "output_tokens" in api_error:
+                usage = {
+                    "input_tokens": api_error["input_tokens"],
+                    "output_tokens": api_error["output_tokens"],
+                }
             return {
                 "story_text": story_text,
                 "model_name": model,
                 "messages": messages,
                 "response": None,
                 "response_id": None,
-                "usage": None,
+                "usage": usage,
                 "raw_output": "",
                 "parsed_output": None,
                 "extracted_output": None,

--- a/lcats/lcats/llm/anthropic_backend.py
+++ b/lcats/lcats/llm/anthropic_backend.py
@@ -88,6 +88,8 @@ class AnthropicBackend:
                     "generating; its input may be incomplete or invalid.",
                     stop_reason=message.stop_reason,
                     max_tokens=max_tokens,
+                    input_tokens=message.usage.input_tokens,
+                    output_tokens=message.usage.output_tokens,
                 )
             tool_block = next(
                 (block for block in message.content if block.type == "tool_use"),

--- a/lcats/lcats/llm/anthropic_backend.py
+++ b/lcats/lcats/llm/anthropic_backend.py
@@ -80,6 +80,15 @@ class AnthropicBackend:
             message = self._client.messages.create(**kwargs)
 
         if tool is not None:
+            if message.stop_reason == "max_tokens":
+                raise backend.TruncatedResponseError(
+                    f"Anthropic response for model {model!r} was truncated "
+                    f"at the max_tokens limit ({max_tokens}) before the "
+                    f"tool_use block for {tool['name']!r} finished "
+                    "generating; its input may be incomplete or invalid.",
+                    stop_reason=message.stop_reason,
+                    max_tokens=max_tokens,
+                )
             tool_block = next(
                 (block for block in message.content if block.type == "tool_use"),
                 None,

--- a/lcats/lcats/llm/backend.py
+++ b/lcats/lcats/llm/backend.py
@@ -15,12 +15,28 @@ class TruncatedResponseError(RuntimeError):
     or holding malformed JSON (e.g. a string field cut off mid-value with no
     closing quote/bracket). Callers should retry the same request with a
     higher `max_tokens`, not attempt to parse or repair the existing result.
+
+    input_tokens/output_tokens carry the usage the provider already reported
+    for this (truncated) call, so callers with cost/usage tracking don't
+    silently undercount a call that was billed despite failing - the
+    response that hit max_tokens still consumed and was charged for those
+    output tokens.
     """
 
-    def __init__(self, message: str, *, stop_reason: str, max_tokens: int):
+    def __init__(
+        self,
+        message: str,
+        *,
+        stop_reason: str,
+        max_tokens: int,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+    ):
         super().__init__(message)
         self.stop_reason = stop_reason
         self.max_tokens = max_tokens
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
 
 
 @dataclasses.dataclass

--- a/lcats/lcats/llm/backend.py
+++ b/lcats/lcats/llm/backend.py
@@ -7,6 +7,22 @@ import dataclasses
 from typing import Any, Optional, Protocol, runtime_checkable
 
 
+class TruncatedResponseError(RuntimeError):
+    """Raised when a backend's response was cut off before completion.
+
+    Typically caused by hitting the max_tokens ceiling mid-generation while a
+    tool_use block was still being produced, leaving `tool_result` incomplete
+    or holding malformed JSON (e.g. a string field cut off mid-value with no
+    closing quote/bracket). Callers should retry the same request with a
+    higher `max_tokens`, not attempt to parse or repair the existing result.
+    """
+
+    def __init__(self, message: str, *, stop_reason: str, max_tokens: int):
+        super().__init__(message)
+        self.stop_reason = stop_reason
+        self.max_tokens = max_tokens
+
+
 @dataclasses.dataclass
 class BackendResponse:
     """Normalized result of an LLMBackend.complete() call.

--- a/lcats/lcats/llm/openai_backend.py
+++ b/lcats/lcats/llm/openai_backend.py
@@ -67,6 +67,7 @@ class OpenAIBackend:
 
         if tool is not None:
             if choice.finish_reason == "length":
+                usage = response.usage
                 raise backend.TruncatedResponseError(
                     f"OpenAI response for model {model!r} was truncated at "
                     f"the max_tokens limit ({max_tokens}) before the tool "
@@ -74,6 +75,8 @@ class OpenAIBackend:
                     "arguments may be incomplete or invalid JSON.",
                     stop_reason=choice.finish_reason,
                     max_tokens=max_tokens,
+                    input_tokens=usage.prompt_tokens if usage else 0,
+                    output_tokens=usage.completion_tokens if usage else 0,
                 )
             tool_calls = choice.message.tool_calls
             if not tool_calls:

--- a/lcats/lcats/llm/openai_backend.py
+++ b/lcats/lcats/llm/openai_backend.py
@@ -66,6 +66,15 @@ class OpenAIBackend:
         choice = response.choices[0]
 
         if tool is not None:
+            if choice.finish_reason == "length":
+                raise backend.TruncatedResponseError(
+                    f"OpenAI response for model {model!r} was truncated at "
+                    f"the max_tokens limit ({max_tokens}) before the tool "
+                    f"call for {tool['name']!r} finished generating; its "
+                    "arguments may be incomplete or invalid JSON.",
+                    stop_reason=choice.finish_reason,
+                    max_tokens=max_tokens,
+                )
             tool_calls = choice.message.tool_calls
             if not tool_calls:
                 raise ValueError(

--- a/lcats/project/executions/AD_HOC/2026_07_27_18_54_02_ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_18_54_02_ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION.md
@@ -1,0 +1,69 @@
+---
+execution_id: 2026_07_27_18_54_02_ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION
+prompt_id: PROMPT(AD_HOC:ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION)[2026-07-27T18:34:09-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/170
+commit: ad57425b
+agent: claude_app
+instruction_source: 2026-07-27-erw-pipeline-structured-output-reliability-audit.md, followed by a confirmed implementation plan presented in-session
+session_transcript: pending
+created_at: 2026-07-27T18:54:02-04:00
+---
+
+# Summary
+
+Implement the fix identified by the ERW pipeline structured-output reliability
+audit (PR #169): the real WI-EVENT-0030 pilot crashed 3x on malformed tool-use
+output because Anthropic silently truncates a tool_use response mid-generation
+when it hits the max_tokens ceiling, and `AnthropicBackend.complete()` never
+checked `stop_reason` for this. Add truncation detection to both LLM backends,
+a new error classification category, and raise the ERW extractors' max_tokens
+ceiling so real segments have headroom.
+
+# Result
+
+- `lcats/lcats/llm/backend.py`: added `TruncatedResponseError(RuntimeError)`
+  carrying `stop_reason`/`max_tokens`, shared by both backend adapters.
+- `lcats/lcats/llm/anthropic_backend.py`: `complete()` now raises
+  `TruncatedResponseError` when a tool was requested and
+  `message.stop_reason == "max_tokens"`, before attempting to read the
+  (possibly incomplete/invalid) tool_use block.
+- `lcats/lcats/llm/openai_backend.py`: symmetric check on
+  `choice.finish_reason == "length"` when a tool was requested.
+- `lcats/lcats/analysis/llm_extractor.py`: `_normalize_api_error` recognizes
+  `TruncatedResponseError` directly (bypassing the generic status/code/message
+  inference path); `_classify_api_error` gained a new `truncated_output`
+  category (`can_retry=False`, `should_abort_batch=False`,
+  `suggested_action="retry_with_higher_max_tokens"`) — distinct from existing
+  categories, none of which mean "same request, bigger max_tokens."
+- `experiments/03_cross_segment_relation_pilot/run_pilot.py`: `_build_erw_extractors`
+  now sets `extractor.max_tokens = _ERW_MAX_TOKENS` (16384) for all five ERW
+  extractors, up from `JSONPromptExtractor`'s default of 4096. Anthropic bills
+  actual output tokens generated, not this ceiling, so this is free for calls
+  that finish early; `claude-opus-4-8` supports up to 128k output tokens.
+- No auto-retry logic was added inside either backend — they raise and
+  classify clearly; the caller (a future pilot run/retry loop) decides whether
+  to retry with a bumped max_tokens, matching the existing `FatalPilotError`
+  pattern of explicit signaling over silent auto-retry.
+
+# Validation
+
+- `pytest tests/llm_tests/anthropic_backend_test.py tests/llm_tests/openai_backend_test.py tests/analysis_tests/llm_extractor_test.py` (run from `lcats/`) — 110 passed, including new truncation-detection tests for both backends (tool-requested vs. no-tool paths) and the new classification category.
+- `scripts/test` (from `lcats/`) — full suite, 1446 passed.
+- `scripts/lint` (from `lcats/`) — ruff clean; black flags one pre-existing, unrelated file (`lcats/gettenberg/metadata.py`) due to known formatter version skew, not touched by this change.
+- `lrh validate` (from `lcats/`) — no new errors/warnings introduced by this change (pre-existing `current_focus.md`/owner-role warnings unrelated).
+
+# Follow-up
+
+- The real WI-EVENT-0030 pilot run still needs to be attempted again with this
+  fix in place — it has never completed successfully. This PR only fixes the
+  detection/signaling; running the pilot end-to-end and confirming no more
+  truncation crashes occur is the next concrete step.
+- No retry loop exists yet for the `truncated_output` category — a caller
+  hitting it today still has the run fail for that segment/story. Whether to
+  add an automatic retry-with-higher-max_tokens loop in `run_pilot.py` is an
+  open follow-up, deliberately deferred per the confirmed plan (raise and
+  classify now; decide on retry policy separately, informed by how often this
+  actually recurs at 16384).

--- a/lcats/project/executions/AD_HOC/2026_07_27_19_03_18_ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_19_03_18_ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION_REVIEW.md
@@ -1,0 +1,64 @@
+---
+execution_id: 2026_07_27_19_03_18_ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION_REVIEW
+prompt_id: PROMPT(AD_HOC:ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION_REVIEW)[2026-07-27T19:03:06-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_27_18_54_02_ANTHROPIC_MAX_TOKENS_TRUNCATION_DETECTION
+pr: https://github.com/xenotaur/LCATS/pull/170
+commit: 1d9a14ed
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/170
+session_transcript: pending
+created_at: 2026-07-27T19:03:18-04:00
+---
+
+# Summary
+
+Address review feedback on PR #170 (max_tokens truncation detection).
+
+# Result
+
+One open review comment from chatgpt-codex-connector (P2):
+"Preserve billed usage on truncation errors" — when a tool response hits
+`max_tokens`, the provider's `message`/`response` already carries token
+usage, but `TruncatedResponseError` only preserved `stop_reason`/`max_tokens`,
+so `JSONPromptExtractor.extract()`'s exception path always returned
+`usage=None`, and `event_role_world.processor._pass_usage_from_extraction()`
+recorded zero tokens in `pilot_usage.jsonl` for every truncated call — even
+though the provider had already billed for the output tokens generated
+before hitting the ceiling.
+
+Triage: presence (still present, confirmed by reading the code) — valid
+(a real cost-undercounting bug, not just a nitpick) — feasible (small,
+localized change). Fixed by:
+
+- `lcats/lcats/llm/backend.py`: `TruncatedResponseError` gained
+  `input_tokens`/`output_tokens` fields (default 0).
+- `lcats/lcats/llm/anthropic_backend.py`: passes
+  `message.usage.input_tokens`/`.output_tokens` when raising.
+- `lcats/lcats/llm/openai_backend.py`: passes
+  `response.usage.prompt_tokens`/`.completion_tokens` when raising (guarding
+  `usage` being `None`, matching the existing non-tool path's guard).
+- `lcats/lcats/analysis/llm_extractor.py`: `_normalize_api_error` surfaces
+  `input_tokens`/`output_tokens` in the payload for `TruncatedResponseError`;
+  `extract()`'s exception handler now builds `usage` from `api_error` when
+  those keys are present, instead of unconditionally returning `None`.
+
+Added direct test coverage for all of the above (both backends' truncation
+paths asserting `.input_tokens`/`.output_tokens` on the raised exception,
+plus an `extract()`-level test asserting `result["usage"]` is populated from
+a `TruncatedResponseError`).
+
+# Validation
+
+- `pytest tests/llm_tests/anthropic_backend_test.py tests/llm_tests/openai_backend_test.py tests/analysis_tests/llm_extractor_test.py` (from `lcats/`) — 113 passed.
+- `scripts/test` (from `lcats/`) — full suite, 1446 passed.
+- `scripts/lint` (from `lcats/`) — ruff clean; black clean on all files touched by this PR (pre-existing, unrelated skew remains on `lcats/gettenberg/metadata.py`, not touched here).
+- `lrh validate` (from `lcats/`) — 0 errors (43 pre-existing warnings, unrelated).
+- Review thread (`PRRT_kwDOKlhIbM6UO0EQ`) resolved via `gh api graphql resolveReviewThread` after the fix landed.
+
+# Follow-up
+
+None beyond what PR #170's primary execution record already lists (running
+the real pilot again with this fix in place is still the next concrete
+step for WI-EVENT-0030).

--- a/lcats/tests/analysis_tests/llm_extractor_test.py
+++ b/lcats/tests/analysis_tests/llm_extractor_test.py
@@ -617,6 +617,23 @@ class TestExtractErrorPaths(unittest.TestCase):
         self.assertEqual(result["extraction_error"], "api_error")
         self.assertIsNone(result["extracted_output"])
 
+    def test_truncated_response_error_preserves_billed_usage_in_result(self):
+        """A TruncatedResponseError's usage flows through to result['usage'],
+        instead of being discarded to None like other backend exceptions."""
+        from lcats.llm import backend as llm_backend
+
+        exc = llm_backend.TruncatedResponseError(
+            "truncated",
+            stop_reason="max_tokens",
+            max_tokens=4096,
+            input_tokens=250,
+            output_tokens=4096,
+        )
+        ext = _make_extractor(backend=_RaisingBackend(exc))
+        result = ext.extract("story")
+        self.assertEqual(result["extraction_error"], "api_error")
+        self.assertEqual(result["usage"], {"input_tokens": 250, "output_tokens": 4096})
+
     def test_api_exception_result_has_all_keys(self):
         """Even on backend exception, result dict has all expected keys."""
         ext = _make_extractor(backend=_RaisingBackend(Exception("fail")))

--- a/lcats/tests/analysis_tests/llm_extractor_test.py
+++ b/lcats/tests/analysis_tests/llm_extractor_test.py
@@ -360,6 +360,11 @@ class TestClassifyApiError(unittest.TestCase):
             ("server_503", {"status": 503}, "server"),
             ("server_504", {"status": 504}, "server"),
             ("server_overloaded", {"message": "the server is overloaded"}, "server"),
+            (
+                "truncated_output_code",
+                {"code": "truncated_output"},
+                "truncated_output",
+            ),
             ("unknown", {}, "unknown"),
         ]
     )
@@ -415,6 +420,13 @@ class TestClassifyApiError(unittest.TestCase):
         self.assertEqual(result["message"], "some msg")
         self.assertEqual(result["status"], 999)
 
+    def test_truncated_output_is_not_retryable_as_is(self):
+        """truncated_output should not set can_retry or should_abort_batch."""
+        result = self._classify(code="truncated_output")
+        self.assertFalse(result["can_retry"])
+        self.assertFalse(result["should_abort_batch"])
+        self.assertEqual(result["suggested_action"], "retry_with_higher_max_tokens")
+
 
 # ---------------------------------------------------------------------------
 # Tests: _normalize_api_error
@@ -453,6 +465,19 @@ class TestNormalizeApiError(unittest.TestCase):
         exc.code = "rate_limit_exceeded"
         result = self.ext._normalize_api_error(exc)
         self.assertEqual(result["code"], "rate_limit_exceeded")
+
+    def test_recognizes_truncated_response_error(self):
+        """TruncatedResponseError is classified as truncated_output directly,
+        bypassing the generic status/code/message inference path."""
+        from lcats.llm import backend as llm_backend
+
+        exc = llm_backend.TruncatedResponseError(
+            "response truncated", stop_reason="max_tokens", max_tokens=4096
+        )
+        result = self.ext._normalize_api_error(exc)
+        self.assertEqual(result["category"], "truncated_output")
+        self.assertEqual(result["raw"]["stop_reason"], "max_tokens")
+        self.assertEqual(result["raw"]["max_tokens"], 4096)
 
     def test_extracts_embedded_json_error_block(self):
         """When exc string contains JSON with an 'error' block, fields are extracted."""

--- a/lcats/tests/llm_tests/anthropic_backend_test.py
+++ b/lcats/tests/llm_tests/anthropic_backend_test.py
@@ -9,7 +9,12 @@ from lcats.llm import anthropic_backend
 
 
 def _make_message(
-    text=None, tool_input=None, model="claude-opus-4-8", input_tokens=5, output_tokens=7
+    text=None,
+    tool_input=None,
+    model="claude-opus-4-8",
+    input_tokens=5,
+    output_tokens=7,
+    stop_reason="end_turn",
 ):
     """Build a stub object shaped like an Anthropic Messages API response."""
     content = []
@@ -20,7 +25,9 @@ def _make_message(
     usage = types.SimpleNamespace(
         input_tokens=input_tokens, output_tokens=output_tokens
     )
-    return types.SimpleNamespace(content=content, usage=usage, model=model)
+    return types.SimpleNamespace(
+        content=content, usage=usage, model=model, stop_reason=stop_reason
+    )
 
 
 class _StubStream:
@@ -122,6 +129,41 @@ class TestAnthropicBackend(unittest.TestCase):
         )
         self.assertEqual(result.tool_result, {"verdict": "include"})
         self.assertEqual(result.text, "")
+
+    def test_complete_with_tool_raises_on_max_tokens_truncation(self):
+        """complete(tool=...) raises TruncatedResponseError on stop_reason='max_tokens'."""
+        from lcats.llm import backend
+
+        tool_schema = {"name": "record_thing", "input_schema": {"type": "object"}}
+        stub_client = _StubAnthropicClient(
+            _make_message(tool_input={"verdict": "incl"}, stop_reason="max_tokens")
+        )
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend()
+            with self.assertRaises(backend.TruncatedResponseError) as ctx:
+                backend_under_test.complete(
+                    system="sys",
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="claude-opus-4-8",
+                    max_tokens=4096,
+                    tool=tool_schema,
+                )
+        self.assertEqual(ctx.exception.stop_reason, "max_tokens")
+        self.assertEqual(ctx.exception.max_tokens, 4096)
+
+    def test_complete_without_tool_does_not_raise_on_max_tokens(self):
+        """Truncation is only checked when a tool_use block was requested."""
+        stub_client = _StubAnthropicClient(
+            _make_message(text="partial tex", stop_reason="max_tokens")
+        )
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend()
+            result = backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-opus-4-8",
+            )
+        self.assertEqual(result.text, "partial tex")
 
     def test_complete_uses_streaming_by_default(self):
         """complete() uses messages.stream() by default."""

--- a/lcats/tests/llm_tests/anthropic_backend_test.py
+++ b/lcats/tests/llm_tests/anthropic_backend_test.py
@@ -151,6 +151,32 @@ class TestAnthropicBackend(unittest.TestCase):
         self.assertEqual(ctx.exception.stop_reason, "max_tokens")
         self.assertEqual(ctx.exception.max_tokens, 4096)
 
+    def test_truncation_error_preserves_billed_usage(self):
+        """TruncatedResponseError carries the usage the provider already billed."""
+        from lcats.llm import backend
+
+        tool_schema = {"name": "record_thing", "input_schema": {"type": "object"}}
+        stub_client = _StubAnthropicClient(
+            _make_message(
+                tool_input={"verdict": "incl"},
+                stop_reason="max_tokens",
+                input_tokens=123,
+                output_tokens=4096,
+            )
+        )
+        with patch("anthropic.Anthropic", return_value=stub_client):
+            backend_under_test = anthropic_backend.AnthropicBackend()
+            with self.assertRaises(backend.TruncatedResponseError) as ctx:
+                backend_under_test.complete(
+                    system="sys",
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="claude-opus-4-8",
+                    max_tokens=4096,
+                    tool=tool_schema,
+                )
+        self.assertEqual(ctx.exception.input_tokens, 123)
+        self.assertEqual(ctx.exception.output_tokens, 4096)
+
     def test_complete_without_tool_does_not_raise_on_max_tokens(self):
         """Truncation is only checked when a tool_use block was requested."""
         stub_client = _StubAnthropicClient(

--- a/lcats/tests/llm_tests/openai_backend_test.py
+++ b/lcats/tests/llm_tests/openai_backend_test.py
@@ -155,6 +155,36 @@ class TestOpenAIBackend(unittest.TestCase):
         self.assertEqual(ctx.exception.stop_reason, "length")
         self.assertEqual(ctx.exception.max_tokens, 4096)
 
+    def test_truncation_error_preserves_billed_usage(self):
+        """TruncatedResponseError carries the usage the provider already billed."""
+        from lcats.llm import backend
+
+        tool_schema = {
+            "name": "record_thing",
+            "description": "Record a thing.",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+        stub_client = _StubOpenAIClient(
+            _make_response(
+                tool_call_arguments='{"verdict": "incl',
+                finish_reason="length",
+                prompt_tokens=88,
+                completion_tokens=4096,
+            )
+        )
+        with patch("openai.OpenAI", return_value=stub_client):
+            backend_under_test = openai_backend.OpenAIBackend()
+            with self.assertRaises(backend.TruncatedResponseError) as ctx:
+                backend_under_test.complete(
+                    system="sys",
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="gpt-4o-2024-08-06",
+                    max_tokens=4096,
+                    tool=tool_schema,
+                )
+        self.assertEqual(ctx.exception.input_tokens, 88)
+        self.assertEqual(ctx.exception.output_tokens, 4096)
+
     def test_complete_without_tool_does_not_raise_on_length(self):
         """Truncation is only checked when a tool call was requested."""
         stub_client = _StubOpenAIClient(

--- a/lcats/tests/llm_tests/openai_backend_test.py
+++ b/lcats/tests/llm_tests/openai_backend_test.py
@@ -15,6 +15,7 @@ def _make_response(
     model="gpt-4o-2024-08-06",
     prompt_tokens=5,
     completion_tokens=7,
+    finish_reason="stop",
 ):
     """Build a stub object shaped like an OpenAI chat completion response."""
     if tool_call_arguments is not None:
@@ -23,7 +24,7 @@ def _make_response(
         message = types.SimpleNamespace(content=None, tool_calls=[tool_call])
     else:
         message = types.SimpleNamespace(content=content, tool_calls=None)
-    choice = types.SimpleNamespace(message=message)
+    choice = types.SimpleNamespace(message=message, finish_reason=finish_reason)
     usage = types.SimpleNamespace(
         prompt_tokens=prompt_tokens, completion_tokens=completion_tokens
     )
@@ -125,6 +126,48 @@ class TestOpenAIBackend(unittest.TestCase):
         self.assertNotIn("response_format", stub_client.last_kwargs)
         self.assertEqual(result.tool_result, {"verdict": "include"})
         self.assertEqual(result.text, "")
+
+    def test_complete_with_tool_raises_on_length_truncation(self):
+        """complete(tool=...) raises TruncatedResponseError on finish_reason='length'."""
+        from lcats.llm import backend
+
+        tool_schema = {
+            "name": "record_thing",
+            "description": "Record a thing.",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+        stub_client = _StubOpenAIClient(
+            _make_response(
+                tool_call_arguments='{"verdict": "incl',
+                finish_reason="length",
+            )
+        )
+        with patch("openai.OpenAI", return_value=stub_client):
+            backend_under_test = openai_backend.OpenAIBackend()
+            with self.assertRaises(backend.TruncatedResponseError) as ctx:
+                backend_under_test.complete(
+                    system="sys",
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="gpt-4o-2024-08-06",
+                    max_tokens=4096,
+                    tool=tool_schema,
+                )
+        self.assertEqual(ctx.exception.stop_reason, "length")
+        self.assertEqual(ctx.exception.max_tokens, 4096)
+
+    def test_complete_without_tool_does_not_raise_on_length(self):
+        """Truncation is only checked when a tool call was requested."""
+        stub_client = _StubOpenAIClient(
+            _make_response(content="partial tex", finish_reason="length")
+        )
+        with patch("openai.OpenAI", return_value=stub_client):
+            backend_under_test = openai_backend.OpenAIBackend()
+            result = backend_under_test.complete(
+                system="sys",
+                messages=[{"role": "user", "content": "hi"}],
+                model="gpt-4o-2024-08-06",
+            )
+        self.assertEqual(result.text, "partial tex")
 
     def test_complete_normalizes_token_usage_and_model(self):
         """input_tokens/output_tokens/model are normalized from the API response."""


### PR DESCRIPTION
## Summary
- The real WI-EVENT-0030 pilot crashed 3x on malformed tool-use output; the postmortem audit (PR #169) confirmed the root cause is Anthropic silently truncating a tool_use response mid-generation on `stop_reason == "max_tokens"`, which `AnthropicBackend.complete()` never checked for.
- Both `AnthropicBackend` and `OpenAIBackend` now raise a new `TruncatedResponseError` when a tool was requested and the response was cut off (`stop_reason == "max_tokens"` / `finish_reason == "length"`), instead of silently returning an incomplete/invalid `tool_result`.
- `llm_extractor.py`'s `_classify_api_error`/`_normalize_api_error` recognize this exception directly and classify it under a new `truncated_output` category (`can_retry=False`, `should_abort_batch=False`, `suggested_action="retry_with_higher_max_tokens"`) — distinct from existing categories, since none of them mean "same request, bigger max_tokens."
- `run_pilot.py`'s `_build_erw_extractors` now raises `max_tokens` from the `JSONPromptExtractor` default of 4096 to 16384 for all five ERW extractors. Anthropic bills actual output tokens generated, not this ceiling, so this costs nothing extra for calls that finish early — `claude-opus-4-8` supports up to 128k output tokens.
- No auto-retry logic is added inside the backends themselves — they raise and classify clearly; the caller decides whether/how to retry with a bumped `max_tokens`, matching the existing `FatalPilotError` pattern of explicit signaling over silent auto-retry.

## Test plan
- [x] `pytest tests/llm_tests/anthropic_backend_test.py tests/llm_tests/openai_backend_test.py tests/analysis_tests/llm_extractor_test.py` — 110 passed, including new truncation-detection tests for both backends and the new classification category.
- [x] `scripts/test` — full suite, 1446 passed.
- [x] `scripts/lint` — ruff clean (black flags a pre-existing, unrelated file due to known formatter version skew, not touched by this change).
- [x] `lrh validate` — no new errors/warnings introduced by this change.
