### PR TITLE
Implement WI-PACKAGING-0036: pyproject.toml-anchored path helper

### DIFF
--- a/lcats/project/executions/WI-PACKAGING-0036/2026_07_28_20_09_19_WI_PACKAGING_0036.md
+++ b/lcats/project/executions/WI-PACKAGING-0036/2026_07_28_20_09_19_WI_PACKAGING_0036.md
@@ -1,0 +1,83 @@
+---
+execution_id: 2026_07_28_20_09_19_WI_PACKAGING_0036
+prompt_id: PROMPT(WI-PACKAGING-0036:WI_PACKAGING_0036)[2026-07-28T19:56:26-04:00]
+work_item: WI-PACKAGING-0036
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/179
+commit: 37750e67
+created_at: 2026-07-28T20:09:19-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-PACKAGING-0036.md
+session_transcript: pending
+---
+
+# Summary
+
+Implemented `WI-PACKAGING-0036`: replaced `secrets.py`'s and
+`test_utils.py`'s hardcoded parent-depth path counting with a shared
+`find_pyproject_root()` helper in `paths.py`, anchored on the presence of
+`pyproject.toml`.
+
+# Result
+
+All 5 Required Changes applied:
+
+1. Added `find_pyproject_root(start=None)` to `paths.py`: walks upward
+   from `start` looking for `pyproject.toml`, returns the containing
+   directory, raises `FileNotFoundError` if none is found.
+2. `secrets.py`: `_DEFAULT_SECRETS_DIR` now computed via
+   `find_pyproject_root(__file__).parent`, guarded with
+   `try/except FileNotFoundError` → `None`, per the WI's Risk Notes (a
+   non-editable install has no `pyproject.toml` ancestor on disk).
+   `load_secrets()` treats `target is None` as the existing silent
+   no-op.
+3. `test_utils.py`: `TestCaseWithData.test_data_dir` now uses
+   `find_pyproject_root(__file__) / "tests" / "data"`.
+4. `paths.py`'s stale header comment corrected
+   (`lcats/lcats/...` → `lcats/src/lcats/...`).
+5. Full test suite run to confirm identical resolution to the prior
+   hardcoded values.
+
+Added new tests: `FindPyprojectRootTest` in `paths_test.py` (direct
+parent, several levels up, directory-as-start, not-found raises) and
+`TestLoadSecretsNoneDefaultDir` in `secrets_test.py` (None fallback
+no-ops).
+
+**Friction encountered (not a WI scope change):** the local pre-commit
+black hook failed on first commit attempt with a version mismatch
+(`0.1.dev1+g...` vs required `25.11.0`) — the documented
+pre-commit/setuptools_scm tagless-clone limitation (see
+`.pre-commit-config.yaml`'s header comment). Fixed by fetching tags into
+the cached hook repo clone (`~/.cache/pre-commit/repo*/`) and deleting
+its stale built venv so it rebuilt against the now-tagged clone. This is
+a local cache fix, not a repo change.
+
+Also found (during test-writing) a macOS-specific test bug in my own new
+`FindPyprojectRootTest`: comparing an unresolved `tempfile` path against
+`find_pyproject_root`'s `.resolve()`d return value failed because macOS
+aliases `/tmp` to `/private/tmp`. Fixed by resolving `self.tmp_dir` in
+`setUp`.
+
+# Validation
+
+All run in the `LCATS` conda env:
+
+- `scripts/format --check --diff`: 165 files unchanged.
+- `scripts/lint`: all checks passed.
+- `scripts/test`: `Ran 1454 tests in 5.731s — OK`.
+- `lrh validate`: 0 errors, 47 warnings (pre-existing, unrelated).
+- `python -c "from lcats.utils.secrets import _DEFAULT_SECRETS_DIR; print(_DEFAULT_SECRETS_DIR)"`:
+  resolved to the repo root's `.secrets/`, matching the prior
+  `parents[4]` behavior exactly.
+- Non-editable install check: built a throwaway venv
+  (`python3 -m venv /tmp/lcats_noneditable_test_venv`), ran
+  `pip install .` (not `-e`) from that venv against the checkout, then
+  from a separate cwd confirmed `import lcats.utils.secrets` succeeds
+  with `_DEFAULT_SECRETS_DIR is None` and `load_secrets()` no-ops rather
+  than raising. Throwaway venv removed afterward.
+
+# Follow-up
+
+None. This closes out `WI-PACKAGING-0036`'s Required Changes in full;
+no further packaging follow-ups are open at this time.

--- a/lcats/project/executions/WI-PACKAGING-0036/2026_07_28_20_09_19_WI_PACKAGING_0036.md
+++ b/lcats/project/executions/WI-PACKAGING-0036/2026_07_28_20_09_19_WI_PACKAGING_0036.md
@@ -77,6 +77,22 @@ All run in the `LCATS` conda env:
   with `_DEFAULT_SECRETS_DIR is None` and `load_secrets()` no-ops rather
   than raising. Throwaway venv removed afterward.
 
+# Review
+
+Codex (2 P1) and Copilot (1) flagged real issues, all fixed:
+
+- `secrets.py`/`test_utils.py` used member imports
+  (`from lcats.utils.paths import find_pyproject_root`) instead of the
+  module-import convention mandated by `AGENTS.md`'s Imports section —
+  changed to `from lcats.utils import paths` / `paths.find_pyproject_root(...)`.
+- `find_pyproject_root`'s `FileNotFoundError` message used the raw
+  `start` argument, which is `None` when the caller omits it (the
+  common case) — captured the effective origin path and used it both
+  for resolution and in the message.
+
+Re-ran `scripts/format`, `scripts/lint`, `scripts/test` (1454 tests,
+OK) after the fixes — all clean.
+
 # Follow-up
 
 None. This closes out `WI-PACKAGING-0036`'s Required Changes in full;

--- a/lcats/src/lcats/utils/paths.py
+++ b/lcats/src/lcats/utils/paths.py
@@ -100,7 +100,8 @@ def find_pyproject_root(start=None):
             (wheel or ``pip install .``) run outside the checkout, since
             no source tree exists on disk to walk.
     """
-    current = pathlib.Path(start if start is not None else __file__).resolve()
+    origin = start if start is not None else __file__
+    current = pathlib.Path(origin).resolve()
     if current.is_file():
         current = current.parent
 
@@ -109,7 +110,7 @@ def find_pyproject_root(start=None):
             return candidate
 
     raise FileNotFoundError(
-        f"no pyproject.toml found in any ancestor directory of {start!r}"
+        f"no pyproject.toml found in any ancestor directory of {origin!r}"
     )
 
 

--- a/lcats/src/lcats/utils/paths.py
+++ b/lcats/src/lcats/utils/paths.py
@@ -1,4 +1,4 @@
-# lcats/lcats/utils/paths.py
+# lcats/src/lcats/utils/paths.py
 """Symlink-aware filesystem helpers for LCATS's regenerable data/cache trees.
 
 Plain ``os.makedirs`` (even with ``exist_ok=True``) does not handle a
@@ -76,6 +76,41 @@ def makedirs(path):
         # os.makedirs below will create it.
 
     os.makedirs(target, exist_ok=True)
+
+
+def find_pyproject_root(start=None):
+    """Walk upward from `start` to find the directory containing pyproject.toml.
+
+    Anchoring on pyproject.toml (rather than counting parent-directory
+    hops) survives future package-layout changes -- the layout move from
+    ``lcats/lcats/`` to ``lcats/src/lcats/`` silently broke two hardcoded
+    depth-counting lookups (see ``lcats.utils.secrets`` and
+    ``lcats.utils.test_utils``) because nothing re-derived the depth.
+
+    Args:
+        start: file or directory to begin the search from. Defaults to
+            this module's own file location.
+
+    Returns:
+        The ``pathlib.Path`` of the directory containing ``pyproject.toml``.
+
+    Raises:
+        FileNotFoundError: no ancestor of `start` contains a
+            ``pyproject.toml`` -- expected for a non-editable install
+            (wheel or ``pip install .``) run outside the checkout, since
+            no source tree exists on disk to walk.
+    """
+    current = pathlib.Path(start if start is not None else __file__).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in (current, *current.parents):
+        if (candidate / "pyproject.toml").is_file():
+            return candidate
+
+    raise FileNotFoundError(
+        f"no pyproject.toml found in any ancestor directory of {start!r}"
+    )
 
 
 def clear_directory_contents(path):

--- a/lcats/src/lcats/utils/secrets.py
+++ b/lcats/src/lcats/utils/secrets.py
@@ -17,14 +17,18 @@ from __future__ import annotations
 
 import pathlib
 
-# .secrets/ is four package dirs above this file, then one more to the repo root:
-#   lcats/src/lcats/utils/secrets.py
-#       parents[0] = lcats/src/lcats/utils/
-#       parents[1] = lcats/src/lcats/
-#       parents[2] = lcats/src/
-#       parents[3] = lcats/        (package root, contains pyproject.toml)
-#       parents[4] = LCATS/LCATS/  (repo root, contains .secrets/)
-_DEFAULT_SECRETS_DIR = pathlib.Path(__file__).resolve().parents[4] / ".secrets"
+from lcats.utils.paths import find_pyproject_root
+
+# .secrets/ lives one level above the package root (the directory that
+# contains pyproject.toml), at the actual git repo root. A non-editable
+# install (wheel or `pip install .` outside the checkout) has no
+# pyproject.toml ancestor on disk at all, so find_pyproject_root raises --
+# fall back to None rather than letting that propagate out of a module
+# import, and treat None the same as "directory doesn't exist" below.
+try:
+    _DEFAULT_SECRETS_DIR = find_pyproject_root(__file__).parent / ".secrets"
+except FileNotFoundError:
+    _DEFAULT_SECRETS_DIR = None
 
 
 def load_secrets(secrets_dir: pathlib.Path | None = None) -> None:
@@ -39,7 +43,7 @@ def load_secrets(secrets_dir: pathlib.Path | None = None) -> None:
             <repo_root>/.secrets/ relative to this file's location.
     """
     target = secrets_dir if secrets_dir is not None else _DEFAULT_SECRETS_DIR
-    if not target.is_dir():
+    if target is None or not target.is_dir():
         return
     import dotenv
 

--- a/lcats/src/lcats/utils/secrets.py
+++ b/lcats/src/lcats/utils/secrets.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import pathlib
 
-from lcats.utils.paths import find_pyproject_root
+from lcats.utils import paths
 
 # .secrets/ lives one level above the package root (the directory that
 # contains pyproject.toml), at the actual git repo root. A non-editable
@@ -26,7 +26,7 @@ from lcats.utils.paths import find_pyproject_root
 # fall back to None rather than letting that propagate out of a module
 # import, and treat None the same as "directory doesn't exist" below.
 try:
-    _DEFAULT_SECRETS_DIR = find_pyproject_root(__file__).parent / ".secrets"
+    _DEFAULT_SECRETS_DIR = paths.find_pyproject_root(__file__).parent / ".secrets"
 except FileNotFoundError:
     _DEFAULT_SECRETS_DIR = None
 

--- a/lcats/src/lcats/utils/test_utils.py
+++ b/lcats/src/lcats/utils/test_utils.py
@@ -5,14 +5,14 @@ import shutil
 import tempfile
 import unittest
 
-from lcats.utils.paths import find_pyproject_root
+from lcats.utils import paths
 
 
 class TestCaseWithData(unittest.TestCase):
 
     def setUp(self):
         """Find the local test data directory, and create a temp dir."""
-        self.test_data_dir = str(find_pyproject_root(__file__) / "tests" / "data")
+        self.test_data_dir = str(paths.find_pyproject_root(__file__) / "tests" / "data")
         self.test_temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):

--- a/lcats/src/lcats/utils/test_utils.py
+++ b/lcats/src/lcats/utils/test_utils.py
@@ -5,17 +5,14 @@ import shutil
 import tempfile
 import unittest
 
+from lcats.utils.paths import find_pyproject_root
+
 
 class TestCaseWithData(unittest.TestCase):
 
     def setUp(self):
         """Find the local test data directory, and create a temp dir."""
-        # lcats/src/lcats/utils/test_utils.py -> ../../../tests/data
-        #   walks up to lcats/src/lcats/, lcats/src/, lcats/ (package root,
-        #   contains pyproject.toml), then into tests/data.
-        self.test_data_dir = os.path.normpath(
-            os.path.join(os.path.dirname(__file__), "../../../tests/data")
-        )
+        self.test_data_dir = str(find_pyproject_root(__file__) / "tests" / "data")
         self.test_temp_dir = tempfile.mkdtemp()
 
     def tearDown(self):

--- a/lcats/tests/utils_tests/paths_test.py
+++ b/lcats/tests/utils_tests/paths_test.py
@@ -207,5 +207,56 @@ class ClearDirectoryContentsTest(unittest.TestCase):
         self.assertTrue((outside_target / "precious.txt").exists())
 
 
+class FindPyprojectRootTest(unittest.TestCase):
+    """Tests for the find_pyproject_root function."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        # Resolved because find_pyproject_root resolves its input (macOS
+        # aliases /tmp to /private/tmp, so an unresolved comparison would
+        # spuriously fail).
+        self.tmp_dir = pathlib.Path(self._tmp.name).resolve()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_finds_pyproject_toml_in_direct_parent(self):
+        (self.tmp_dir / "pyproject.toml").touch()
+        start_file = self.tmp_dir / "src" / "pkg" / "mod.py"
+        start_file.parent.mkdir(parents=True)
+        start_file.touch()
+
+        found = paths.find_pyproject_root(start_file)
+
+        self.assertEqual(found, self.tmp_dir)
+
+    def test_finds_pyproject_toml_several_levels_up(self):
+        (self.tmp_dir / "pyproject.toml").touch()
+        start_file = self.tmp_dir / "a" / "b" / "c" / "d" / "mod.py"
+        start_file.parent.mkdir(parents=True)
+        start_file.touch()
+
+        found = paths.find_pyproject_root(start_file)
+
+        self.assertEqual(found, self.tmp_dir)
+
+    def test_accepts_directory_as_start(self):
+        (self.tmp_dir / "pyproject.toml").touch()
+        nested_dir = self.tmp_dir / "nested"
+        nested_dir.mkdir()
+
+        found = paths.find_pyproject_root(nested_dir)
+
+        self.assertEqual(found, self.tmp_dir)
+
+    def test_raises_when_no_ancestor_has_pyproject_toml(self):
+        start_file = self.tmp_dir / "a" / "b" / "mod.py"
+        start_file.parent.mkdir(parents=True)
+        start_file.touch()
+
+        with self.assertRaises(FileNotFoundError):
+            paths.find_pyproject_root(start_file)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/lcats/tests/utils_tests/secrets_test.py
+++ b/lcats/tests/utils_tests/secrets_test.py
@@ -101,5 +101,22 @@ class TestLoadSecretsExplicitDir(unittest.TestCase):
                 os.environ.pop("TEST_LCATS_EXPLICIT", None)
 
 
+class TestLoadSecretsNoneDefaultDir(unittest.TestCase):
+    """A None _DEFAULT_SECRETS_DIR (non-editable install) is a silent no-op.
+
+    Simulates the case find_pyproject_root can't resolve a pyproject.toml
+    ancestor -- e.g. a wheel or `pip install .` install run outside the
+    checkout -- where _DEFAULT_SECRETS_DIR falls back to None at import
+    time rather than raising.
+    """
+
+    def test_none_default_does_not_raise(self):
+        with unittest.mock.patch.object(secrets, "_DEFAULT_SECRETS_DIR", None):
+            try:
+                secrets.load_secrets()
+            except Exception as exc:  # pragma: no cover
+                self.fail(f"load_secrets raised unexpectedly: {exc}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements `WI-PACKAGING-0036`: replaces `secrets.py`'s and `test_utils.py`'s hardcoded parent-depth path counting with a shared `find_pyproject_root()` helper anchored on the presence of `pyproject.toml`, so a future package-layout change can't silently break either lookup again.

PROMPT(WI-PACKAGING-0036:WI_PACKAGING_0036)[2026-07-28T19:56:26-04:00]

## Details

- `lcats/src/lcats/utils/paths.py`: new `find_pyproject_root(start=None)` — walks upward from `start` looking for `pyproject.toml`, raising `FileNotFoundError` if none is found. Fixed the file's stale header comment (`lcats/lcats/...` → `lcats/src/lcats/...`).
- `lcats/src/lcats/utils/secrets.py`: `_DEFAULT_SECRETS_DIR` now computed via `find_pyproject_root(__file__).parent`, guarded with a `try/except FileNotFoundError` → `None` fallback so a non-editable install (wheel or `pip install .` outside the checkout, no `pyproject.toml` ancestor on disk) doesn't fail at import time. `load_secrets()` treats `target is None` as the existing silent no-op.
- `lcats/src/lcats/utils/test_utils.py`: `TestCaseWithData.test_data_dir` now uses `find_pyproject_root(__file__) / "tests" / "data"`.
- New tests: `FindPyprojectRootTest` in `paths_test.py` (found directly, found several levels up, directory-as-start, not-found raises); `TestLoadSecretsNoneDefaultDir` in `secrets_test.py` (None fallback no-ops).

## Validation

- `scripts/format --check --diff`: 165 files unchanged
- `scripts/lint`: all checks passed
- `scripts/test`: `Ran 1454 tests in 5.731s — OK`
- `lrh validate`: 0 errors, 47 warnings (pre-existing, unrelated)
- `python -c "from lcats.utils.secrets import _DEFAULT_SECRETS_DIR; print(_DEFAULT_SECRETS_DIR)"` → resolves to the repo root's `.secrets/`, matching prior `parents[4]` behavior
- Non-editable install check: built a throwaway venv, `pip install .` (not `-e`) from a separate cwd, confirmed `import lcats.utils.secrets` succeeds with `_DEFAULT_SECRETS_DIR is None` and `load_secrets()` no-ops rather than raising

## Test plan

- [x] `scripts/format`, `scripts/lint`, `scripts/test`, `lrh validate` all pass
- [x] Non-editable install verified directly (not just `pip install -e .`)
- [x] New unit tests cover both the found and not-found paths of the new helper
