### PR TITLE
Add work item WI-PACKAGING-0032: Move lcats package to src-layout

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_27_19_32_26_PR171_REVIEW_FIXES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_19_32_26_PR171_REVIEW_FIXES.md
@@ -1,0 +1,55 @@
+---
+execution_id: 2026_07_27_19_32_26_PR171_REVIEW_FIXES
+prompt_id: PROMPT(AD_HOC:PR171_REVIEW_FIXES)[2026-07-27T19:31:45-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/171
+commit: 
+created_at: 2026-07-27T19:32:26-04:00
+---
+
+# Summary
+
+Apply direct fixes to `WI-PACKAGING-0032.md` in response to PR #171's
+landed automated review (Copilot + Codex), following the land-to-closeout
+skill's "apply fixes directly" path rather than routing through
+`/lrh-review-response` for the fix itself.
+
+# Result
+
+3 findings from the landed review were verified and fixed:
+
+1. Codex (P1) — a real gap in the original blast-radius audit:
+   `lcats/lcats/utils/test_utils.py`'s `TestCaseWithData.setUp` computes
+   `test_data_dir` via `os.path.join(os.path.dirname(__file__),
+   "../../tests/data")`, the same parent-depth-counting pattern as
+   `secrets.py`. After the move this resolves to `lcats/src/tests/data`
+   instead of the real `lcats/tests/data`. Confirmed by reading the file
+   directly — I had missed this file when drafting the WI even though I'd
+   already caught the analogous `secrets.py` bug. Added it to `Required
+   Changes`, `Acceptance Criteria`, `artifacts_expected`, and `Risk Notes`.
+2. Copilot — path-style inconsistency in Acceptance Criteria: some bullets
+   used bare `scripts/...`/`tools/...` (lcats-subproject-relative) while
+   `Required Changes`/`artifacts_expected` used `lcats/scripts/...`/
+   `lcats/tools/...` (repo-root-relative). Made Acceptance Criteria
+   consistently repo-root-relative to match, while leaving the
+   `## Validation` section's bare `scripts/...` alone — that section is
+   `lcats/`-relative by established project convention (matches
+   `WI-PACKAGING-0031`'s Validation section).
+3. Copilot — `pip install -e ...` vs `python -m pip install -e ...`
+   inconsistency between Required Changes/Acceptance Criteria and the
+   Validation section. Standardized on `python -m pip` everywhere to avoid
+   the interpreter-mismatch footgun the reviewer flagged.
+
+# Validation
+
+- `lrh validate` from `lcats/`: 0 errors, 43 warnings (pre-existing,
+  unrelated to this file).
+- Verified the `test_utils.py` bug by reading the file directly:
+  `os.path.join(os.path.dirname(__file__), "../../tests/data")` at
+  `lcats/lcats/utils/test_utils.py:15`.
+
+# Follow-up
+
+None — proceeding to `/lrh-confirm-fixes` to resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_27_20_19_57_WI_PACKAGING_0032_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_20_19_57_WI_PACKAGING_0032_CONFIRM.md
@@ -1,0 +1,57 @@
+---
+execution_id: 2026_07_27_20_19_57_WI_PACKAGING_0032_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_PACKAGING_0032_CONFIRM)[2026-07-27T19:43:25-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_27_19_32_26_PR171_REVIEW_FIXES
+pr: https://github.com/xenotaur/LCATS/pull/171
+commit: 
+created_at: 2026-07-27T20:19:57-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/171
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge confirm-fixes pass for PR #171. Independently verified the fixes
+applied in `2026_07_27_19_32_26_PR171_REVIEW_FIXES` against the live PR
+diff (never against that record's own claims), and resolved the review
+threads the diff plainly satisfies.
+
+# Result
+
+All 3 threads classified **Clear-satisfied** against `gh pr diff 171`
+(`HEAD` = `8c805388`):
+
+1. chatgpt-codex-connector (P1) — `test_utils.py`'s hardcoded
+   path-depth bug (a real gap in the original blast-radius audit) → diff
+   adds it to Required Changes, Acceptance Criteria, `artifacts_expected`,
+   and Risk Notes. Resolved.
+2. copilot-pull-request-reviewer — path-style inconsistency (bare
+   `scripts/`/`tools/` vs `lcats/scripts/`/`lcats/tools/`) → diff makes
+   Acceptance Criteria consistently repo-root-relative. Resolved.
+3. copilot-pull-request-reviewer — `pip install` vs `python -m pip
+   install` inconsistency → diff standardizes on `python -m pip`.
+   Resolved.
+
+No Unaddressed / Partial / Ambiguous / Problematic threads.
+
+Thread-resolution verdict: **green**.
+
+# Validation
+
+- `lrh github threads --mode raw --state all`: 3 threads found, all
+  correlated to review comments 1:1 by latest-comment URL.
+- `gh pr diff 171`: confirmed all 3 fixes are plainly present in the diff.
+- `gh api graphql resolveReviewThread`: all 3 threads confirmed
+  `isResolved: true` after mutation.
+- `gh pr checks 171` (unfiltered — no required-status-checks configured):
+  `coverage`, `lint`, 2× `test` all `SUCCESS` on `8c805388`.
+- `lrh validate`: 0 errors, 43 pre-existing warnings unrelated to this
+  change.
+
+# Follow-up
+
+None — final readiness verdict is green; reporting the merge one-liner to
+the user for the human merge gate.

--- a/lcats/project/work_items/proposed/WI-PACKAGING-0032.md
+++ b/lcats/project/work_items/proposed/WI-PACKAGING-0032.md
@@ -33,10 +33,11 @@ forbidden_actions:
 acceptance:
   - lcats/lcats/ no longer exists; the package lives at lcats/src/lcats/ with the same module contents
   - lcats/pyproject.toml has [tool.setuptools] package-dir = {"" = "src"} and [tool.setuptools.packages.find] where = ["src"]
-  - scripts/lint and scripts/format default targets reference src instead of lcats
+  - lcats/scripts/lint and lcats/scripts/format default targets reference src instead of lcats
   - lcats/src/lcats/utils/secrets.py's parents[N] depth count is updated for the new path depth and still resolves .secrets/ at the repo root
-  - .pre-commit-config.yaml, tools/sourcetree_surveyor.py, tools/create_request.py, experiments/02_llm_backend_comparison/run_comparison.py, and experiments/03_cross_segment_relation_pilot/run_pilot.py are audited for lcats/lcats path literals or sys.path bootstraps, and updated to point at lcats/src where they assumed the old layout
-  - pip install -e ".[dev]" succeeds from lcats/ against the new layout
+  - lcats/src/lcats/utils/test_utils.py's TestCaseWithData test_data_dir calculation is updated for the new path depth and still resolves lcats/tests/data, not lcats/src/tests/data
+  - .pre-commit-config.yaml, lcats/tools/sourcetree_surveyor.py, lcats/tools/create_request.py, experiments/02_llm_backend_comparison/run_comparison.py, and experiments/03_cross_segment_relation_pilot/run_pilot.py are audited for lcats/lcats path literals or sys.path bootstraps, and updated to point at lcats/src where they assumed the old layout
+  - python -m pip install -e ".[dev]" succeeds from lcats/ against the new layout
   - the full test suite (scripts/test) passes against the new layout
   - lrh validate reports 0 errors
 required_evidence:
@@ -48,6 +49,7 @@ artifacts_expected:
   - lcats/scripts/lint
   - lcats/scripts/format
   - lcats/src/lcats/utils/secrets.py
+  - lcats/src/lcats/utils/test_utils.py
   - .pre-commit-config.yaml
   - lcats/tools/sourcetree_surveyor.py
   - lcats/tools/create_request.py
@@ -109,16 +111,23 @@ constraint — encoded here via `depends_on`.
 4. `lcats/src/lcats/utils/secrets.py`: update the `parents[N]` depth-count
    comment and index (shifts by one level since the package moved one
    directory deeper).
-5. Audit and update `.pre-commit-config.yaml`,
+5. `lcats/src/lcats/utils/test_utils.py`: `TestCaseWithData.setUp`'s
+   `os.path.join(os.path.dirname(__file__), "../../tests/data")`
+   calculation resolves to `lcats/src/tests/data` after the move instead of
+   the actual `lcats/tests/data` — update the relative path (or the
+   depth-counting approach) so `test_data_dir` still resolves correctly.
+   Numerous tests inherit `TestCaseWithData`, so this must be fixed before
+   the full test run in step 8 can pass.
+6. Audit and update `.pre-commit-config.yaml`,
    `lcats/tools/sourcetree_surveyor.py`, `lcats/tools/create_request.py`
    for `lcats/lcats` path literals.
-6. Update `experiments/02_llm_backend_comparison/run_comparison.py` and
+7. Update `experiments/02_llm_backend_comparison/run_comparison.py` and
    `experiments/03_cross_segment_relation_pilot/run_pilot.py`'s
    `sys.path.insert(0, ... / "lcats")` bootstraps to point at
    `.../lcats/src` instead.
-7. `rm -rf lcats/lcats.egg-info && pip install -e ".[dev]"` from `lcats/`
-   to regenerate the editable install against the new layout.
-8. Run `scripts/test` and confirm the full suite passes.
+8. `rm -rf lcats/lcats.egg-info && python -m pip install -e ".[dev]"` from
+   `lcats/` to regenerate the editable install against the new layout.
+9. Run `scripts/test` and confirm the full suite passes.
 
 ## Non-Goals
 
@@ -142,17 +151,21 @@ constraint — encoded here via `depends_on`.
 - `lcats/pyproject.toml` has
   `[tool.setuptools] package-dir = {"" = "src"}` and
   `[tool.setuptools.packages.find] where = ["src"]`.
-- `scripts/lint` and `scripts/format` default targets reference `src`
-  instead of `lcats`.
+- `lcats/scripts/lint` and `lcats/scripts/format` default targets
+  reference `src` instead of `lcats`.
 - `lcats/src/lcats/utils/secrets.py`'s `parents[N]` depth count is updated
   for the new path depth and still resolves `.secrets/` at the repo root.
-- `.pre-commit-config.yaml`, `tools/sourcetree_surveyor.py`,
-  `tools/create_request.py`,
+- `lcats/src/lcats/utils/test_utils.py`'s `TestCaseWithData` `test_data_dir`
+  calculation is updated for the new path depth and still resolves
+  `lcats/tests/data`, not `lcats/src/tests/data`.
+- `.pre-commit-config.yaml`, `lcats/tools/sourcetree_surveyor.py`,
+  `lcats/tools/create_request.py`,
   `experiments/02_llm_backend_comparison/run_comparison.py`, and
   `experiments/03_cross_segment_relation_pilot/run_pilot.py` are audited
   for `lcats/lcats` path literals or `sys.path` bootstraps, and updated to
   point at `lcats/src` where they assumed the old layout.
-- `pip install -e ".[dev]"` succeeds from `lcats/` against the new layout.
+- `python -m pip install -e ".[dev]"` succeeds from `lcats/` against the
+  new layout.
 - The full test suite (`scripts/test`) passes against the new layout.
 - `lrh validate` reports 0 errors.
 
@@ -171,10 +184,12 @@ constraint — encoded here via `depends_on`.
   since they're outside `lcats/` entirely — the proposal's review cycle
   already caught this once; double-check both files specifically before
   calling this item done.
-- `secrets.py`'s hardcoded `parents[N]` depth count is exactly the kind of
-  off-by-one that passes review by inspection but fails at runtime —
-  verify by actually invoking a code path that reads `.secrets/`, not
-  just by reading the diff.
+- `secrets.py` and `test_utils.py` both hardcode `parents[N]`/relative-path
+  depth counts that pass review by inspection but fail at runtime — verify
+  each by actually invoking a code path that reads `.secrets/` and by
+  running the full test suite (not just reading the diff), since
+  `test_utils.py`'s bug specifically only surfaces when tests that inherit
+  `TestCaseWithData` try to load fixture data.
 - Deleting `lcats/lcats.egg-info` before reinstalling is safe (it's
   untracked/gitignored, confirmed during the design phase), but skipping
   that step risks a stale editable-install pointing at the old path.

--- a/lcats/project/work_items/proposed/WI-PACKAGING-0032.md
+++ b/lcats/project/work_items/proposed/WI-PACKAGING-0032.md
@@ -1,0 +1,185 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-PACKAGING-0032
+title: Move lcats package from lcats/lcats/ to lcats/src/lcats/ (src-layout)
+type: deliverable
+status: proposed
+owner: xenotaur
+contributors:
+  - xenotaur
+assigned_agents: []
+related_focus: []
+related_roadmap: []
+related_workstreams:
+  - WS-PACKAGING
+related_design:
+  - project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md
+depends_on:
+  - WI-PACKAGING-0031
+blocked_by: []
+expected_actions:
+  - create_file
+  - edit_file
+  - delete_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - implement_lcats_setuptools_scm_versioning
+  - modify_ci_pipeline
+acceptance:
+  - lcats/lcats/ no longer exists; the package lives at lcats/src/lcats/ with the same module contents
+  - lcats/pyproject.toml has [tool.setuptools] package-dir = {"" = "src"} and [tool.setuptools.packages.find] where = ["src"]
+  - scripts/lint and scripts/format default targets reference src instead of lcats
+  - lcats/src/lcats/utils/secrets.py's parents[N] depth count is updated for the new path depth and still resolves .secrets/ at the repo root
+  - .pre-commit-config.yaml, tools/sourcetree_surveyor.py, tools/create_request.py, experiments/02_llm_backend_comparison/run_comparison.py, and experiments/03_cross_segment_relation_pilot/run_pilot.py are audited for lcats/lcats path literals or sys.path bootstraps, and updated to point at lcats/src where they assumed the old layout
+  - pip install -e ".[dev]" succeeds from lcats/ against the new layout
+  - the full test suite (scripts/test) passes against the new layout
+  - lrh validate reports 0 errors
+required_evidence:
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/src/lcats/
+  - lcats/pyproject.toml
+  - lcats/scripts/lint
+  - lcats/scripts/format
+  - lcats/src/lcats/utils/secrets.py
+  - .pre-commit-config.yaml
+  - lcats/tools/sourcetree_surveyor.py
+  - lcats/tools/create_request.py
+  - experiments/02_llm_backend_comparison/run_comparison.py
+  - experiments/03_cross_segment_relation_pilot/run_pilot.py
+---
+
+## Summary
+
+Move the `lcats` Python package from the flat-layout `lcats/lcats/` to the
+PyPA-recommended src-layout `lcats/src/lcats/`, as Phase 2 of
+`WS-PACKAGING`, updating every dependent script/tool/experiment path along
+the way. No metadata or versioning changes.
+
+## Problem / Context
+
+`PROP-LCATS-PACKAGING-MODERNIZATION` (merged via PR #159) identified
+LCATS's flat package layout as carrying the import-shadowing risk PyPA's
+own guidance warns against; `WS-PACKAGING` (merged via PR #160) sequences
+this as Phase 2, after Phase 1's tool-version self-enforcement
+(`WI-PACKAGING-0031`) lands, so lint/format skew is caught immediately if
+this move introduces any. This item must not begin implementation before
+`WI-PACKAGING-0031` is resolved, per the workstream's documented ordering
+constraint — encoded here via `depends_on`.
+
+### Duplication search
+- In-repo: No existing implementation found.
+- Sibling repos: `logical_robotics_harness/src/lrh` already uses
+  src-layout — reference, not duplicate.
+- External libraries: None identified — this is project packaging
+  structure.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found (`WI-PACKAGING-0031` is the sibling Phase 1 item,
+  not a duplicate of this Phase 2 scope).
+- Proposals: None found (`PROP-LCATS-PACKAGING-MODERNIZATION` is the
+  originating request, already linked via `related_design`).
+- Backlog: No matching entries.
+- Recommendation: No action.
+
+## Scope
+
+- Move `lcats/lcats/` → `lcats/src/lcats/` (preserve git history via
+  `git mv`).
+- Update `lcats/pyproject.toml`'s package-discovery config.
+- Update every dependent script, tool, and experiment path identified in
+  the proposal's confirmed blast-radius audit.
+- Reinstall editable and run the full test suite to confirm nothing broke.
+
+## Required Changes
+
+1. `git mv lcats/lcats lcats/src/lcats`.
+2. `lcats/pyproject.toml`: add
+   `[tool.setuptools] package-dir = {"" = "src"}` and
+   `[tool.setuptools.packages.find] where = ["src"]`.
+3. `lcats/scripts/lint` and `lcats/scripts/format`: change default target
+   list from `(lcats tests tools)` to `(src tests tools)`.
+4. `lcats/src/lcats/utils/secrets.py`: update the `parents[N]` depth-count
+   comment and index (shifts by one level since the package moved one
+   directory deeper).
+5. Audit and update `.pre-commit-config.yaml`,
+   `lcats/tools/sourcetree_surveyor.py`, `lcats/tools/create_request.py`
+   for `lcats/lcats` path literals.
+6. Update `experiments/02_llm_backend_comparison/run_comparison.py` and
+   `experiments/03_cross_segment_relation_pilot/run_pilot.py`'s
+   `sys.path.insert(0, ... / "lcats")` bootstraps to point at
+   `.../lcats/src` instead.
+7. `rm -rf lcats/lcats.egg-info && pip install -e ".[dev]"` from `lcats/`
+   to regenerate the editable install against the new layout.
+8. Run `scripts/test` and confirm the full suite passes.
+
+## Non-Goals
+
+- Does not add `setuptools-scm` or change `version = "0.1"` — that is
+  Phase 3 (the next work item).
+- Does not remove `lcats/setup.py` — also Phase 3.
+- Does not modify CI workflow YAML — `working-directory: lcats` in
+  `tests.yml`/`coverage.yml`/`lint.yml` already treats `lcats/` as project
+  root regardless of internal layout, confirmed in the proposal.
+- Does not replace `secrets.py`'s parent-depth-counting pattern with a
+  more robust anchor-on-`pyproject.toml` approach — only the one-line
+  index bump needed for the new depth; a proper fix is a candidate
+  follow-up per the proposal's Non-Goals.
+- Does not touch any file outside the audited blast-radius list without
+  first confirming it's actually affected.
+
+## Acceptance Criteria
+
+- `lcats/lcats/` no longer exists; the package lives at `lcats/src/lcats/`
+  with the same module contents.
+- `lcats/pyproject.toml` has
+  `[tool.setuptools] package-dir = {"" = "src"}` and
+  `[tool.setuptools.packages.find] where = ["src"]`.
+- `scripts/lint` and `scripts/format` default targets reference `src`
+  instead of `lcats`.
+- `lcats/src/lcats/utils/secrets.py`'s `parents[N]` depth count is updated
+  for the new path depth and still resolves `.secrets/` at the repo root.
+- `.pre-commit-config.yaml`, `tools/sourcetree_surveyor.py`,
+  `tools/create_request.py`,
+  `experiments/02_llm_backend_comparison/run_comparison.py`, and
+  `experiments/03_cross_segment_relation_pilot/run_pilot.py` are audited
+  for `lcats/lcats` path literals or `sys.path` bootstraps, and updated to
+  point at `lcats/src` where they assumed the old layout.
+- `pip install -e ".[dev]"` succeeds from `lcats/` against the new layout.
+- The full test suite (`scripts/test`) passes against the new layout.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `python -m pip install -e ".[dev]"`
+- `python -c "import lcats; print(lcats.__file__)"`
+
+## Risk Notes
+
+- The `experiments/*/run_*.py` `sys.path` bootstraps are easy to miss
+  since they're outside `lcats/` entirely — the proposal's review cycle
+  already caught this once; double-check both files specifically before
+  calling this item done.
+- `secrets.py`'s hardcoded `parents[N]` depth count is exactly the kind of
+  off-by-one that passes review by inspection but fails at runtime —
+  verify by actually invoking a code path that reads `.secrets/`, not
+  just by reading the diff.
+- Deleting `lcats/lcats.egg-info` before reinstalling is safe (it's
+  untracked/gitignored, confirmed during the design phase), but skipping
+  that step risks a stale editable-install pointing at the old path.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-PACKAGING.md`
+- Design: `project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md`

--- a/lcats/project/workstreams/proposed/WS-PACKAGING.md
+++ b/lcats/project/workstreams/proposed/WS-PACKAGING.md
@@ -12,6 +12,7 @@ related_design:
   - project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md
 work_items:
   - WI-PACKAGING-0031
+  - WI-PACKAGING-0032
 exit_criteria:
   - lcats/pyproject.toml declares license via PEP 639 (license = "MIT" + license-files), pins setuptools>=77 (the version that added PEP 639 support), sets required-version for tool.ruff and tool.black, has no duplicate test/dev extras, and pins gutenbergpy to a commit SHA
   - lcats package code lives at lcats/src/lcats/ with scripts/lint, scripts/format, secrets.py, and all lcats/lcats path literals updated accordingly, and the full test suite passes against the new layout
@@ -63,9 +64,10 @@ item couldn't express.
 - **WI-PACKAGING-0031** — Metadata/config fixes: PEP 639 license,
   `setuptools>=77` build-system pin, tool `required-version` pins, dedupe
   extras, pin `gutenbergpy` to a commit SHA, `project.urls`/classifiers.
-- *(planned)* src-layout move — `lcats/lcats/` → `lcats/src/lcats/`, update
-  `scripts/lint`/`scripts/format`, `secrets.py`, path-literal audit,
-  reinstall, full test run.
+- **WI-PACKAGING-0032** — src-layout move: `lcats/lcats/` →
+  `lcats/src/lcats/`, update `scripts/lint`/`scripts/format`, `secrets.py`,
+  path-literal audit, reinstall, full test run. `depends_on:
+  WI-PACKAGING-0031`.
 - *(planned)* Dynamic versioning + `setup.py` removal — `setuptools-scm`,
   first git tag, delete `setup.py`.
 


### PR DESCRIPTION
## Summary
Phase 2 of `WS-PACKAGING`: move the `lcats` package from `lcats/lcats/` (flat-layout) to `lcats/src/lcats/` (PyPA src-layout), updating `pyproject.toml`'s package-discovery config plus every dependent script/tool/experiment path (`scripts/lint`, `scripts/format`, `secrets.py`'s parent-depth count, `.pre-commit-config.yaml`, `tools/sourcetree_surveyor.py`, `tools/create_request.py`, and both `experiments/*/run_*.py` `sys.path` bootstraps).

- `id`: WI-PACKAGING-0032
- `type`: deliverable
- `related_workstreams`: WS-PACKAGING
- `depends_on`: WI-PACKAGING-0031 (must not start implementation before Phase 1 resolves, per the workstream's ordering constraint)

## Acceptance criteria
See the work item's `## Acceptance Criteria` section — 8 conditions covering the layout move, `pyproject.toml` config, script/tool/experiment path updates, editable reinstall, full test pass, and `lrh validate`.

This is a planning artifact only — no implementation in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
