### PR TITLE
Add work item WI-PACKAGING-0035: Add setuptools-scm dynamic versioning and remove lcats/setup.py

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_28_15_43_44_PR176_REVIEW_FIXES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_15_43_44_PR176_REVIEW_FIXES.md
@@ -1,0 +1,43 @@
+---
+execution_id: 2026_07_28_15_43_44_PR176_REVIEW_FIXES
+prompt_id: PROMPT(AD_HOC:PR176_REVIEW_FIXES)[2026-07-28T15:43:32-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/176
+commit: 
+created_at: 2026-07-28T15:43:44-04:00
+---
+
+# Summary
+
+Apply direct fixes to `WI-PACKAGING-0035.md`, `WS-PACKAGING.md`, and
+`work_items/README.md` in response to PR #176's landed automated review
+(Codex + Copilot), following the land-to-closeout skill's "apply fixes
+directly" path rather than routing through `/lrh-review-response` for
+the fix itself.
+
+# Result
+
+3 findings, all legitimate:
+
+1. Codex (P2) — `WS-PACKAGING.md`'s `work_items:` still listed only
+   `WI-PACKAGING-0031`/`-0032`, and its `## Work Items` prose still
+   described this item as `*(planned)*`. Added `WI-PACKAGING-0035` to
+   `work_items:` and replaced the planned-bullet with a resolved entry
+   (matching the same pattern used for the prior two phases).
+2. Codex (P2) — the new item wasn't listed in
+   `project/work_items/README.md`'s `## Proposed Items` index. Added it.
+3. Copilot — Required Change #6's `rm -rf src/lcats.egg-info && pip
+   install -e ".[dev]"` command is cwd-dependent but the WI didn't state
+   it must run from `lcats/`. Added that explicitly, matching the
+   convention already established across `lcats/scripts/*`.
+
+# Validation
+
+- `lrh validate` from `lcats/`: 0 errors, 47 warnings (pre-existing,
+  unrelated).
+
+# Follow-up
+
+None — proceeding to `/lrh-confirm-fixes` to resolve the review threads.

--- a/lcats/project/executions/AD_HOC/2026_07_28_15_47_46_WI_PACKAGING_0035_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_15_47_46_WI_PACKAGING_0035_CONFIRM.md
@@ -1,0 +1,50 @@
+---
+execution_id: 2026_07_28_15_47_46_WI_PACKAGING_0035_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_PACKAGING_0035_CONFIRM)[2026-07-28T15:46:06-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_28_15_43_44_PR176_REVIEW_FIXES
+pr: https://github.com/xenotaur/LCATS/pull/176
+commit: 
+created_at: 2026-07-28T15:47:46-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/176
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge confirm-fixes pass for PR #176. Independently verified the fixes
+applied in `2026_07_28_15_43_44_PR176_REVIEW_FIXES` against the live PR
+diff, and resolved the review threads the diff plainly satisfies.
+
+# Result
+
+All 3 threads classified **Clear-satisfied** against `gh pr diff 176`
+(`HEAD` = `34a601a5`):
+
+1. chatgpt-codex-connector (P2) — `WS-PACKAGING.md` not registering the
+   item → diff adds `work_items:` entry + prose update. Resolved.
+2. chatgpt-codex-connector (P2) — missing from `work_items/README.md`
+   index → diff adds it. Resolved.
+3. copilot-pull-request-reviewer — Step 6's cwd-dependent command → diff
+   adds explicit `lcats/` cwd. Resolved.
+
+No Unaddressed / Partial / Ambiguous / Problematic threads.
+
+Thread-resolution verdict: **green**.
+
+# Validation
+
+- `lrh github threads --mode raw --state all`: 3 threads found, all
+  correlated to review comments 1:1 by latest-comment URL.
+- `gh pr diff 176`: confirmed all 3 fixes are plainly present in the diff.
+- `gh api graphql resolveReviewThread`: all 3 threads confirmed
+  `isResolved: true` after mutation.
+- `lrh validate`: 0 errors, 47 pre-existing warnings unrelated to this
+  change.
+
+# Follow-up
+
+None — final readiness verdict reported to the user for the human merge
+gate.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -16,6 +16,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md` — Design persistence layer for corpus state and operation history
 - `proposed/WI-EVENT-0030.md` — Run stratified cross-segment relation density pilot across genres
+- `proposed/WI-PACKAGING-0035.md` — Add setuptools-scm dynamic versioning and remove lcats/setup.py
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-PACKAGING-0035.md
+++ b/lcats/project/work_items/proposed/WI-PACKAGING-0035.md
@@ -1,0 +1,165 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-PACKAGING-0035
+title: Add setuptools-scm dynamic versioning and remove lcats/setup.py
+type: deliverable
+status: proposed
+owner: xenotaur
+contributors:
+  - xenotaur
+assigned_agents: []
+related_focus: []
+related_roadmap: []
+related_workstreams:
+  - WS-PACKAGING
+related_design:
+  - project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md
+depends_on:
+  - WI-PACKAGING-0032
+blocked_by: []
+expected_actions:
+  - create_file
+  - edit_file
+  - delete_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - modify_ci_pipeline
+acceptance:
+  - lcats/pyproject.toml declares dynamic = ["version"] and no longer has a static version = "0.1" field
+  - build-system.requires includes setuptools-scm
+  - a [tool.setuptools_scm] table exists with a fallback_version set, matching logical_robotics_harness's own pattern
+  - a first git tag (e.g. v0.1.0) exists on the repo, since none currently exist
+  - lcats/setup.py no longer exists
+  - python -m pip install -e ".[dev]" succeeds and reports a version derived from the git tag, not a hardcoded string
+  - lrh validate reports 0 errors
+required_evidence:
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/pyproject.toml
+  - lcats/setup.py
+---
+
+## Summary
+
+Add dynamic versioning to `lcats/pyproject.toml` via `setuptools-scm`
+(deriving the installed version from git tags instead of the hardcoded,
+never-updated `version = "0.1"`), cut the repo's first git tag, and
+remove the now-fully-redundant `lcats/setup.py`. Phase 3 of `WS-PACKAGING`
+— the last piece before the workstream can close.
+
+## Problem / Context
+
+`PROP-LCATS-PACKAGING-MODERNIZATION` (merged via PR #159) identified
+`version = "0.1"` as static and never updated since it was added;
+`WS-PACKAGING` (merged via PR #160) sequences this as Phase 3, after the
+src-layout move (`WI-PACKAGING-0032`, resolved) lands, so the package
+structure is stable before adding SCM-based versioning on top of it. This
+item must not begin before `WI-PACKAGING-0032` is resolved (already
+true). Confirmed this session: the repo currently has **zero git tags**
+— `git tag --list` returns nothing — so cutting the first tag is a real,
+necessary action, not a formality. Also confirmed: `lcats/setup.py` still
+calls bare `find_packages()` with no `where="src"` parameter, meaning
+it's already silently broken/stale since the Phase 2 src-layout move (it
+would discover zero packages if anything still invoked it) — one more
+reason it's safe and correct to delete rather than fix.
+
+### Duplication search
+- In-repo: No existing implementation found.
+- Sibling repos: `logical_robotics_harness/pyproject.toml` already
+  implements this exact pattern (`dynamic = ["version"]`,
+  `[tool.setuptools_scm]` with `fallback_version`) — reference, not
+  duplicate.
+- External libraries: None identified — `setuptools-scm` is the
+  dependency being adopted, not duplicated.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found (`PROP-LCATS-PACKAGING-MODERNIZATION` is the
+  originating request, already linked via `related_design`).
+- Backlog: No matching entries (`project/design/backlog.md` doesn't exist
+  in this repo).
+- Recommendation: No action.
+
+## Scope
+
+- Edit `lcats/pyproject.toml`: add `setuptools-scm` to
+  `build-system.requires`, switch `version` to `dynamic = ["version"]`,
+  add `[tool.setuptools_scm]` with `fallback_version`.
+- Cut the repo's first git tag.
+- Delete `lcats/setup.py`.
+- Reinstall editable and confirm the derived version reports correctly.
+
+## Required Changes
+
+1. `lcats/pyproject.toml`: add `"setuptools-scm"` to
+   `build-system.requires`.
+2. `lcats/pyproject.toml`: remove `version = "0.1"` from `[project]`, add
+   `dynamic = ["version"]`.
+3. `lcats/pyproject.toml`: add `[tool.setuptools_scm]` with
+   `fallback_version = "0.1.0"` (matching
+   `logical_robotics_harness`'s own `fallback_version = "0.0.0"` pattern,
+   adjusted to reflect LCATS's prior static version).
+4. Cut a first annotated git tag (e.g. `v0.1.0`) and push it — confirm
+   with the user before pushing, since tagging affects shared repo state.
+5. Delete `lcats/setup.py`.
+6. `rm -rf src/lcats.egg-info && pip install -e ".[dev]"` in the `LCATS`
+   conda env to regenerate against dynamic versioning.
+7. Verify the installed version reflects the git tag: `pip show lcats` or
+   `python -c "import importlib.metadata; print(importlib.metadata.version('lcats'))"`.
+
+## Non-Goals
+
+- Does not change `requires-python` or any runtime dependency.
+- Does not modify CI workflow YAML.
+- Does not touch `lcats/src/lcats/` package code.
+- Does not establish a broader release/tagging cadence or changelog
+  process — only the first tag needed to unblock `setuptools-scm`.
+
+## Acceptance Criteria
+
+- `lcats/pyproject.toml` declares `dynamic = ["version"]` and no longer
+  has a static `version = "0.1"` field.
+- `build-system.requires` includes `setuptools-scm`.
+- A `[tool.setuptools_scm]` table exists with a `fallback_version` set,
+  matching `logical_robotics_harness`'s own pattern.
+- A first git tag (e.g. `v0.1.0`) exists on the repo, since none
+  currently exist.
+- `lcats/setup.py` no longer exists.
+- `python -m pip install -e ".[dev]"` succeeds and reports a version
+  derived from the git tag, not a hardcoded string.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `python -m pip install -e ".[dev]"`
+- `python -c "import importlib.metadata; print(importlib.metadata.version('lcats'))"`
+
+## Risk Notes
+
+- Cutting and pushing a git tag is a shared-state, harder-to-reverse
+  action (unlike file edits on a branch) — confirm explicitly with the
+  user before pushing, even though this WI's `expected_actions` covers
+  it.
+- `fallback_version` must be set so a tag-less checkout (e.g. a shallow
+  CI clone, or a tarball) doesn't hard-fail the build — verify by testing
+  an install after a fresh shallow clone if feasible, or at minimum
+  confirm the fallback value is sane.
+- Deleting `setup.py` outright (rather than gutting it) is safe per the
+  proposal's Decision 3 — confirmed no other file in the repo invokes it
+  directly.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-PACKAGING.md`
+- Design: `project/design/proposals/proposed/lcats-packaging-modernization/00_proposal.md`

--- a/lcats/project/work_items/proposed/WI-PACKAGING-0035.md
+++ b/lcats/project/work_items/proposed/WI-PACKAGING-0035.md
@@ -109,7 +109,9 @@ reason it's safe and correct to delete rather than fix.
 4. Cut a first annotated git tag (e.g. `v0.1.0`) and push it — confirm
    with the user before pushing, since tagging affects shared repo state.
 5. Delete `lcats/setup.py`.
-6. `rm -rf src/lcats.egg-info && pip install -e ".[dev]"` in the `LCATS`
+6. From `lcats/` (the package root — the `egg-info` path is relative to
+   it, matching the convention already used throughout `lcats/scripts/*`):
+   `rm -rf src/lcats.egg-info && pip install -e ".[dev]"` in the `LCATS`
    conda env to regenerate against dynamic versioning.
 7. Verify the installed version reflects the git tag: `pip show lcats` or
    `python -c "import importlib.metadata; print(importlib.metadata.version('lcats'))"`.

--- a/lcats/project/workstreams/proposed/WS-PACKAGING.md
+++ b/lcats/project/workstreams/proposed/WS-PACKAGING.md
@@ -13,6 +13,7 @@ related_design:
 work_items:
   - WI-PACKAGING-0031
   - WI-PACKAGING-0032
+  - WI-PACKAGING-0035
 exit_criteria:
   - lcats/pyproject.toml declares license via PEP 639 (license = "MIT" + license-files), pins setuptools>=77 (the version that added PEP 639 support), sets required-version for tool.ruff and tool.black, has no duplicate test/dev extras, and pins gutenbergpy to a commit SHA
   - lcats package code lives at lcats/src/lcats/ with scripts/lint, scripts/format, secrets.py, and all lcats/lcats path literals updated accordingly, and the full test suite passes against the new layout
@@ -68,8 +69,9 @@ item couldn't express.
   `lcats/src/lcats/`, update `scripts/lint`/`scripts/format`, `secrets.py`,
   path-literal audit, reinstall, full test run. `depends_on:
   WI-PACKAGING-0031`.
-- *(planned)* Dynamic versioning + `setup.py` removal — `setuptools-scm`,
-  first git tag, delete `setup.py`.
+- **WI-PACKAGING-0035** — Dynamic versioning + `setup.py` removal:
+  `setuptools-scm`, first git tag, delete `setup.py`. `depends_on:
+  WI-PACKAGING-0032`.
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary
Phase 3 of `WS-PACKAGING`: add `setuptools-scm` dynamic versioning to `lcats/pyproject.toml` (deriving the installed version from git tags instead of the hardcoded, never-updated `version = "0.1"`), cut the repo's first git tag, and remove the now-fully-redundant `lcats/setup.py`.

- `id`: WI-PACKAGING-0035
- `type`: deliverable
- `related_workstreams`: WS-PACKAGING
- `depends_on`: WI-PACKAGING-0032 (already resolved)

## Confirmed findings during drafting
- This repo currently has **zero git tags** — cutting the first one is a real, necessary action.
- `lcats/setup.py` is already silently broken since the Phase 2 src-layout move (bare `find_packages()` with no `where="src"`) — confirms it's safe to delete outright.

## Acceptance criteria
See the work item's `## Acceptance Criteria` section — 7 conditions covering the `dynamic = ["version"]` switch, `setuptools-scm` build-requires, `[tool.setuptools_scm]` config, the first git tag, `setup.py` removal, and the derived-version verification.

This is a planning artifact only — no implementation in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
