### PR TITLE
Add work item WI-RELEASE-0037: Resolve gutenbergpy VCS-pin PyPI-publish blocker

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_28_22_37_49_WI_RELEASE_0037_REVIEW_FIXES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_22_37_49_WI_RELEASE_0037_REVIEW_FIXES.md
@@ -1,0 +1,64 @@
+---
+execution_id: 2026_07_28_22_37_49_WI_RELEASE_0037_REVIEW_FIXES
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0037_REVIEW_FIXES)[2026-07-28T22:37:43-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/180
+commit: 81481efe
+created_at: 2026-07-28T22:37:49-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/180
+session_transcript: pending
+---
+
+# Summary
+
+Address the `copilot-pull-request-reviewer` review comments on PR #180
+(WI-RELEASE-0037: resolve the gutenbergpy VCS-pin PyPI-publish blocker
+work item), applied directly rather than through `/lrh-review-response`
+per the land-a-PR runbook's "specific, minimal changes" allowance.
+
+# Result
+
+Three review comments addressed, all presence/validity/feasibility-
+checked and fixed on `project/work_items/proposed/WI-RELEASE-0037.md`:
+
+1. Acceptance Criteria's `pyproject.toml:26` parenthetical lacked the
+   `lcats/` prefix used elsewhere in the file — changed to
+   `lcats/pyproject.toml:26` for consistency.
+   (https://github.com/xenotaur/LCATS/pull/180#discussion_r3670560209)
+2. The Duplication Search section claimed paths (`src/`,
+   `project/design/proposals/`, `.claude/skills/`) that don't exist at
+   the locations implied when read from repo root — corrected to the
+   actual searched paths (`lcats/src/`, `lcats/project/design/
+   proposals/`) and noted that `.claude/skills/` does not exist
+   anywhere in this repo, so it was never actually searched despite the
+   original text implying it was.
+   (https://github.com/xenotaur/LCATS/pull/180#discussion_r3670560221)
+3. The `unzip -p dist/*.whl ...` validation command would only check
+   the first wheel if `dist/` contained more than one — changed to loop
+   over `dist/*.whl`.
+   (https://github.com/xenotaur/LCATS/pull/180#discussion_r3670560229)
+
+Also fixed, while editing, a stale self-introduced reference unrelated
+to the review: the Non-Goals section referenced "WI-RELEASE-0002" (the
+work item's ID before it was renumbered to WI-RELEASE-0037 during
+authoring, to avoid colliding with the shared cross-prefix numbering
+pool already at WI-PACKAGING-0036); corrected to WI-RELEASE-0038, the
+sibling version-tooling work item's actual final ID.
+
+No primary execution record exists for this PR's original authoring —
+`/lrh-work-item` (which created WI-RELEASE-0037) does not mint execution
+records, so `rerun_of` is left empty here rather than guessed.
+
+# Validation
+
+- `lrh validate` — 0 errors, 47 pre-existing unrelated warnings, none on
+  this file
+- Diff reviewed manually against all three review comments plus the
+  self-found stale reference
+
+# Follow-up
+
+- None — `/lrh-confirm-fixes` to run next per the land-a-PR runbook.

--- a/lcats/project/executions/AD_HOC/2026_07_28_22_41_22_WI_RELEASE_0037_REVIEW_ROUND2.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_22_41_22_WI_RELEASE_0037_REVIEW_ROUND2.md
@@ -1,0 +1,65 @@
+---
+execution_id: 2026_07_28_22_41_22_WI_RELEASE_0037_REVIEW_ROUND2
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0037_REVIEW_ROUND2)[2026-07-28T22:41:14-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_28_22_37_49_WI_RELEASE_0037_REVIEW_FIXES
+pr: https://github.com/xenotaur/LCATS/pull/180
+commit: fb12b1c2
+created_at: 2026-07-28T22:41:22-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/180
+session_transcript: pending
+---
+
+# Summary
+
+Address a second round of review comments on PR #180 (WI-RELEASE-0037),
+posted by `chatgpt-codex-connector` after the first round of Copilot
+fixes was pushed. Applied directly, continuing the same direct-fix
+allowance as the prior round.
+
+# Result
+
+Three new comments addressed, all presence/validity/feasibility-checked
+against the actual repo state and fixed on
+`project/work_items/proposed/WI-RELEASE-0037.md`:
+
+1. P1: the vendoring path's acceptance criteria only required "tests
+   pass unchanged," but `tests/gettenberg_tests/cache_test.py` mocks
+   `GutenbergCache.create` and `metadata_test.py` injects fake rows via
+   `_FakeCache` (confirmed by reading both files) — an incomplete
+   parser/cache-writer port could satisfy that criterion while newly
+   built caches remain wrong. Added a requirement for a real,
+   non-mocked regression test covering the ported logic, citing
+   `AGENTS.md`'s mocking/test philosophy (`lcats/AGENTS.md:42-44`).
+   (https://github.com/xenotaur/LCATS/pull/180#discussion_r3670566880)
+2. P2: `lcats/environment.yml:263` pins the identical
+   `gutenbergpy @ git+https://...` reference (confirmed by reading the
+   file) but was not in the work item's Required Changes or
+   `artifacts_expected` — only `pyproject.toml` was. Added
+   `lcats/environment.yml` to Required Changes, `artifacts_expected`,
+   and Acceptance Criteria.
+   (https://github.com/xenotaur/LCATS/pull/180#discussion_r3670566882)
+3. P2: Required Change 4 (re-fork-and-publish path) required publishing
+   the fork, while the work item's own `forbidden_actions` includes
+   `publish_package` — a real self-contradiction (confirmed by reading
+   the frontmatter). Resolved by scoping the fork's actual PyPI publish
+   as an explicit separate prerequisite work item, keeping this item's
+   `forbidden_actions` intact and unambiguous, per the reviewer's own
+   suggested resolution.
+   (https://github.com/xenotaur/LCATS/pull/180#discussion_r3670566883)
+
+# Validation
+
+- `lrh validate` — 0 errors, 47 pre-existing unrelated warnings, none on
+  this file
+- Read `tests/gettenberg_tests/cache_test.py`,
+  `tests/gettenberg_tests/metadata_test.py`, `lcats/AGENTS.md:38-48`,
+  and `environment.yml:255-270` directly to confirm each comment's
+  factual claims before fixing
+
+# Follow-up
+
+- None — proceeding to `/lrh-confirm-fixes` to resolve all six threads
+  and produce a merge-readiness verdict.

--- a/lcats/project/executions/AD_HOC/2026_07_28_22_48_17_WI_RELEASE_0037_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_22_48_17_WI_RELEASE_0037_CONFIRM.md
@@ -1,0 +1,61 @@
+---
+execution_id: 2026_07_28_22_48_17_WI_RELEASE_0037_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0037_CONFIRM)[2026-07-28T22:47:38-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/180
+commit: 22af595f
+created_at: 2026-07-28T22:48:17-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/180
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass for PR #180 (WI-RELEASE-0037). Independently
+verified all 6 unresolved review threads (3 from
+`copilot-pull-request-reviewer`, 3 from `chatgpt-codex-connector` in a
+second review round) against the current `HEAD` diff, resolved all 6.
+
+# Result
+
+All 6 threads classified Clear-satisfied against `gh pr diff 180` at
+commit `22af595f` — the diff plainly resolves each:
+
+- `discussion_r3670560209` (pyproject.toml:26 prefix) — resolved
+- `discussion_r3670560221` (duplication-search paths) — resolved
+- `discussion_r3670560229` (unzip wheel loop) — resolved
+- `discussion_r3670566880` (vendoring regression test requirement) —
+  resolved
+- `discussion_r3670566882` (environment.yml) — resolved
+- `discussion_r3670566883` (forbidden_actions/publish_package
+  contradiction) — resolved
+
+No exceptions surfaced. Thread-resolution verdict: **green**.
+
+All 6 threads resolved via `resolveReviewThread` GraphQL mutation.
+
+No primary implementation execution record exists for this PR —
+`/lrh-work-item` (which authored WI-RELEASE-0037) does not mint
+execution records — so `rerun_of` is left empty rather than guessed;
+this record and the two review-fix records
+(`2026_07_28_22_37_49_WI_RELEASE_0037_REVIEW_FIXES`,
+`2026_07_28_22_41_22_WI_RELEASE_0037_REVIEW_ROUND2`) are the only
+execution records tied to this PR.
+
+# Validation
+
+- CI on `22af595f`: `test`, `coverage`, `lint` all `SUCCESS`
+  (`gh pr checks 180 --json name,state,bucket`; this repo has no
+  required-check branch protection, so the unfiltered result is
+  authoritative)
+- `lrh validate` — 0 errors
+
+# Follow-up
+
+- Final verdict: **All threads resolved, CI green on `22af595f` → ready
+  to merge.**
+  `gh pr merge https://github.com/xenotaur/LCATS/pull/180 --squash --match-head-commit 22af595f`
+- Next: report to user for the merge gate; `/lrh-closeout` after merge.

--- a/lcats/project/work_items/proposed/WI-RELEASE-0037.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0037.md
@@ -28,10 +28,11 @@ forbidden_actions:
   - modify_ci_pipeline
 acceptance:
   - A documented decision (vendor the fix vs. publish/maintain a distinct-named LCATS-controlled PyPI fork vs. wait on upstream) exists with rationale, including why "wait on upstream" is or isn't viable given no ETA
-  - lcats/pyproject.toml's gutenbergpy dependency (currently pyproject.toml:26, a git+https direct reference) no longer contains a git+https or other direct URL reference
-  - If vendoring - the alias-table/title-index logic from raduangelescu/gutenbergpy PR #26 is present in lcats/src/lcats/gettenberg/ with clear attribution/comment pointing at the upstream PR
-  - If re-fork-and-publish - the published PyPI project uses a distinct name (not gutenbergpy, to avoid squatting the upstream maintainer's namespace) and lcats/pyproject.toml pins it by version, not URL
-  - lcats/src/lcats/gettenberg/ tests pass unchanged in behavior after the change
+  - lcats/pyproject.toml's gutenbergpy dependency (currently lcats/pyproject.toml:26, a git+https direct reference) no longer contains a git+https or other direct URL reference
+  - lcats/environment.yml's matching gutenbergpy pin (currently environment.yml:263, the identical git+https reference) is updated to match whichever replacement was chosen, so the documented conda environment no longer installs the old fork
+  - If vendoring - the alias-table/title-index logic from raduangelescu/gutenbergpy PR #26 is present in lcats/src/lcats/gettenberg/ with clear attribution/comment pointing at the upstream PR, accompanied by a new regression test that exercises the real parser/cache-writer path (not the mocked/fake-row paths in cache_test.py and metadata_test.py) and asserts on resulting title associations and alias tables
+  - If re-fork-and-publish - a distinct PyPI project name is reserved and, once published via a separate prerequisite work item (this item's own forbidden_actions bars publish_package), lcats/pyproject.toml pins it by version, not URL
+  - lcats/src/lcats/gettenberg/ tests, including the new regression test for the vendoring path, pass unchanged in behavior after the change
   - A built wheel's metadata contains no direct URL/VCS reference (verified via twine check and metadata inspection)
   - lrh validate reports 0 errors
 required_evidence:
@@ -40,6 +41,7 @@ required_evidence:
   - test_output
 artifacts_expected:
   - lcats/pyproject.toml
+  - lcats/environment.yml
   - lcats/src/lcats/gettenberg/
 ---
 
@@ -87,8 +89,13 @@ rest of release-readiness work proceeds.
 - Decide among: (a) wait for upstream to cut a new PyPI release, (b)
   vendor the merged diff directly into `lcats/src/lcats/gettenberg/`,
   (c) publish and maintain a distinct-named LCATS-controlled PyPI fork.
-- Update `lcats/pyproject.toml`'s dependency declaration to remove the
-  direct VCS reference, per whichever path is chosen.
+- Update `lcats/pyproject.toml`'s and `lcats/environment.yml`'s
+  dependency declarations to remove the direct VCS reference, per
+  whichever path is chosen.
+- If vendoring, add a real (non-mocked) regression test covering the
+  ported parser/cache-writer logic.
+- If re-fork-and-publish, scope the fork's actual PyPI publish as a
+  separate prerequisite work item rather than performing it here.
 - Verify existing Gutenberg-fetching functionality is unaffected.
 
 ## Required Changes
@@ -96,16 +103,35 @@ rest of release-readiness work proceeds.
 1. Record the decision and rationale (in this work item's Problem/Context
    or its execution record).
 2. Update `lcats/pyproject.toml:26`'s `gutenbergpy` dependency
-   accordingly.
+   accordingly. Also update `lcats/environment.yml:263`, which pins the
+   identical `gutenbergpy @ git+https://...` reference for the conda
+   development environment — leaving it unchanged would mean
+   contributors recreating the documented conda environment continue
+   pulling the old fork commit, and tests run in that environment could
+   mask a broken vendored or PyPI dependency.
 3. If vendoring: port the alias-table/title-fix logic into
    `lcats/src/lcats/gettenberg/`, with a comment attributing it to the
    upstream PR, and stop depending on any gutenbergpy fork/commit for
-   that behavior.
-4. If forking-and-publishing: reserve a distinct PyPI project name and
-   publish it (as its own small, explicitly scoped action — this work
-   item does not include the actual PyPI upload of `lcats` itself).
-5. Run `lcats/src/lcats/gettenberg/`'s test suite to confirm no behavior
-   regression.
+   that behavior. Add a real parser/cache-writer regression test
+   alongside the port — `tests/gettenberg_tests/cache_test.py` mocks
+   `GutenbergCache.create` and `metadata_test.py` injects fake query
+   rows via `_FakeCache`, so rerunning the existing suite alone cannot
+   demonstrate the ported alias-table/title logic is actually correct;
+   an incomplete port could satisfy "tests pass unchanged" while newly
+   built caches remain wrong. Per `AGENTS.md`'s mocking/test philosophy
+   ("avoid heavy mocking... validate behavior, not that mocks were
+   called"), the new test should exercise the real parsing/cache-write
+   path and assert on the resulting title associations and alias
+   tables, not a mocked stand-in.
+4. If forking-and-publishing: reserve a distinct PyPI project name.
+   This work item's `forbidden_actions` includes `publish_package`
+   (scoped to `lcats` itself, the actual release blocker this item
+   exists to unblock) — so the fork's own publish is out of scope for
+   this item regardless of which path is chosen; if re-fork-and-publish
+   is selected, scope the fork's publish as an explicit, separate
+   prerequisite work item rather than performing it inline here.
+5. Run `lcats/src/lcats/gettenberg/`'s test suite, including the new
+   regression test from step 3, to confirm no behavior regression.
 
 ## Non-Goals
 
@@ -126,14 +152,25 @@ rest of release-readiness work proceeds.
 - `lcats/pyproject.toml`'s gutenbergpy dependency (currently
   `lcats/pyproject.toml:26`, a git+https direct reference) no longer
   contains a git+https or other direct URL reference.
+- `lcats/environment.yml`'s matching gutenbergpy pin (currently
+  `environment.yml:263`) is updated to the same replacement, so the
+  documented conda environment doesn't silently keep installing the old
+  fork.
 - If vendoring: the alias-table/title-index logic from
   `raduangelescu/gutenbergpy` PR #26 is present in
   `lcats/src/lcats/gettenberg/` with clear attribution/comment pointing
-  at the upstream PR.
-- If re-fork-and-publish: the published PyPI project uses a distinct
-  name (not `gutenbergpy`, to avoid squatting the upstream maintainer's
-  namespace) and `lcats/pyproject.toml` pins it by version, not URL.
-- `lcats/src/lcats/gettenberg/` tests pass unchanged in behavior after
+  at the upstream PR, and a new regression test exercises the real
+  parser/cache-writer path (not the mocked `GutenbergCache.create` or
+  fake-row `_FakeCache` paths already in the suite) and asserts on the
+  resulting title associations and alias tables.
+- If re-fork-and-publish: a distinct PyPI project name is reserved (not
+  `gutenbergpy`, to avoid squatting the upstream maintainer's
+  namespace); the actual publish is scoped as a separate prerequisite
+  work item, consistent with this item's own `forbidden_actions:
+  publish_package`; once published, `lcats/pyproject.toml` pins it by
+  version, not URL.
+- `lcats/src/lcats/gettenberg/` tests, including the new regression
+  test where applicable, pass unchanged in behavior after
   the change.
 - A built wheel's metadata contains no direct URL/VCS reference
   (verified via `twine check` and metadata inspection).

--- a/lcats/project/work_items/proposed/WI-RELEASE-0037.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0037.md
@@ -1,0 +1,156 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-RELEASE-0037
+title: Resolve gutenbergpy VCS-pin PyPI-publish blocker
+type: deliverable
+status: proposed
+owner: xenotaur
+contributors:
+  - xenotaur
+assigned_agents: []
+related_focus: []
+related_roadmap: []
+related_workstreams: []
+related_design: []
+depends_on: []
+blocked_by: []
+expected_actions:
+  - edit_file
+  - create_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - publish_package
+  - modify_ci_pipeline
+acceptance:
+  - A documented decision (vendor the fix vs. publish/maintain a distinct-named LCATS-controlled PyPI fork vs. wait on upstream) exists with rationale, including why "wait on upstream" is or isn't viable given no ETA
+  - lcats/pyproject.toml's gutenbergpy dependency (currently pyproject.toml:26, a git+https direct reference) no longer contains a git+https or other direct URL reference
+  - If vendoring - the alias-table/title-index logic from raduangelescu/gutenbergpy PR #26 is present in lcats/src/lcats/gettenberg/ with clear attribution/comment pointing at the upstream PR
+  - If re-fork-and-publish - the published PyPI project uses a distinct name (not gutenbergpy, to avoid squatting the upstream maintainer's namespace) and lcats/pyproject.toml pins it by version, not URL
+  - lcats/src/lcats/gettenberg/ tests pass unchanged in behavior after the change
+  - A built wheel's metadata contains no direct URL/VCS reference (verified via twine check and metadata inspection)
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/pyproject.toml
+  - lcats/src/lcats/gettenberg/
+---
+
+## Summary
+
+Resolve `lcats/pyproject.toml:26`'s `gutenbergpy @ git+https://github.com/xenotaur/gutenbergpy.git@60ca548...`
+dependency so LCATS's distributed package metadata contains no direct
+URL/VCS reference — a hard PyPI-publish blocker independent of any other
+release-readiness work.
+
+## Problem / Context
+
+LCATS depends on two fixes (alias tables, title-index correction) that were
+merged upstream into `raduangelescu/gutenbergpy:master` via
+[PR #25](https://github.com/raduangelescu/gutenbergpy/pull/25) and
+[PR #26](https://github.com/raduangelescu/gutenbergpy/pull/26), both
+authored by `xenotaur`. However, the published `gutenbergpy` PyPI package
+is still 0.3.5 (released 2023-03-27), predating that merge — there is no
+PyPI release containing the needed fixes, and no ETA for one, since
+cutting a release is the upstream maintainer's call, not LCATS's. As
+currently pinned, LCATS cannot be uploaded to PyPI with this dependency.
+This blocks any real (non-placeholder) PyPI release regardless of how the
+rest of release-readiness work proceeds.
+
+### Duplication search
+- In-repo: No existing implementation or decision record found (grepped
+  `src/`, `project/design/proposals/`, `.claude/skills/` for
+  `gutenbergpy`; only hits were unrelated design/execution docs
+  referencing the dependency in passing).
+- Sibling repos: None identified — this is LCATS-specific.
+- External libraries: None identified as an alternative; the two
+  realistic paths are vendoring the small diff or publishing a
+  maintained fork.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found.
+- Backlog: No `project/design/backlog.md` in this repo.
+- Recommendation: No action.
+
+## Scope
+
+- Decide among: (a) wait for upstream to cut a new PyPI release, (b)
+  vendor the merged diff directly into `lcats/src/lcats/gettenberg/`,
+  (c) publish and maintain a distinct-named LCATS-controlled PyPI fork.
+- Update `lcats/pyproject.toml`'s dependency declaration to remove the
+  direct VCS reference, per whichever path is chosen.
+- Verify existing Gutenberg-fetching functionality is unaffected.
+
+## Required Changes
+
+1. Record the decision and rationale (in this work item's Problem/Context
+   or its execution record).
+2. Update `lcats/pyproject.toml:26`'s `gutenbergpy` dependency
+   accordingly.
+3. If vendoring: port the alias-table/title-fix logic into
+   `lcats/src/lcats/gettenberg/`, with a comment attributing it to the
+   upstream PR, and stop depending on any gutenbergpy fork/commit for
+   that behavior.
+4. If forking-and-publishing: reserve a distinct PyPI project name and
+   publish it (as its own small, explicitly scoped action — this work
+   item does not include the actual PyPI upload of `lcats` itself).
+5. Run `lcats/src/lcats/gettenberg/`'s test suite to confirm no behavior
+   regression.
+
+## Non-Goals
+
+- Does not implement the full LCATS PyPI publish workflow or CI
+  changes — separate future work.
+- Does not update `README.md:33`'s stale "not yet supported" claim —
+  separate item.
+- Does not build `scripts/version`/release-smoke tooling — that's
+  WI-RELEASE-0002.
+- Does not actually publish `lcats` to PyPI.
+
+## Acceptance Criteria
+
+- A documented decision (vendor the fix vs. publish/maintain a
+  distinct-named LCATS-controlled PyPI fork vs. wait on upstream) exists
+  with rationale, including why "wait on upstream" is or isn't viable
+  given no ETA.
+- `lcats/pyproject.toml`'s gutenbergpy dependency (currently
+  `pyproject.toml:26`, a git+https direct reference) no longer contains
+  a git+https or other direct URL reference.
+- If vendoring: the alias-table/title-index logic from
+  `raduangelescu/gutenbergpy` PR #26 is present in
+  `lcats/src/lcats/gettenberg/` with clear attribution/comment pointing
+  at the upstream PR.
+- If re-fork-and-publish: the published PyPI project uses a distinct
+  name (not `gutenbergpy`, to avoid squatting the upstream maintainer's
+  namespace) and `lcats/pyproject.toml` pins it by version, not URL.
+- `lcats/src/lcats/gettenberg/` tests pass unchanged in behavior after
+  the change.
+- A built wheel's metadata contains no direct URL/VCS reference
+  (verified via `twine check` and metadata inspection).
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `lrh validate`
+- `scripts/test`
+- `scripts/build && twine check dist/*`
+- `unzip -p dist/*.whl '*.dist-info/METADATA' | grep -i gutenbergpy` (confirm no `git+`/URL reference remains)
+
+## Risk Notes
+
+- Vendoring permanently diverges LCATS's copy from upstream; future
+  upstream fixes must be manually re-ported.
+- A separate LCATS-controlled PyPI fork adds an ongoing maintenance and
+  security surface (a second package to keep current).
+- "Wait on upstream" has no ETA and, left unresolved, blocks the real
+  release indefinitely — list explicitly as a considered-and-likely-
+  rejected option, not silently dropped.

--- a/lcats/project/work_items/proposed/WI-RELEASE-0037.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0037.md
@@ -66,9 +66,10 @@ rest of release-readiness work proceeds.
 
 ### Duplication search
 - In-repo: No existing implementation or decision record found (grepped
-  `src/`, `project/design/proposals/`, `.claude/skills/` for
-  `gutenbergpy`; only hits were unrelated design/execution docs
-  referencing the dependency in passing).
+  `lcats/src/`, `lcats/project/design/proposals/` for `gutenbergpy`;
+  `.claude/skills/` does not exist in this repo, so it was skipped
+  rather than searched. Only hits in the searched paths were unrelated
+  design/execution docs referencing the dependency in passing).
 - Sibling repos: None identified — this is LCATS-specific.
 - External libraries: None identified as an alternative; the two
   realistic paths are vendoring the small diff or publishing a
@@ -113,7 +114,7 @@ rest of release-readiness work proceeds.
 - Does not update `README.md:33`'s stale "not yet supported" claim —
   separate item.
 - Does not build `scripts/version`/release-smoke tooling — that's
-  WI-RELEASE-0002.
+  WI-RELEASE-0038.
 - Does not actually publish `lcats` to PyPI.
 
 ## Acceptance Criteria
@@ -123,8 +124,8 @@ rest of release-readiness work proceeds.
   with rationale, including why "wait on upstream" is or isn't viable
   given no ETA.
 - `lcats/pyproject.toml`'s gutenbergpy dependency (currently
-  `pyproject.toml:26`, a git+https direct reference) no longer contains
-  a git+https or other direct URL reference.
+  `lcats/pyproject.toml:26`, a git+https direct reference) no longer
+  contains a git+https or other direct URL reference.
 - If vendoring: the alias-table/title-index logic from
   `raduangelescu/gutenbergpy` PR #26 is present in
   `lcats/src/lcats/gettenberg/` with clear attribution/comment pointing
@@ -143,7 +144,7 @@ rest of release-readiness work proceeds.
 - `lrh validate`
 - `scripts/test`
 - `scripts/build && twine check dist/*`
-- `unzip -p dist/*.whl '*.dist-info/METADATA' | grep -i gutenbergpy` (confirm no `git+`/URL reference remains)
+- `for whl in dist/*.whl; do unzip -p "$whl" '*.dist-info/METADATA'; done | grep -i gutenbergpy` (confirm no `git+`/URL reference remains; loops so multiple wheels in `dist/` are each checked, not just the first)
 
 ## Risk Notes
 


### PR DESCRIPTION
## Summary
- Adds `WI-RELEASE-0037`, scoping the decision (vendor the fix vs. publish/maintain a distinct-named LCATS-controlled PyPI fork vs. wait on upstream) needed to remove the `git+https` direct-reference gutenbergpy dependency from `lcats/pyproject.toml:26` before LCATS can be uploaded to PyPI.
- Confirmed upstream context: the LCATS-needed fixes are merged into `raduangelescu/gutenbergpy:master` via [PR #25](https://github.com/raduangelescu/gutenbergpy/pull/25) and [PR #26](https://github.com/raduangelescu/gutenbergpy/pull/26), but the last PyPI release of `gutenbergpy` (0.3.5, 2023-03-27) predates that merge.

**Type:** deliverable
**Related workstream:** none (out-of-band, precursor to a future PyPI-release workstream)

## Acceptance Criteria
- Documented decision (vendor / re-fork-and-publish / wait-on-upstream) with rationale
- `lcats/pyproject.toml`'s gutenbergpy dependency no longer contains a direct URL/VCS reference
- `lcats/src/lcats/gettenberg/` tests pass unchanged
- Built wheel metadata contains no direct URL/VCS reference
- `lrh validate` reports 0 errors

## Test plan
- [x] `lrh validate` — 0 errors, 47 pre-existing unrelated warnings
