### PR TITLE
Scope ERW structured-output reliability workstream (WI-EVENT-0032/0033)

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_27_19_45_15_ERW_RELIABILITY_SCOPING.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_19_45_15_ERW_RELIABILITY_SCOPING.md
@@ -1,0 +1,86 @@
+---
+execution_id: 2026_07_27_19_45_15_ERW_RELIABILITY_SCOPING
+prompt_id: PROMPT(AD_HOC:ERW_RELIABILITY_SCOPING)[2026-07-27T19:27:06-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/172
+commit: 2ac5a5e3
+agent: claude_app
+instruction_source: user request, per the audit's own "Next steps" recommendation in lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
+session_transcript: pending
+created_at: 2026-07-27T19:45:15-04:00
+---
+
+# Summary
+
+Create the actual work item(s)/workstream the 2026-07-27 ERW pipeline
+structured-output reliability audit recommends as its own next step:
+Categories A/B/D (blocked by WI-EVENT-0030's `forbidden_actions:
+modify_event_role_world_extractor`, need an unconstrained work item) and
+Category C (the three unconstrained extractors, a separate, more novel
+design problem). Category E is explicitly out of scope, per the audit's
+own note that it's independent and schedulable separately.
+
+# Result
+
+Authored three new control-plane planning artifacts (no source code
+changed):
+
+- `project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md`
+  — coordinates the two work items below; scope explicitly excludes
+  Category E.
+- `project/work_items/proposed/WI-EVENT-0032.md` — Categories A/B/D:
+  strict-mode tool schemas across all seven ERW-adjacent schemas
+  (previously only five were patched at runtime by PR #168, and only for
+  `--backend anthropic`), defensive array-item checks with explicit
+  extraction-error surfacing at all eleven identified sites (a guard that
+  merely skips a malformed item is explicitly called out as insufficient,
+  per the audit's own review correction), and `processor.py`'s
+  model-override parameter plus preserving the structured `api_error` dict
+  instead of discarding it into a plain string. Deliberately unconstrained
+  by `forbidden_actions: modify_event_role_world_extractor` — this is the
+  entire reason this item exists as a separate item from WI-EVENT-0030.
+  Also scopes removal of `run_pilot.py`'s now-redundant runtime
+  strict-schema override once the schemas are strict at the source.
+- `project/work_items/proposed/WI-EVENT-0033.md` — Category C: adds
+  `tool_schema=` to `scene_analysis.py`'s `make_segment_extractor`/
+  `make_semantics_extractor` and `story_analysis.py`'s
+  `make_doc_classification_extractor`. Scoped explicitly to address the
+  `story_processors.py` blast radius the audit flagged — `tool_schema`
+  mode changes `extracted_output`'s shape from a bare list to a
+  single-key dict, which would silently break `story_processors.py`'s two
+  existing call sites if not designed around. Acceptance criteria include
+  measuring the fix's real effect against the live 65% segmentation
+  exclusion rate seen during WI-EVENT-0030 dogfooding.
+
+Both work items' `depends_on`/`related_workstreams`/`related_design` link
+back to the workstream and the audit doc; neither touches WI-EVENT-0030's
+own frontmatter, since neither is a dependency of it.
+
+# Validation
+
+- `lrh validate` (from `lcats/`) — 0 errors, 47 warnings (up from the
+  pre-existing 43; the 4 new ones are `OWNER_ROLE_INSUFFICIENT`/
+  `OWNER_NOT_IN_CONTRIBUTORS` on the two new work items, matching the
+  repo's existing `owner: unassigned` convention used throughout, e.g.
+  WI-EVENT-0030 itself).
+- Manual review of both new work items' frontmatter against
+  `lrh-work-item`'s schema reference (required/policy-required fields,
+  type vocabulary, status→directory bucket mapping) and against
+  WI-EVENT-0030's own file as a structural precedent.
+- Manual review of the new workstream against `WS-PACKAGING.md`'s
+  proposed-state structure as a precedent.
+
+# Follow-up
+
+- Neither WI-EVENT-0032 nor WI-EVENT-0033 has been implemented yet — this
+  PR is scoping only. Each should be picked up as its own
+  `/lrh-implement` run once prioritized.
+- Category E (cost/logging/checkpointing/local models) still needs a
+  scoping decision of its own — the audit's "Next steps" section leaves
+  open whether it becomes its own workstream/work item or folds into an
+  existing one; this PR deliberately did not decide that question.
+- WI-EVENT-0030's real pilot run still needs a successful attempt with
+  PR #170's max_tokens truncation fix in place — independent of this
+  scoping PR, still the next concrete step for that item.

--- a/lcats/project/executions/AD_HOC/2026_07_27_20_24_17_ERW_RELIABILITY_SCOPING_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_27_20_24_17_ERW_RELIABILITY_SCOPING_REVIEW.md
@@ -1,0 +1,80 @@
+---
+execution_id: 2026_07_27_20_24_17_ERW_RELIABILITY_SCOPING_REVIEW
+prompt_id: PROMPT(AD_HOC:ERW_RELIABILITY_SCOPING_REVIEW)[2026-07-27T20:22:52-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_27_19_45_15_ERW_RELIABILITY_SCOPING
+pr: https://github.com/xenotaur/LCATS/pull/172
+commit: c99ba9ff
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/172
+session_transcript: pending
+created_at: 2026-07-27T20:24:17-04:00
+---
+
+# Summary
+
+Address review feedback on PR #172 (WI-EVENT-0032/0033 +
+WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY scoping).
+
+# Result
+
+Seven review comments across 7 threads (3 from copilot-pull-request-reviewer,
+4 from chatgpt-codex-connector). All triaged as present/valid/feasible and
+fixed:
+
+1. **Path prefix missing (copilot, 3 threads):** `related_design` entries
+   pointed to `project/design/proposals/adopted/...` without the `lcats/`
+   prefix the actual file path requires — added the prefix in all three
+   files (workstream + both work items).
+2. **P1 (codex): segmentation-consumer scope wrong.** WI-EVENT-0033 named
+   "story_processors.py's two call sites (lines 76 and 142)" as the
+   consumers needing an update, but line 76 only constructs the extractor
+   — it never reads `extracted_output`. The real second consumer,
+   completely missed, is `run_pilot.py`'s `_segment_story` (`:277`,
+   `segments = seg_result.get("extracted_output") or []`). Verified
+   directly via `git show origin/main:...`; corrected the acceptance
+   criterion, Scope, Summary, and `artifacts_expected` to name both real
+   consumers accurately.
+3. **P2 (codex): structured-error contract self-contradiction.**
+   WI-EVENT-0032's acceptance criterion required preserving `api_error` as
+   a dict, but its own Non-Goals forbade "no new fields" — and
+   `SegmentWorldAnnotation`/`StoryWorldAnnotation`'s `extraction_errors`
+   field is `List[str]` (verified: `schema.py:426,767`), which cannot hold
+   a dict as-is; `run_pilot.py:673`'s `"; ".join(extraction_errors)` also
+   assumes a list of strings. Fixed by scoping the specific schema-change
+   options (widen the element type, or add an additive field) and the
+   required caller update, and carving an explicit exception into the
+   Non-Goals line instead of leaving a blanket "no new fields" that
+   contradicted the acceptance criterion next to it.
+4. **P1 (codex): uncaught-exception finding unscoped.** The workstream's
+   Purpose claims to fix "every finding... except Category E," but the
+   audit's own Category B update also flags that `run_pilot.py`'s `main()`
+   only catches `FatalPilotError` around `run_story()`, so any other
+   per-story exception discards the entire run's already-completed
+   results — and neither work item's acceptance actually required fixing
+   this. Added it as an explicit WI-EVENT-0032 scope bullet and acceptance
+   criterion, since that item already touches `run_pilot.py`.
+5. **P2 (codex): array-item site count wrong.** The audit doc (and this PR,
+   copying it) said "eleven" sites but the enumerated list actually totals
+   twelve (2 entity + 4 event + 1 relation + 3 discourse + 1 story-relation
+   + 1 hypothesis = 12). Recounted directly against the enumerated list;
+   corrected "eleven" to "twelve" everywhere in WI-EVENT-0032 and the
+   workstream.
+
+# Validation
+
+- `lrh validate` (from `lcats/`) — 0 errors, 47 warnings (unchanged from
+  before the fixes; all pre-existing `OWNER_ROLE_INSUFFICIENT`/
+  `OWNER_NOT_IN_CONTRIBUTORS` style, matching repo convention).
+- No source code involved — these are markdown control-plane files, so no
+  test/lint/format run applies beyond `lrh validate`.
+- All 7 review threads resolved via `gh api graphql resolveReviewThread`
+  after the fix commit landed.
+
+# Follow-up
+
+None beyond what the primary execution record already lists (neither
+WI-EVENT-0032 nor WI-EVENT-0033 has been implemented yet; Category E's
+scoping decision remains open; WI-EVENT-0030's real pilot run still needs a
+successful attempt).

--- a/lcats/project/work_items/proposed/WI-EVENT-0032.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0032.md
@@ -1,0 +1,199 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EVENT-0032
+title: Harden Event-Role-World tool-schema reliability and processor error/model handling
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY
+related_design:
+  - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
+  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+depends_on:
+  - WI-EVENT-0029
+blocked_by: []
+expected_actions:
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - implement_new_architecture
+acceptance:
+  - All seven tool schemas (entity_extractor.py's ENTITY_TOOL_SCHEMA, event_extractor.py's EVENT_TOOL_SCHEMA, relation_extractor.py's RELATION_TOOL_SCHEMA, discourse_extractor.py's DISCOURSE_TOOL_SCHEMA, story_relation_extractor.py's STORY_RELATION_TOOL_SCHEMA, hypothesis_extractor.py's HYPOTHESIS_TOOL_SCHEMA, and corpus/assess.py's ASSESSMENT_TOOL) set strict:true and additionalProperties:false on every object level, at the source, superseding run_pilot.py's PR #168 runtime override for the five it currently patches
+  - All eleven identified array-item sites across the six event_role_world/ extractors (entity_extractor.py:142,144; event_extractor.py:185,203,219,225; relation_extractor.py:131; discourse_extractor.py:196,213,232; story_relation_extractor.py:205; hypothesis_extractor.py:146) detect a non-dict item, preserve the raw offending item for diagnosis (e.g. logged or attached to the extraction error), and surface an explicit extraction error for the affected segment/story rather than silently skipping the malformed item and treating the rest as a clean success
+  - processor.py's process_segments() (plural) accepts a model parameter that overrides each extractor's factory-hardcoded default, matching the override run_pilot.py's _build_erw_extractors() already applies by building extractors itself
+  - processor.py's per-pass error handling (the five _pass_usage_from_extraction call sites) preserves the structured api_error dict (category/can_retry/should_abort_batch) from llm_extractor.py's _classify_api_error instead of discarding it into a plain f-string, so callers no longer need to re-derive fatality via substring matching (as run_pilot.py's FatalPilotError/_check_fatal do today)
+  - run_pilot.py's _strict_tool_schema()/_close_schema_objects() runtime override and its --backend anthropic gate are removed once schemas are strict at the source, since they become redundant
+  - Existing ERW pipeline tests pass, and new tests cover both the strict-schema fix and at least one malformed-array-item scenario per extractor module
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/lcats/analysis/event_role_world/entity_extractor.py
+  - lcats/lcats/analysis/event_role_world/event_extractor.py
+  - lcats/lcats/analysis/event_role_world/relation_extractor.py
+  - lcats/lcats/analysis/event_role_world/discourse_extractor.py
+  - lcats/lcats/analysis/event_role_world/story_relation_extractor.py
+  - lcats/lcats/analysis/event_role_world/hypothesis_extractor.py
+  - lcats/lcats/analysis/event_role_world/processor.py
+  - lcats/lcats/analysis/corpus/assess.py
+  - experiments/03_cross_segment_relation_pilot/run_pilot.py
+---
+
+## Summary
+
+Fix, at the source, the three related reliability gaps the 2026-07-27 ERW
+pipeline audit found inside `lcats/lcats/analysis/event_role_world/` and its
+`processor.py`: none of the module's tool schemas set Anthropic's
+`strict: true`/`additionalProperties: false`; all six extractors share an
+identical unguarded-array-item pattern that has already caused two real
+pilot crashes; and `processor.py` hardcodes `gpt-4o` with no override while
+discarding structured API error information into a plain string.
+WI-EVENT-0030 cannot fix any of this itself — its own
+`forbidden_actions: modify_event_role_world_extractor` blocks edits inside
+this exact directory, which is why PR #166 and PR #168 landed as
+caller-local runtime overrides in `run_pilot.py` instead of source fixes.
+This item is deliberately unconstrained by that restriction so the real fix
+can land where the bug actually lives.
+
+## Problem / Context
+
+Two real crashes during WI-EVENT-0030 dogfooding — a `ValueError` on
+non-JSON segmentation output (fixed at the source in PR #167, outside this
+directory) and an `AttributeError` on a malformed tool-result array item in
+`relation_extractor.build_relations` (worked around only via a runtime
+strict-schema override in PR #168, since WI-EVENT-0030 cannot touch
+`event_role_world/` directly) — turned out to be instances of systemic
+gaps affecting every extractor in this module, documented in full in
+`lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md`
+(Categories A, B, and D). A third crash occurred at a *different*
+Category B site (`entity_extractor.py:144`) even with PR #168's strict-mode
+override confirmed genuinely active in the request that crashed, which the
+audit treats as raising — not lowering — the priority of Category B's
+defensive-check fix, since strict mode alone demonstrably did not prevent
+it.
+
+### Duplication search
+- In-repo: No existing work item fixes these gaps at the source. PR #166
+  and PR #168 are caller-local workarounds in `run_pilot.py`, gated to
+  `--backend anthropic` only, and explicitly do not reach
+  `hypothesis_extractor.py` (never built by that pilot) or
+  `corpus/assess.py`'s `ASSESSMENT_TOOL` (built via a separate code path).
+  This item supersedes both workarounds with real source fixes.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: WI-EVENT-0030's audit note ("Not yet acted on... per user
+  request to scope a properly unconstrained work item... instead of
+  another caller-side workaround") directly requests this item.
+- Proposals: None found beyond the governing Event-Role-World extractor
+  proposal, whose Implementation prerequisites already name `tool=`
+  structured output as the intended reliability mechanism this item
+  completes.
+- Backlog: No matching entries.
+- Recommendation: Proceed.
+
+## Scope
+
+- **Category A (strict-mode schemas):** add `strict: true` and
+  `additionalProperties: false` (at every object level, including nested
+  array-item objects) to all seven schemas: the six `event_role_world/`
+  extractors' own `*_TOOL_SCHEMA` module constants, plus
+  `corpus/assess.py`'s `ASSESSMENT_TOOL`. Once these are strict at the
+  source, remove `run_pilot.py`'s `_strict_tool_schema()`/
+  `_close_schema_objects()` runtime override and its `--backend anthropic`
+  gate — it becomes dead code once the schemas it patches are already
+  strict.
+- **Category B (defensive array-item checks):** at each of the eleven
+  identified sites, detect a non-dict array item, preserve the raw
+  offending item (e.g. write it to a diagnosis log or attach it to the
+  returned extraction error) rather than discarding it silently, and
+  surface an explicit extraction error for the affected segment/story. A
+  guard that merely skips the malformed item and continues is **not**
+  sufficient — per the audit's own review correction, that would make a
+  segment with a dropped entity/event/relation look like a *successful*
+  partial extraction instead of a failed one, biasing density figures
+  exactly the way WI-EVENT-0030's acceptance criteria warn against.
+- **Category D (`processor.py`):** add a `model` parameter to
+  `process_segments()` that overrides each extractor's factory-hardcoded
+  default (matching the override `run_pilot.py` already applies by
+  building extractors itself and calling `process_segment()` directly);
+  and change each pass's error handling to preserve the structured
+  `api_error` dict instead of stringifying it, so a caller can read
+  `category`/`can_retry`/`should_abort_batch` directly instead of
+  re-deriving fatality via substring matching.
+- Add test coverage for both the strict-schema change and at least one
+  malformed-array-item scenario per extractor module (six extractors, one
+  scenario each at minimum), plus a `process_segments(model=...)` override
+  test and a structured-error-preserved test for `processor.py`.
+
+## Non-Goals
+
+- Does not implement Category C (the three extractors with no tool schema
+  at all) — that is WI-EVENT-0033, a separate and more novel design
+  problem given `story_processors.py`'s call-site blast radius.
+- Does not implement Category E (cost/logging/checkpointing/local models)
+  — independent of this item's reliability-bug scope per the audit's own
+  "Next steps" section.
+- Does not change the Event-Role-World pipeline's architecture, stage
+  ordering, or object schemas beyond adding `strict`/`additionalProperties`
+  and defensive checks — no new passes, no new fields.
+- Does not attempt to further diagnose the unresolved "why did strict mode
+  not prevent the third crash" question the audit raises — this item
+  implements the defensive fix the audit concludes is needed regardless of
+  that question's answer, not a root-cause investigation into Anthropic's
+  grammar-constrained sampling behavior.
+
+## Acceptance Criteria
+
+(see frontmatter `acceptance:` above)
+
+## Validation
+
+- lrh validate
+- scripts/test (full suite, including new tests for all six extractors and
+  processor.py)
+- scripts/lint
+- Manual review confirming run_pilot.py's now-redundant strict-schema
+  override was removed cleanly with no regression to --backend openai
+  behavior
+
+## Risk Notes
+
+- Touching all six `event_role_world/` extractor modules plus
+  `processor.py` in one item is a wide diff — consider splitting into
+  smaller PRs per extractor if review load becomes unwieldy, as long as
+  each PR keeps its own extractor's schema-strictness and defensive-check
+  changes together (splitting Category A from Category B for the same
+  extractor risks a half-fixed intermediate state).
+- Removing `run_pilot.py`'s runtime strict-schema override must happen only
+  after the source schemas are confirmed strict — removing it first would
+  reopen the exact crash class this item exists to fix, with no override
+  left to catch it.
+- The audit's own postmortem could not fully resolve why the third crash
+  occurred despite strict mode being confirmed active — this item's
+  Category B fix is the correct response regardless, but if malformed
+  array items keep recurring even after this item lands, that is evidence
+  the underlying cause is not fully understood yet and may need its own
+  follow-up investigation, not evidence this item's fix was wrong.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md`
+- Design/audit: `lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md`
+- Design: `project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`

--- a/lcats/project/work_items/proposed/WI-EVENT-0032.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0032.md
@@ -17,7 +17,7 @@ related_workstreams:
   - WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY
 related_design:
   - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
-  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+  - lcats/project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
 depends_on:
   - WI-EVENT-0029
 blocked_by: []
@@ -31,10 +31,11 @@ forbidden_actions:
   - implement_new_architecture
 acceptance:
   - All seven tool schemas (entity_extractor.py's ENTITY_TOOL_SCHEMA, event_extractor.py's EVENT_TOOL_SCHEMA, relation_extractor.py's RELATION_TOOL_SCHEMA, discourse_extractor.py's DISCOURSE_TOOL_SCHEMA, story_relation_extractor.py's STORY_RELATION_TOOL_SCHEMA, hypothesis_extractor.py's HYPOTHESIS_TOOL_SCHEMA, and corpus/assess.py's ASSESSMENT_TOOL) set strict:true and additionalProperties:false on every object level, at the source, superseding run_pilot.py's PR #168 runtime override for the five it currently patches
-  - All eleven identified array-item sites across the six event_role_world/ extractors (entity_extractor.py:142,144; event_extractor.py:185,203,219,225; relation_extractor.py:131; discourse_extractor.py:196,213,232; story_relation_extractor.py:205; hypothesis_extractor.py:146) detect a non-dict item, preserve the raw offending item for diagnosis (e.g. logged or attached to the extraction error), and surface an explicit extraction error for the affected segment/story rather than silently skipping the malformed item and treating the rest as a clean success
+  - All twelve identified array-item sites across the six event_role_world/ extractors (entity_extractor.py:142,144; event_extractor.py:185,203,219,225; relation_extractor.py:131; discourse_extractor.py:196,213,232; story_relation_extractor.py:205; hypothesis_extractor.py:146) detect a non-dict item, preserve the raw offending item for diagnosis (e.g. logged or attached to the extraction error), and surface an explicit extraction error for the affected segment/story rather than silently skipping the malformed item and treating the rest as a clean success
   - processor.py's process_segments() (plural) accepts a model parameter that overrides each extractor's factory-hardcoded default, matching the override run_pilot.py's _build_erw_extractors() already applies by building extractors itself
-  - processor.py's per-pass error handling (the five _pass_usage_from_extraction call sites) preserves the structured api_error dict (category/can_retry/should_abort_batch) from llm_extractor.py's _classify_api_error instead of discarding it into a plain f-string, so callers no longer need to re-derive fatality via substring matching (as run_pilot.py's FatalPilotError/_check_fatal do today)
+  - processor.py's per-pass error handling preserves the structured api_error dict (category/can_retry/should_abort_batch) from llm_extractor.py's _classify_api_error instead of discarding it into a plain f-string, via a schema change scoped explicitly by this item (see Scope) since SegmentWorldAnnotation/StoryWorldAnnotation's extraction_errors field is currently List[str] (schema.py:426,767) and cannot hold a dict as-is; run_pilot.py:673's "; ".join(extraction_errors) caller is updated to match whatever new representation is chosen, so callers no longer need to re-derive fatality via substring matching (as run_pilot.py's FatalPilotError/_check_fatal do today)
   - run_pilot.py's _strict_tool_schema()/_close_schema_objects() runtime override and its --backend anthropic gate are removed once schemas are strict at the source, since they become redundant
+  - run_pilot.py's main() per-story loop catches any exception around run_story() (not just FatalPilotError), so an unexpected per-story failure still preserves and writes already-completed pilot_stories.jsonl/pilot_usage.jsonl/pilot_summary.json results instead of discarding the entire run's data, per the audit's Category B update finding
   - Existing ERW pipeline tests pass, and new tests cover both the strict-schema fix and at least one malformed-array-item scenario per extractor module
   - lrh validate reports 0 errors
 required_evidence:
@@ -49,6 +50,7 @@ artifacts_expected:
   - lcats/lcats/analysis/event_role_world/story_relation_extractor.py
   - lcats/lcats/analysis/event_role_world/hypothesis_extractor.py
   - lcats/lcats/analysis/event_role_world/processor.py
+  - lcats/lcats/analysis/event_role_world/schema.py
   - lcats/lcats/analysis/corpus/assess.py
   - experiments/03_cross_segment_relation_pilot/run_pilot.py
 ---
@@ -119,7 +121,7 @@ it.
   `_close_schema_objects()` runtime override and its `--backend anthropic`
   gate — it becomes dead code once the schemas it patches are already
   strict.
-- **Category B (defensive array-item checks):** at each of the eleven
+- **Category B (defensive array-item checks):** at each of the twelve
   identified sites, detect a non-dict array item, preserve the raw
   offending item (e.g. write it to a diagnosis log or attach it to the
   returned extraction error) rather than discarding it silently, and
@@ -136,11 +138,33 @@ it.
   and change each pass's error handling to preserve the structured
   `api_error` dict instead of stringifying it, so a caller can read
   `category`/`can_retry`/`should_abort_batch` directly instead of
-  re-deriving fatality via substring matching.
+  re-deriving fatality via substring matching. This requires a schema
+  change: `SegmentWorldAnnotation`/`StoryWorldAnnotation`'s
+  `extraction_errors` field is currently `List[str]`
+  (`schema.py:426,767`) and cannot hold a structured dict as-is. Decide
+  and implement one of: (a) widen `extraction_errors`' element type to
+  accept either a string or a structured-error dict, or (b) add a
+  separate, additive field (e.g. `structured_extraction_errors`) alongside
+  the existing string list, left untouched for backward compatibility.
+  Whichever is chosen, update `run_pilot.py:673`'s
+  `"; ".join(extraction_errors)` call (which assumes a list of strings)
+  to match the new representation, and confirm no other caller of
+  `extraction_errors` breaks.
+- **Uncaught-exception data loss (audit's Category B update):**
+  `run_pilot.py`'s `main()` per-story loop only catches `FatalPilotError`
+  around `run_story()` — any other exception propagates uncaught, and the
+  code that writes `pilot_stories.jsonl`/`pilot_usage.jsonl`/
+  `pilot_summary.json` never runs, discarding every already-completed,
+  already-paid-for story in the run, not just the one that failed. Wrap
+  the per-story loop to catch any exception, log/record it the same way a
+  non-fatal per-story failure is handled today, and still write out
+  whatever results completed before the failure.
 - Add test coverage for both the strict-schema change and at least one
   malformed-array-item scenario per extractor module (six extractors, one
   scenario each at minimum), plus a `process_segments(model=...)` override
-  test and a structured-error-preserved test for `processor.py`.
+  test, a structured-error-preserved test for `processor.py`, and a test
+  confirming an unexpected per-story exception still yields written
+  partial results.
 
 ## Non-Goals
 
@@ -150,9 +174,11 @@ it.
 - Does not implement Category E (cost/logging/checkpointing/local models)
   — independent of this item's reliability-bug scope per the audit's own
   "Next steps" section.
-- Does not change the Event-Role-World pipeline's architecture, stage
-  ordering, or object schemas beyond adding `strict`/`additionalProperties`
-  and defensive checks — no new passes, no new fields.
+- Does not change the Event-Role-World pipeline's architecture or stage
+  ordering — no new passes. The one explicitly scoped exception to "no
+  new/changed schema fields" is `extraction_errors`' representation (see
+  Category D above), needed to preserve structured `api_error` data; no
+  other schema field changes are in scope.
 - Does not attempt to further diagnose the unresolved "why did strict mode
   not prevent the third crash" question the audit raises — this item
   implements the defensive fix the audit concludes is needed regardless of
@@ -196,4 +222,4 @@ it.
 
 - Workstream: `project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md`
 - Design/audit: `lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md`
-- Design: `project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`
+- Design: `lcats/project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`

--- a/lcats/project/work_items/proposed/WI-EVENT-0033.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0033.md
@@ -1,0 +1,174 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EVENT-0033
+title: Add schema-hardened structured output to scene/story analysis extractors
+type: deliverable
+status: proposed
+priority: medium
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY
+related_design:
+  - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
+  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - implement_new_architecture
+acceptance:
+  - scene_analysis.py's make_segment_extractor (Stage 1 segmentation) uses a tool_schema= structured-output call instead of unconstrained json_object mode
+  - scene_analysis.py's make_semantics_extractor (per-segment semantics judgment) uses a tool_schema= structured-output call instead of unconstrained json_object mode
+  - story_analysis.py's make_doc_classification_extractor (whole-text document classification) uses a tool_schema= structured-output call instead of unconstrained json_object mode
+  - story_processors.py's two call sites that read segmentation output as a bare list (segments = seg_extraction.get("extracted_output") or [], lines 76 and 142) are updated to match whatever extracted_output shape the schema-hardened segment extractor now returns, with no regression to story_processors.py's own existing behavior or tests
+  - The segmentation fix measurably reduces the parsing_error exclusion rate seen live during WI-EVENT-0030 dogfooding (11 of 17 sampled stories, 65%, excluded with claude-haiku-4-5-20251001), verified by re-running the same sampled story set (or an equivalent smoke sample) through the fixed extractor and comparing exclusion counts
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/lcats/analysis/scene_analysis.py
+  - lcats/lcats/analysis/story_analysis.py
+  - lcats/lcats/analysis/story_processors.py
+---
+
+## Summary
+
+Retrofit the three LCATS extractors that still use fully unconstrained
+`json_object`-mode JSON-in-text output — `scene_analysis.py`'s
+`make_segment_extractor` and `make_semantics_extractor`, and
+`story_analysis.py`'s `make_doc_classification_extractor` — with a
+`tool_schema=` structured-output call, matching the pattern the
+Event-Role-World extractors already use. This is a more novel design
+problem than WI-EVENT-0032's fixes, because `llm_extractor.py`'s
+`extract()` behaves differently once `tool_schema` is set: `extracted_output`
+becomes the whole parsed dict rather than an `output_key`-unwrapped value,
+which would change `make_segment_extractor`'s output shape from a bare list
+to `{"segments": [...]}` and break its other real caller,
+`story_processors.py`'s two call sites that expect a bare list today. This
+item must design around that shape change, not just add a schema to the
+shared factory function in isolation.
+
+## Problem / Context
+
+The 2026-07-27 ERW pipeline audit's Category C confirms `scene_analysis.py`'s
+segmentation extractor is the actual, currently-blocking reliability
+problem in the pipeline — worse than either of the two crashes WI-EVENT-0032
+fixes: a real run with `claude-haiku-4-5-20251001` excluded 11 of 17 sampled
+stories (65%) with `extraction_error="parsing_error"`, and the `western`
+genre stratum had zero included stories as a result. The governing
+Event-Role-World extractor proposal's own Implementation prerequisites
+section already flagged the scene/sequel prompts' `json_object` mode as the
+weaker pattern the ERW stages were specifically designed to replace via
+`tool=` — this gap was a known, accepted limitation at proposal time, not
+an oversight introduced later, but it was left unfixed pending this
+broader audit and scoping step.
+
+### Duplication search
+- In-repo: No existing work item retrofits these three extractors. The
+  governing Event-Role-World proposal names this gap explicitly as a
+  Non-Goal for the ERW work itself ("scene/sequel extraction" is not being
+  reimplemented) — this item does not reimplement segmentation, it only
+  hardens its existing output contract.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: WI-EVENT-0030's audit note requests this scoping step
+  directly, describing Category C as "a separate, more novel design
+  problem per extractor" needing to address the `story_processors.py`
+  blast radius, not just bolt on a schema.
+- Proposals: The governing Event-Role-World extractor proposal's
+  Implementation prerequisites section already recommends this direction.
+- Backlog: No matching entries.
+- Recommendation: Proceed.
+
+## Scope
+
+- Design a `tool_schema` for `make_segment_extractor`'s segment output
+  (list of segments, each with the fields the existing prompt already
+  requests) and wire it through `extract()`'s `tool=` path.
+- Decide and implement how to preserve a bare-list `extracted_output` for
+  `story_processors.py`'s two existing call sites (`:76`, `:142`) despite
+  `tool_schema` mode's whole-dict-return behavior — options include (a)
+  unwrapping the single top-level key in `story_processors.py` itself, (b)
+  a second, schema-hardened extractor variant specific to this caller, or
+  (c) another design; the chosen approach and its rationale must be
+  recorded in this item's implementation, and `story_processors.py`'s
+  existing tests must still pass unmodified in behavior (only in internal
+  implementation, if needed).
+- Apply the same `tool_schema=` treatment to `make_semantics_extractor`
+  (`output_key="judgment"`) and `make_doc_classification_extractor`
+  (`output_key="classification"`), auditing each for its own callers
+  before assuming the same unwrapping approach applies identically.
+- Verify the segmentation fix's real-world effect: re-run (or smoke-test)
+  the same sampled story set from the live dogfooding run that saw a 65%
+  exclusion rate, and report the new exclusion rate for comparison.
+- Add or update test coverage for all three retrofitted extractors and for
+  `story_processors.py`'s adapted call sites.
+
+## Non-Goals
+
+- Does not reimplement scene/sequel segmentation logic itself — the
+  governing proposal already treats that as a Non-Goal; this item only
+  hardens the existing extractors' output contract.
+- Does not implement WI-EVENT-0032's Category A/B/D fixes — those are a
+  separate item, unconstrained by comparison, since this item's scope is
+  specifically the three extractors outside `event_role_world/`.
+- Does not implement Category E (cost/logging/checkpointing/local models).
+- Does not change `story_processors.py`'s public behavior or existing
+  callers' expectations — only its internal handling of the segmentation
+  extractor's new output shape, verified by its existing tests continuing
+  to pass.
+
+## Acceptance Criteria
+
+(see frontmatter `acceptance:` above)
+
+## Validation
+
+- lrh validate
+- scripts/test (full suite, including `story_processors.py`'s existing
+  tests unmodified in behavior, plus new tests for all three retrofitted
+  extractors)
+- scripts/lint
+- Re-run or smoke-test against the same sampled story set that saw the
+  live 65% exclusion rate, reporting the new rate
+
+## Risk Notes
+
+- The `extracted_output` shape change between `tool_schema` and
+  non-`tool_schema` modes is the central design risk this item must solve
+  correctly — an incomplete fix that changes `make_segment_extractor`'s
+  return shape without updating both `story_processors.py` call sites
+  would silently break Stage 1 segmentation for every downstream caller,
+  a strictly worse outcome than the current parsing-error exclusion rate.
+- `make_semantics_extractor` and `make_doc_classification_extractor` are
+  not exercised by the current pilot, so their failure rates are
+  unmeasured (not absent, per the audit) — treat their fixes with the same
+  care as segmentation's even without a live failure rate to compare
+  against.
+- If the segmentation fix's measured exclusion-rate improvement is smaller
+  than expected, report that plainly rather than treating it as a failed
+  fix — the audit's own finding is that `json_object` mode is *a* cause of
+  the exclusion rate, not necessarily the only one.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md`
+- Design/audit: `lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md`
+- Design: `project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`

--- a/lcats/project/work_items/proposed/WI-EVENT-0033.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0033.md
@@ -17,7 +17,7 @@ related_workstreams:
   - WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY
 related_design:
   - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
-  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+  - lcats/project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
 depends_on: []
 blocked_by: []
 expected_actions:
@@ -32,7 +32,7 @@ acceptance:
   - scene_analysis.py's make_segment_extractor (Stage 1 segmentation) uses a tool_schema= structured-output call instead of unconstrained json_object mode
   - scene_analysis.py's make_semantics_extractor (per-segment semantics judgment) uses a tool_schema= structured-output call instead of unconstrained json_object mode
   - story_analysis.py's make_doc_classification_extractor (whole-text document classification) uses a tool_schema= structured-output call instead of unconstrained json_object mode
-  - story_processors.py's two call sites that read segmentation output as a bare list (segments = seg_extraction.get("extracted_output") or [], lines 76 and 142) are updated to match whatever extracted_output shape the schema-hardened segment extractor now returns, with no regression to story_processors.py's own existing behavior or tests
+  - Both real consumers of make_segment_extractor's bare-list output are updated to match whatever extracted_output shape the schema-hardened segment extractor now returns: story_processors.py:142 (segments = seg_extraction.get("extracted_output") or []) and experiments/03_cross_segment_relation_pilot/run_pilot.py's _segment_story (:277, segments = seg_result.get("extracted_output") or []) — with no regression to either caller's existing behavior or tests
   - The segmentation fix measurably reduces the parsing_error exclusion rate seen live during WI-EVENT-0030 dogfooding (11 of 17 sampled stories, 65%, excluded with claude-haiku-4-5-20251001), verified by re-running the same sampled story set (or an equivalent smoke sample) through the fixed extractor and comparing exclusion counts
   - lrh validate reports 0 errors
 required_evidence:
@@ -43,6 +43,7 @@ artifacts_expected:
   - lcats/lcats/analysis/scene_analysis.py
   - lcats/lcats/analysis/story_analysis.py
   - lcats/lcats/analysis/story_processors.py
+  - experiments/03_cross_segment_relation_pilot/run_pilot.py
 ---
 
 ## Summary
@@ -57,10 +58,12 @@ problem than WI-EVENT-0032's fixes, because `llm_extractor.py`'s
 `extract()` behaves differently once `tool_schema` is set: `extracted_output`
 becomes the whole parsed dict rather than an `output_key`-unwrapped value,
 which would change `make_segment_extractor`'s output shape from a bare list
-to `{"segments": [...]}` and break its other real caller,
-`story_processors.py`'s two call sites that expect a bare list today. This
-item must design around that shape change, not just add a schema to the
-shared factory function in isolation.
+to `{"segments": [...]}` and break both of its real callers —
+`story_processors.py:142` and
+`experiments/03_cross_segment_relation_pilot/run_pilot.py`'s
+`_segment_story` (`:277`) — which each expect a bare list today. This item
+must design around that shape change for both callers, not just add a
+schema to the shared factory function in isolation.
 
 ## Problem / Context
 
@@ -103,13 +106,17 @@ broader audit and scoping step.
   (list of segments, each with the fields the existing prompt already
   requests) and wire it through `extract()`'s `tool=` path.
 - Decide and implement how to preserve a bare-list `extracted_output` for
-  `story_processors.py`'s two existing call sites (`:76`, `:142`) despite
-  `tool_schema` mode's whole-dict-return behavior — options include (a)
-  unwrapping the single top-level key in `story_processors.py` itself, (b)
-  a second, schema-hardened extractor variant specific to this caller, or
+  `make_segment_extractor`'s two real consumers —
+  `story_processors.py:142` and
+  `experiments/03_cross_segment_relation_pilot/run_pilot.py`'s
+  `_segment_story` (`:277`) — despite `tool_schema` mode's
+  whole-dict-return behavior. (`story_processors.py:76` only constructs
+  the extractor; it is not itself a consumption site.) Options include
+  (a) unwrapping the single top-level key at each call site, (b) a
+  second, schema-hardened extractor variant specific to these callers, or
   (c) another design; the chosen approach and its rationale must be
-  recorded in this item's implementation, and `story_processors.py`'s
-  existing tests must still pass unmodified in behavior (only in internal
+  recorded in this item's implementation, and both callers' existing
+  tests must still pass unmodified in behavior (only in internal
   implementation, if needed).
 - Apply the same `tool_schema=` treatment to `make_semantics_extractor`
   (`output_key="judgment"`) and `make_doc_classification_extractor`
@@ -171,4 +178,4 @@ broader audit and scoping step.
 
 - Workstream: `project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md`
 - Design/audit: `lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md`
-- Design: `project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`
+- Design: `lcats/project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md`

--- a/lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
@@ -1,0 +1,106 @@
+---
+id: WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY
+kind: planning_node
+title: Event-Role-World pipeline structured-output reliability
+status: proposed
+stage: designed
+origin: design_review
+summary: Fix the systemic structured-output reliability gaps found by the 2026-07-27 ERW pipeline audit — missing strict-mode tool schemas, unguarded array-item type assumptions, unconstrained extractors with no tool schema at all, and processor.py's model/error-handling gaps — across two work items split by whether the fix touches lcats/lcats/analysis/event_role_world/ directly.
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_design:
+  - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
+  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+work_items:
+  - WI-EVENT-0032
+  - WI-EVENT-0033
+exit_criteria:
+  - All seven Event-Role-World-adjacent tool schemas (the six event_role_world/ extractors plus corpus/assess.py's ASSESSMENT_TOOL) set strict:true and additionalProperties:false at every object level, at the source rather than via a caller-local runtime override
+  - All eleven array-item sites across the six event_role_world/ extractors detect a malformed (non-dict) item, preserve the raw offending payload for diagnosis, and surface an explicit extraction error for the affected segment/story instead of silently skipping it
+  - processor.py's process_segments() accepts a model override and process_segment()'s per-pass error handling preserves the structured api_error dict (category/can_retry/should_abort_batch) instead of discarding it into a plain string
+  - scene_analysis.py's make_segment_extractor and make_semantics_extractor, and story_analysis.py's make_doc_classification_extractor, use the tool= structured-output path instead of unconstrained json_object mode, with story_processors.py's two call sites (segments = seg_extraction.get("extracted_output") or []) updated to match the new extracted_output shape
+  - Both work items resolved and lrh validate reports 0 errors
+---
+
+# Workstream: Event-Role-World pipeline structured-output reliability
+
+## Purpose
+
+This workstream coordinates the fix for every finding in the 2026-07-27 ERW
+pipeline structured-output reliability audit
+(`lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md`),
+except Category E (cost visibility, checkpointing, local models), which the
+audit's own "Next steps" section identifies as independent and schedulable
+separately. Two real crashes during WI-EVENT-0030 dogfooding (a `ValueError`
+on non-JSON segmentation output, fixed at the source in PR #167; an
+`AttributeError` on a malformed tool-result array item in
+`relation_extractor.build_relations`, worked around via a caller-local
+runtime override in PR #168) turned out to be instances of systemic gaps
+that WI-EVENT-0030's own `forbidden_actions: modify_event_role_world_extractor`
+blocks it from fixing at the source. This workstream exists to give that
+fix an unconstrained work item, split from a second, more novel design
+problem (Category C) that needs its own scoping because of a real
+call-site blast radius.
+
+## Scope
+
+- **WI-EVENT-0032** (Categories A, B, D): harden the six
+  `event_role_world/` extractors' tool schemas to `strict: true`, add
+  defensive array-item type checks with explicit extraction-error surfacing
+  at all eleven identified sites, and fix `processor.py`'s hardcoded model
+  and discarded structured error info. This item is deliberately
+  unconstrained by `modify_event_role_world_extractor` — fixing at the
+  source inside `event_role_world/` is the entire point.
+- **WI-EVENT-0033** (Category C): add `tool_schema=` to the three
+  extractors that currently use unconstrained `json_object` mode
+  (`scene_analysis.py`'s `make_segment_extractor`/`make_semantics_extractor`,
+  `story_analysis.py`'s `make_doc_classification_extractor`), explicitly
+  handling the `extracted_output` shape change this implies for
+  `story_processors.py`'s two call sites that currently expect a bare list.
+- Land both work items through the standard LRH execution lifecycle
+  (`/lrh-implement` → `/lrh-review-response` → `/lrh-confirm-fixes` →
+  `/lrh-closeout`).
+- Category E (model-invocation logging/budgeting, restartable/checkpointed
+  runs, local/cheaper models) is explicitly out of scope for this
+  workstream — the audit's own "Next steps" section treats it as an
+  independent, non-correctness concern schedulable on its own, separate
+  from this workstream's reliability-bug focus.
+
+## Prior Art Check
+
+### Duplication search
+- In-repo: No existing work item or workstream covers these findings.
+  WI-EVENT-0030 identifies the same gaps but is explicitly blocked from
+  fixing them by its own `forbidden_actions`. PR #166/#167/#168 already
+  fixed the two crashes that triggered this audit, but only #167 fixed at
+  the source (a shared parser bug outside `event_role_world/`) — #166 and
+  #168 are caller-local workarounds in `run_pilot.py`, not source fixes,
+  and are exactly what these two work items now supersede with real fixes.
+- Sibling repos: None identified.
+- External libraries: None identified.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: WI-EVENT-0030's own audit note ("Not yet acted on") directly
+  requests this scoping step, having deferred it pending the audit and the
+  in-progress pilot run finishing.
+- Proposals: None found beyond the governing Event-Role-World extractor
+  proposal, which this workstream's fixes bring closer to that proposal's
+  own stated reliability expectations (structured output via `tool=`, not
+  `json_object` mode).
+- Backlog: No matching entries.
+- Recommendation: Proceed.
+
+## Work Items
+
+- **WI-EVENT-0032** — Harden Event-Role-World tool-schema reliability:
+  strict-mode schemas, defensive array-item checks with explicit error
+  surfacing, and `processor.py`'s model-override/structured-error gaps.
+- **WI-EVENT-0033** — Add schema-hardened structured output to the three
+  unconstrained scene/story analysis extractors, addressing the
+  `story_processors.py` call-site blast radius.
+
+## Exit Criteria
+
+(see frontmatter `exit_criteria:` above)

--- a/lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
@@ -11,15 +11,15 @@ related_focus:
 related_roadmap: []
 related_design:
   - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
-  - project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
+  - lcats/project/design/proposals/adopted/lcats-event-role-world-extractor/00_proposal.md
 work_items:
   - WI-EVENT-0032
   - WI-EVENT-0033
 exit_criteria:
   - All seven Event-Role-World-adjacent tool schemas (the six event_role_world/ extractors plus corpus/assess.py's ASSESSMENT_TOOL) set strict:true and additionalProperties:false at every object level, at the source rather than via a caller-local runtime override
-  - All eleven array-item sites across the six event_role_world/ extractors detect a malformed (non-dict) item, preserve the raw offending payload for diagnosis, and surface an explicit extraction error for the affected segment/story instead of silently skipping it
-  - processor.py's process_segments() accepts a model override and process_segment()'s per-pass error handling preserves the structured api_error dict (category/can_retry/should_abort_batch) instead of discarding it into a plain string
-  - scene_analysis.py's make_segment_extractor and make_semantics_extractor, and story_analysis.py's make_doc_classification_extractor, use the tool= structured-output path instead of unconstrained json_object mode, with story_processors.py's two call sites (segments = seg_extraction.get("extracted_output") or []) updated to match the new extracted_output shape
+  - All twelve array-item sites across the six event_role_world/ extractors detect a malformed (non-dict) item, preserve the raw offending payload for diagnosis, and surface an explicit extraction error for the affected segment/story instead of silently skipping it
+  - processor.py's process_segments() accepts a model override and process_segment()'s per-pass error handling preserves the structured api_error dict (category/can_retry/should_abort_batch) instead of discarding it into a plain string, via an explicitly scoped extraction_errors representation change in schema.py and its callers (see WI-EVENT-0032)
+  - scene_analysis.py's make_segment_extractor and make_semantics_extractor, and story_analysis.py's make_doc_classification_extractor, use the tool= structured-output path instead of unconstrained json_object mode, with both real consumers of make_segment_extractor's bare-list output (story_processors.py:142 and run_pilot.py's _segment_story:277) updated to match the new extracted_output shape
   - Both work items resolved and lrh validate reports 0 errors
 ---
 
@@ -48,7 +48,7 @@ call-site blast radius.
 - **WI-EVENT-0032** (Categories A, B, D): harden the six
   `event_role_world/` extractors' tool schemas to `strict: true`, add
   defensive array-item type checks with explicit extraction-error surfacing
-  at all eleven identified sites, and fix `processor.py`'s hardcoded model
+  at all twelve identified sites, and fix `processor.py`'s hardcoded model
   and discarded structured error info. This item is deliberately
   unconstrained by `modify_event_role_world_extractor` — fixing at the
   source inside `event_role_world/` is the entire point.
@@ -57,7 +57,9 @@ call-site blast radius.
   (`scene_analysis.py`'s `make_segment_extractor`/`make_semantics_extractor`,
   `story_analysis.py`'s `make_doc_classification_extractor`), explicitly
   handling the `extracted_output` shape change this implies for
-  `story_processors.py`'s two call sites that currently expect a bare list.
+  its two real consumers (`story_processors.py:142` and
+  `run_pilot.py`'s `_segment_story:277`) that currently expect a bare
+  list.
 - Land both work items through the standard LRH execution lifecycle
   (`/lrh-implement` → `/lrh-review-response` → `/lrh-confirm-fixes` →
   `/lrh-closeout`).


### PR DESCRIPTION
## Summary
- Per the 2026-07-27 ERW pipeline structured-output reliability audit's own "Next steps" recommendation (`lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md`), this PR creates the actual work item(s)/workstream for its Categories A/B/D and C findings. Category E (cost/logging/checkpointing/local models) is explicitly out of scope, per the audit's own note that it's independent and schedulable separately.
- **WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY** (`project/workstreams/proposed/`): coordinates the two work items below.
- **WI-EVENT-0032** (Categories A/B/D): strict-mode tool schemas across all seven ERW-adjacent schemas, defensive array-item checks with explicit extraction-error surfacing at all eleven identified sites, and `processor.py`'s model-override/structured-error gaps. Deliberately unconstrained by `forbidden_actions: modify_event_role_world_extractor` — WI-EVENT-0030 cannot fix any of this at the source itself, which is why PR #166/#168 landed as caller-local runtime overrides instead.
- **WI-EVENT-0033** (Category C): schema-hardened structured output for the three extractors currently using unconstrained `json_object` mode (two in `scene_analysis.py`, one in `story_analysis.py`), scoped to explicitly address the `story_processors.py` call-site blast radius the audit flagged — `extracted_output`'s shape changes under `tool_schema` mode, which would otherwise silently break segmentation's other real caller.
- This PR authors only the planning artifacts — no source code is changed. Implementation of each item is separate, future work.

## Test plan
- [x] `lrh validate` (from `lcats/`) — 0 errors (47 warnings, all pre-existing `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS` style warnings matching the repo's existing `owner: unassigned` convention, e.g. WI-EVENT-0030 itself).
