### PR TITLE
Add work item WI-RELEASE-0038: lcats.version module, --version flag, scripts/version helper

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_28_23_56_05_WI_RELEASE_0038_REVIEW_FIXES.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_23_56_05_WI_RELEASE_0038_REVIEW_FIXES.md
@@ -1,0 +1,49 @@
+---
+execution_id: 2026_07_28_23_56_05_WI_RELEASE_0038_REVIEW_FIXES
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0038_REVIEW_FIXES)[2026-07-28T23:55:56-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/181
+commit: 7b460f25
+created_at: 2026-07-28T23:56:05-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/181
+session_transcript: pending
+---
+
+# Summary
+
+Address the `chatgpt-codex-connector` review comment on PR #181
+(`WI-RELEASE-0038`: version tooling work item), applied directly per the
+land-a-PR runbook's "specific, minimal changes" allowance.
+
+# Result
+
+One review comment addressed, presence/validity/feasibility-checked and
+fixed on `project/work_items/README.md`:
+
+1. P2: adding `WI-RELEASE-0038` with `status: proposed` without
+   registering it in `project/work_items/README.md`'s Proposed Items
+   index left it undiscoverable to anyone consulting the documented
+   index. Confirmed by reading the index directly — it was indeed
+   missing. Added the entry.
+   (https://github.com/xenotaur/LCATS/pull/181#discussion_r3670561659)
+
+Also fixed, while editing the same list: `WI-RELEASE-0037` (already
+merged via PR #180) had the identical gap — never registered in this
+index either, despite this being exactly the recurring pattern already
+tracked in project memory
+(`feedback_wi_workstream_readme_registration_recurring_gap.md`, "WI/WS
+registration recurring gap... confirmed 3x recurring"). Registered it
+alongside `WI-RELEASE-0038` in the same commit, since it's the same
+file and the same fix.
+
+# Validation
+
+- `lrh validate` — 0 errors, only pre-existing unrelated warnings, none
+  on this file
+
+# Follow-up
+
+- None — `/lrh-confirm-fixes` to run next per the land-a-PR runbook.

--- a/lcats/project/executions/AD_HOC/2026_07_28_23_59_31_WI_RELEASE_0038_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_23_59_31_WI_RELEASE_0038_CONFIRM.md
@@ -1,0 +1,44 @@
+---
+execution_id: 2026_07_28_23_59_31_WI_RELEASE_0038_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0038_CONFIRM)[2026-07-28T23:59:12-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/181
+commit: 3bdfd7f7
+created_at: 2026-07-28T23:59:31-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/181
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass for PR #181 (`WI-RELEASE-0038`). Independently
+verified the one unresolved review thread (`chatgpt-codex-connector`)
+against the current `HEAD` diff, resolved it.
+
+# Result
+
+Thread classified Clear-satisfied against the diff at commit `3bdfd7f7`:
+
+- `discussion_r3670561659` (WI-RELEASE-0038 not registered in
+  `project/work_items/README.md`'s Proposed Items index) — resolved;
+  diff confirmed to add both `WI-RELEASE-0037` and `WI-RELEASE-0038` to
+  the index.
+
+No exceptions surfaced. Thread-resolution verdict: **green**.
+
+Thread resolved via `resolveReviewThread` GraphQL mutation.
+
+# Validation
+
+- CI on `3bdfd7f7`: `test`, `coverage`, `lint` all `SUCCESS`
+- `lrh validate` — 0 errors
+
+# Follow-up
+
+- Final verdict: **All threads resolved, CI green on `3bdfd7f7` → ready
+  to merge.**
+  `gh pr merge https://github.com/xenotaur/LCATS/pull/181 --squash --match-head-commit 3bdfd7f7`
+- Next: report to user for the merge gate; `/lrh-closeout` after merge.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -19,6 +19,8 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 - `proposed/WI-ASSESS-0031.md` — Extend VALID_GENRES from 4 to 8 target genres
 - `proposed/WI-EVENT-0032.md` — Harden Event-Role-World tool-schema reliability and processor error/model handling
 - `proposed/WI-EVENT-0033.md` — Add schema-hardened structured output to scene/story analysis extractors
+- `proposed/WI-RELEASE-0037.md` — Resolve gutenbergpy VCS-pin PyPI-publish blocker
+- `proposed/WI-RELEASE-0038.md` — Add lcats.version module, --version CLI flag, and scripts/version release helper
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-RELEASE-0038.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0038.md
@@ -1,0 +1,157 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-RELEASE-0038
+title: Add lcats.version module, --version CLI flag, and scripts/version release helper
+type: deliverable
+status: proposed
+owner: xenotaur
+contributors:
+  - xenotaur
+assigned_agents: []
+related_focus: []
+related_roadmap: []
+related_workstreams: []
+related_design: []
+depends_on: []
+blocked_by: []
+expected_actions:
+  - create_file
+  - edit_file
+  - run_tests
+  - create_pr
+  - add_cli_command
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - publish_package
+  - modify_ci_pipeline
+acceptance:
+  - lcats/src/lcats/version.py exists with get_installed_version()/format_cli_version(), mirroring lrh.version's shape
+  - lcats --version prints installed package version via importlib.metadata, not a hardcoded string
+  - scripts/version tools prints lcats package/CLI version plus toolchain versions (python, ruff, black, pip)
+  - scripts/version verify [tag] validates tag format (if given), requires a clean working tree, and runs scripts/lint, scripts/format --check, scripts/test
+  - scripts/version tag <tag> and scripts/version push <tag> create/push a git tag idempotently, mirroring lrh.dev.versioning's tag/push behavior
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/src/lcats/version.py
+  - lcats/src/lcats/dev/versioning.py
+  - lcats/scripts/version
+  - lcats/src/lcats/cli.py
+---
+
+## Summary
+
+Give LCATS a `lcats.version` module, a `lcats --version` CLI flag, and a
+`scripts/version` helper (`tools`/`verify`/`tag`/`push`), mirroring LRH's
+`lrh.dev.versioning` pattern but scoped to what LCATS's own
+`scripts/lint`/`scripts/format`/`scripts/test` actually support.
+
+## Problem / Context
+
+LCATS currently has no way to answer "what version is this
+checkout/install?" — no `--version` flag on the CLI (confirmed via grep
+on `lcats/src/lcats/cli.py`, no hits for `version`) and no `lcats.version`
+module. The one existing tag, `v0.1.0`, was cut by hand with no tooling
+behind it, unlike LRH's `scripts/version` which gates tagging behind a
+clean-tree + lint/format/test check. This gap was identified while
+comparing LCATS's packaging tooling against LRH's `scripts/version`/
+`lrh.dev.versioning`
+(`logical_robotics_harness/src/lrh/dev/versioning.py`) during a
+release-readiness assessment session.
+
+### Duplication search
+- In-repo: No existing version-reporting module or `--version` flag
+  found (grepped `src/lcats/cli.py` and `src/` broadly).
+- Sibling repos: LRH's `lrh.dev.versioning` is the direct model, not a
+  duplicate — LCATS has no equivalent.
+- External libraries: None needed; `importlib.metadata` (stdlib) is
+  sufficient, matching LRH's approach.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found.
+- Backlog: No `project/design/backlog.md` in this repo.
+- Recommendation: No action.
+
+## Scope
+
+- `lcats/src/lcats/version.py` — `importlib.metadata`-based version
+  helpers.
+- `--version` flag on the `lcats` CLI.
+- `lcats/src/lcats/dev/versioning.py` + `lcats/scripts/version` wrapper,
+  supporting `tools`, `verify [tag]`, `tag <tag>`, `push <tag>`.
+
+## Required Changes
+
+1. Create `lcats/src/lcats/version.py` with `DISTRIBUTION_NAME =
+   "lcats"`, `get_installed_version()`, `format_cli_version()`.
+2. Add a `--version` flag to `lcats/src/lcats/cli.py`'s argument parser,
+   printing `format_cli_version()`.
+3. Create `lcats/src/lcats/dev/versioning.py` with `tools`/`verify`/
+   `tag`/`push` subcommands, scoped to LCATS's actual toolchain
+   (`scripts/lint`, `scripts/format --check`, `scripts/test` all exist
+   and are the right checks to run for `verify`).
+4. Create `lcats/scripts/version`, a thin bash wrapper matching the
+   shape of `scripts/build`/`scripts/lint` (set `PYTHONPATH`, invoke
+   `python -m lcats.dev.versioning "$@"`).
+
+## Non-Goals
+
+- Does not implement `scripts/release-smoke` — deferred, likely a
+  near-term follow-up once this and WI-RELEASE-0037 land, but out of
+  scope here.
+- Does not modify CI workflows.
+- Does not write the release runbook doc.
+- Does not change `scripts/publish`'s current stub behavior.
+
+## Acceptance Criteria
+
+- `lcats/src/lcats/version.py` exists with
+  `get_installed_version()`/`format_cli_version()`, mirroring
+  `lrh.version`'s shape.
+- `lcats --version` prints installed package version via
+  `importlib.metadata`, not a hardcoded string.
+- `scripts/version tools` prints lcats package/CLI version plus
+  toolchain versions (python, ruff, black, pip).
+- `scripts/version verify [tag]` validates tag format (if given),
+  requires a clean working tree, and runs `scripts/lint`,
+  `scripts/format --check`, `scripts/test`.
+- `scripts/version tag <tag>` and `scripts/version push <tag>`
+  create/push a git tag idempotently, mirroring
+  `lrh.dev.versioning`'s `tag`/`push` behavior.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+- `scripts/version tools`
+- `scripts/version verify`
+- `lcats --version`
+
+## Risk Notes
+
+- `scripts/version verify <tag>` must not be run with a real tag against
+  `v0.1.0`'s existing history in a way that could confuse it with a new
+  release attempt — keep `verify`'s tag argument optional-and-inert
+  (validation only, no side effects) as LRH's does.
+- Keep `tools`'s toolchain list matched to what LCATS actually pins
+  (`ruff==0.15.0`, `black==25.11.0` per `pyproject.toml`) rather than
+  copying LRH's list wholesale (e.g. LRH checks `pylint`/`pyright`,
+  which LCATS's `dev` extras don't include).
+
+## Dependencies / Order
+
+Independent of `WI-RELEASE-0037` — this item's tooling doesn't need the
+gutenbergpy dependency question resolved, and can proceed in parallel.
+Both are precursors to a future `/lrh-proposal` + `/lrh-workstream` for
+the real LCATS PyPI release.


### PR DESCRIPTION
## Summary
- Adds `WI-RELEASE-0038`, scoping an `lcats.version` module, a `lcats --version` CLI flag, and a `scripts/version` helper (`tools`/`verify`/`tag`/`push`), mirroring LRH's `lrh.dev.versioning` pattern scoped down to LCATS's own toolchain.
- LCATS currently has no `--version` flag and no way to check installed version; `v0.1.0` was tagged by hand with no verification gate.

**Type:** deliverable
**Related workstream:** none (out-of-band, precursor to a future PyPI-release workstream)

## Acceptance Criteria
- `lcats.version` module with `get_installed_version()`/`format_cli_version()`
- `lcats --version` works via `importlib.metadata`
- `scripts/version tools` / `verify` / `tag` / `push` subcommands, scoped to LCATS's actual `scripts/lint`/`scripts/format`/`scripts/test`
- `lrh validate` reports 0 errors

## Test plan
- [x] `lrh validate` — 0 errors, only pre-existing unrelated warnings

Independent of and parallel to #180 (WI-RELEASE-0037, gutenbergpy dependency resolution) — both precede a future `/lrh-proposal` + `/lrh-workstream` for the real PyPI release.
