### PR TITLE
Add work item WI-PACKAGING-0036: Replace hardcoded parent-depth path counting with a pyproject.toml anchor

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_28_17_49_16_WI_PACKAGING_0036_REVIEW_FIXES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_17_49_16_WI_PACKAGING_0036_REVIEW_FIXES.md
@@ -5,7 +5,7 @@ work_item: AD_HOC
 status: in_progress
 rerun_of: 
 pr: https://github.com/xenotaur/LCATS/pull/178
-commit: 
+commit: e5c42e4b
 created_at: 2026-07-28T17:49:16-04:00
 ---
 

--- a/lcats/project/executions/AD_HOC/2026_07_28_17_49_16_WI_PACKAGING_0036_REVIEW_FIXES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_17_49_16_WI_PACKAGING_0036_REVIEW_FIXES.md
@@ -1,0 +1,59 @@
+---
+execution_id: 2026_07_28_17_49_16_WI_PACKAGING_0036_REVIEW_FIXES
+prompt_id: PROMPT(AD_HOC:WI_PACKAGING_0036_REVIEW_FIXES)[2026-07-28T17:49:10-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/178
+commit: 
+created_at: 2026-07-28T17:49:16-04:00
+---
+
+# Summary
+
+Applied automated-review fixes to PR #178 (creation of `WI-PACKAGING-0036`,
+a planning-only work item — no primary execution record existed since
+`/lrh-work-item` mints none). This record serves as the primary record for
+the whole PR.
+
+# Result
+
+Reviewed 3 automated comments (Copilot + Codex) against the actual source
+files rather than applying blindly:
+
+1. **Copilot — `work_items/README.md` Proposed Items index incomplete.**
+   Confirmed via grep (`status: proposed` files not listed:
+   `WI-ASSESS-0031`, `WI-EVENT-0032`, `WI-EVENT-0033`). Valid — added all
+   three to the index.
+2. **Copilot — `.parent` in the `secrets.py` replacement example is
+   wrong.** Checked `src/lcats/utils/secrets.py`'s own header comment:
+   `.secrets/` lives at the repo root, one level *above* the directory
+   containing `pyproject.toml`. `find_pyproject_root(__file__)` (per the
+   WI's own stated contract) returns that `pyproject.toml` directory, so
+   `.parent` is required to reach the repo root and matches the existing
+   `parents[4]` behavior exactly. Determined this finding to be factually
+   incorrect — left the example unchanged.
+3. **Codex (P1) — non-editable install risk.** Valid: the WI's original
+   Required Changes item 2 computed `_DEFAULT_SECRETS_DIR` via an
+   unguarded module-level call to `find_pyproject_root`, which would raise
+   `FileNotFoundError` at `import lcats.utils.secrets` time for a wheel or
+   `pip install .` install outside the checkout — breaking imports
+   entirely instead of preserving the current silent no-op behavior.
+   Updated Required Changes, Risk Notes, and Validation sections to
+   require a guarded fallback (catch the not-found case, set
+   `_DEFAULT_SECRETS_DIR` to `None`) and a non-editable-install validation
+   step.
+
+# Validation
+
+- `lrh validate`: 0 errors, 47 warnings (all pre-existing, unrelated).
+- No code changes in this PR (planning-artifact-only); no test suite run
+  required.
+
+# Follow-up
+
+None. `WI-PACKAGING-0036` remains `status: proposed`; a future
+implementation PR will pick it up and apply the fallback design captured
+here.
+
+CHAIN-NOTE: cycles=1; stops=0; gates=[merge]; friction=none; note="one bot finding (Copilot .parent) was factually wrong and rebutted rather than applied"

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -16,6 +16,9 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md` — Design persistence layer for corpus state and operation history
 - `proposed/WI-EVENT-0030.md` — Run stratified cross-segment relation density pilot across genres
+- `proposed/WI-ASSESS-0031.md` — Extend VALID_GENRES from 4 to 8 target genres
+- `proposed/WI-EVENT-0032.md` — Harden Event-Role-World tool-schema reliability and processor error/model handling
+- `proposed/WI-EVENT-0033.md` — Add schema-hardened structured output to scene/story analysis extractors
 - `proposed/WI-PACKAGING-0036.md` — Replace hardcoded parent-depth path counting with a pyproject.toml anchor
 
 ## Abandoned Items

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -16,6 +16,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 ## Proposed Items
 - `proposed/WI-PERSIST-0004.md` — Design persistence layer for corpus state and operation history
 - `proposed/WI-EVENT-0030.md` — Run stratified cross-segment relation density pilot across genres
+- `proposed/WI-PACKAGING-0036.md` — Replace hardcoded parent-depth path counting with a pyproject.toml anchor
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-PACKAGING-0036.md
+++ b/lcats/project/work_items/proposed/WI-PACKAGING-0036.md
@@ -95,7 +95,9 @@ rather than the anchor approach — so this WI covers both, not just
    without finding one.
 2. `secrets.py`: replace
    `pathlib.Path(__file__).resolve().parents[4] / ".secrets"` with
-   `find_pyproject_root(__file__).parent / ".secrets"`.
+   `find_pyproject_root(__file__).parent / ".secrets"`, guarding the
+   module-level assignment so a non-editable install (no `pyproject.toml`
+   ancestor on disk) doesn't raise at import time — see Risk Notes.
 3. `test_utils.py`: replace the `../../../tests/data` relative-path join
    with `find_pyproject_root(__file__) / "tests" / "data"`.
 4. `paths.py`: correct the header comment path from
@@ -133,15 +135,33 @@ rather than the anchor approach — so this WI covers both, not just
 - `scripts/lint`
 - `scripts/test`
 - `python -c "from lcats.utils.secrets import _DEFAULT_SECRETS_DIR; print(_DEFAULT_SECRETS_DIR)"`
+- A non-editable install check: `pip install .` (not `-e`) into a
+  throwaway venv outside the checkout, then confirm
+  `import lcats.utils.secrets` succeeds and `load_secrets()` still
+  no-ops rather than raising.
 
 ## Risk Notes
 
 - The new helper must correctly handle both editable-install and
-  non-editable-install cases — verify with the actual `pip install -e .`
-  state already in use, not just a fresh checkout.
+  non-editable-install cases — verify with an actual non-editable install
+  (e.g. `pip install .` into a separate venv, or a built wheel), not just
+  `pip install -e .`.
+- `secrets.py`'s `_DEFAULT_SECRETS_DIR` is computed at module import time.
+  A wheel or `pip install .` install outside the checkout has no
+  `pyproject.toml` ancestor on disk, so calling `find_pyproject_root`
+  unguarded at module scope would raise `FileNotFoundError` on every
+  `import lcats.utils.secrets` — breaking `load_secrets()` entirely,
+  including calls that pass an explicit `secrets_dir=...` and don't need
+  the default at all. Today's behavior is a silent no-op when
+  `.secrets/` doesn't exist (see `load_secrets`'s docstring); the fallback
+  must preserve that: catch the "not found" case at import time and set
+  `_DEFAULT_SECRETS_DIR` to `None` (or similar), so `load_secrets()`
+  continues to no-op gracefully in non-editable installs instead of
+  failing to import.
 - Keep the walk-up bounded (stop at filesystem root) so a misconfigured
-  environment fails loudly with a clear error rather than looping or
-  raising an unrelated exception.
+  environment fails loudly with a clear error only when the lookup is
+  actually invoked with no explicit override — not as an import-time
+  side effect.
 
 ## Related Workstream and Designs
 

--- a/lcats/project/work_items/proposed/WI-PACKAGING-0036.md
+++ b/lcats/project/work_items/proposed/WI-PACKAGING-0036.md
@@ -1,0 +1,152 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-PACKAGING-0036
+title: Replace hardcoded parent-depth path counting with a pyproject.toml anchor
+type: operation
+status: proposed
+owner: xenotaur
+contributors:
+  - xenotaur
+assigned_agents: []
+related_focus: []
+related_roadmap: []
+related_workstreams: []
+related_design:
+  - project/design/proposals/adopted/lcats-packaging-modernization/00_proposal.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - create_file
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - modify_ci_pipeline
+acceptance:
+  - lcats/src/lcats/utils/paths.py has a new helper that walks up from a starting file to find the directory containing pyproject.toml, raising a clear error if none is found
+  - secrets.py's _DEFAULT_SECRETS_DIR uses the new helper instead of parents[4]
+  - test_utils.py's TestCaseWithData.test_data_dir uses the new helper instead of ../../../tests/data
+  - paths.py's own header comment is corrected (still says lcats/lcats/utils/paths.py, stale since the src-layout move)
+  - the full test suite passes, confirming the anchor-based lookup resolves identically to the current hardcoded values
+  - lrh validate reports 0 errors
+required_evidence:
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/src/lcats/utils/paths.py
+  - lcats/src/lcats/utils/secrets.py
+  - lcats/src/lcats/utils/test_utils.py
+---
+
+## Summary
+
+Replace the two hardcoded `parents[N]`/relative-path depth-counting
+lookups in `secrets.py` and `test_utils.py` with a shared helper that
+anchors on the presence of `pyproject.toml`, so a future package-layout
+change can't silently break either one again the way the src-layout move
+already did twice.
+
+## Problem / Context
+
+`WI-PACKAGING-0032`'s Non-Goals explicitly deferred this: "Does not
+replace `secrets.py`'s parent-depth-counting pattern with a more robust
+anchor-on-`pyproject.toml` approach... a proper fix is a candidate
+follow-up per the proposal's Non-Goals." No work item was ever created
+for it. During the same effort, `test_utils.py`'s `TestCaseWithData` was
+found to have the identical fragility class (`../../../tests/data`,
+discovered via the project's own grep-parent-depth-pattern lesson from
+that effort), and was fixed with the same kind of one-line index bump
+rather than the anchor approach — so this WI covers both, not just
+`secrets.py`, since they're the same root cause.
+
+### Duplication search
+- In-repo: No existing repo-root/package-root-finder utility found
+  (confirmed via grep across `lcats/src/lcats`).
+- Sibling repos: None checked — this is LCATS-specific path-resolution
+  logic.
+- External libraries: None identified — a simple upward directory walk
+  doesn't need a dependency.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found (the deferral is a Non-Goals note in
+  `WI-PACKAGING-0032`, not a separate request).
+- Backlog: `project/design/backlog.md` doesn't exist in this repo.
+- Recommendation: No action.
+
+## Scope
+
+- Add one shared helper to `lcats/src/lcats/utils/paths.py`.
+- Update `secrets.py` and `test_utils.py` to use it instead of their
+  current hardcoded depth/relative-path logic.
+- Fix `paths.py`'s own stale header comment while touching the file.
+
+## Required Changes
+
+1. Add a function to `paths.py` (e.g. `find_pyproject_root(start=None)`)
+   that walks up from a starting path looking for a `pyproject.toml`
+   file, returning the containing directory, and raises a clear
+   `FileNotFoundError`-style error if it walks off the filesystem root
+   without finding one.
+2. `secrets.py`: replace
+   `pathlib.Path(__file__).resolve().parents[4] / ".secrets"` with
+   `find_pyproject_root(__file__).parent / ".secrets"`.
+3. `test_utils.py`: replace the `../../../tests/data` relative-path join
+   with `find_pyproject_root(__file__) / "tests" / "data"`.
+4. `paths.py`: correct the header comment path from
+   `lcats/lcats/utils/paths.py` to `lcats/src/lcats/utils/paths.py`.
+5. Run the full test suite to confirm both resolve to the same paths as
+   before.
+
+## Non-Goals
+
+- Does not touch any other file's path-resolution logic beyond these
+  two.
+- Does not add a general-purpose "project root" concept beyond what
+  these two call sites need.
+- Does not modify CI workflow YAML.
+
+## Acceptance Criteria
+
+- `lcats/src/lcats/utils/paths.py` has a new helper that walks up from a
+  starting file to find the directory containing `pyproject.toml`,
+  raising a clear error if none is found.
+- `secrets.py`'s `_DEFAULT_SECRETS_DIR` uses the new helper instead of
+  `parents[4]`.
+- `test_utils.py`'s `TestCaseWithData.test_data_dir` uses the new helper
+  instead of `../../../tests/data`.
+- `paths.py`'s own header comment is corrected (still says
+  `lcats/lcats/utils/paths.py`, stale since the src-layout move).
+- The full test suite passes, confirming the anchor-based lookup
+  resolves identically to the current hardcoded values.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `python -c "from lcats.utils.secrets import _DEFAULT_SECRETS_DIR; print(_DEFAULT_SECRETS_DIR)"`
+
+## Risk Notes
+
+- The new helper must correctly handle both editable-install and
+  non-editable-install cases — verify with the actual `pip install -e .`
+  state already in use, not just a fresh checkout.
+- Keep the walk-up bounded (stop at filesystem root) so a misconfigured
+  environment fails loudly with a clear error rather than looping or
+  raising an unrelated exception.
+
+## Related Workstream and Designs
+
+- Design:
+  `project/design/proposals/adopted/lcats-packaging-modernization/00_proposal.md`
+  (the closed effort that deferred this)
+- Not linked to any workstream — `WS-PACKAGING` is closed and this is
+  out-of-band cleanup, following the same pattern as `WI-PACKAGING-0034`.


### PR DESCRIPTION
## Summary

Registers `WI-PACKAGING-0036`, the deferred follow-up from `WI-PACKAGING-0032`'s Non-Goals: replace `secrets.py`'s `parents[4]` and `test_utils.py`'s `../../../tests/data` hardcoded path lookups with a shared `pyproject.toml`-anchor helper in `paths.py`, so a future package-layout change can't silently break either one again.

This is planning-only — no implementation code in this PR.

## Details

- New file: `lcats/project/work_items/proposed/WI-PACKAGING-0036.md`
- Registered in `lcats/project/work_items/README.md`'s Proposed Items index
- Not linked to a workstream (`WS-PACKAGING` is closed) — same pattern as `WI-PACKAGING-0034`
- `lrh validate`: 0 errors, 47 warnings (all pre-existing, unrelated to this file)

## Test plan

- [x] `lrh validate` passes with 0 errors
- [x] New WI file follows existing frontmatter/body conventions
- [x] README index updated in the same PR
