### PR TITLE
Update WI-RELEASE-0037 with Option A/B/C tradeoff findings

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_28_23_42_59_WI_RELEASE_0037_UPDATE_OPTIONS_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_23_42_59_WI_RELEASE_0037_UPDATE_OPTIONS_REVIEW.md
@@ -1,0 +1,67 @@
+---
+execution_id: 2026_07_28_23_42_59_WI_RELEASE_0037_UPDATE_OPTIONS_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0037_UPDATE_OPTIONS_REVIEW)[2026-07-28T23:42:51-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/182
+commit: 77fdf162
+created_at: 2026-07-28T23:42:59-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/182
+session_transcript: pending
+---
+
+# Summary
+
+Address review comments on PR #182 (a `WI-RELEASE-0037` content update
+documenting the Option A/B/C tradeoff analysis) from
+`copilot-pull-request-reviewer` and `chatgpt-codex-connector`, applied
+directly following the same direct-fix allowance used on PR #180.
+
+# Result
+
+Two comments addressed on `project/work_items/proposed/WI-RELEASE-0037.md`:
+
+1. Copilot: the Risk Notes sentence "diffing against a moving GitHub
+   repo rather than a real git history" was confusing (a GitHub repo
+   *is* a git history). Rewrote to state the actual point: vendored
+   files, copied rather than pulled as a git dependency, don't carry
+   upstream's commit history/tags into LCATS's tree, so future upstream
+   fixes must be found and compared against upstream manually rather
+   than picked up via a version bump.
+   (https://github.com/xenotaur/LCATS/pull/182#discussion_r3670775631)
+2. Codex P1: the vendoring file list (5 files, from the two PRs' diff)
+   was incomplete. Verified against the actual `gutenbergpy` source
+   before fixing: `SQLiteCache.create_cache()`
+   (`gutenbergpy/caches/sqlitecache.py:68,103`) reads both
+   `gutenbergindex.db.sql` *and* `gutenbergindex_indices.db.sql`, and
+   the `GutenbergCache` orchestrator class referenced in Required
+   Change 3 lives in `gutenbergpy/gutenbergcache.py`, a sixth file not
+   in the original diff-derived list. While verifying, further tracing
+   of `sqlitecache.py`'s own imports found three more transitive
+   dependencies neither reviewer flagged: `gutenbergpy/caches/cache.py`
+   (the abstract `Cache` base class), `gutenbergpy/gutenbergcachesettings.py`,
+   and `gutenbergpy/utils.py`. Rather than publish a third
+   hand-enumerated list likely to be wrong again, revised Required
+   Change 3, its matching Acceptance Criterion, the Scope section, and
+   Problem/Context to name the confirmed additions, state explicitly
+   that the list is provisional, and instruct implementers to trace
+   gutenbergpy's real import closure at implementation time instead of
+   trusting any list in this planning document.
+   (https://github.com/xenotaur/LCATS/pull/182#discussion_r3670777395)
+
+# Validation
+
+- `lrh validate` — 0 errors, 47 pre-existing unrelated warnings, none on
+  this file
+- Fetched and read the actual upstream source
+  (`gutenbergpy/caches/sqlitecache.py`, `gutenbergpy/gutenbergcache.py`,
+  `gutenbergpy/caches/cache.py`, and a directory listing of
+  `gutenbergpy/caches/`) to confirm both review claims and find the
+  additional transitive dependencies before editing the work item
+
+# Follow-up
+
+- None — proceeding to `/lrh-confirm-fixes` to resolve both threads and
+  produce a merge-readiness verdict.

--- a/lcats/project/executions/AD_HOC/2026_07_28_23_47_57_WI_RELEASE_0037_UPDATE_OPTIONS_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_28_23_47_57_WI_RELEASE_0037_UPDATE_OPTIONS_CONFIRM.md
@@ -1,0 +1,46 @@
+---
+execution_id: 2026_07_28_23_47_57_WI_RELEASE_0037_UPDATE_OPTIONS_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0037_UPDATE_OPTIONS_CONFIRM)[2026-07-28T23:47:37-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/182
+commit: 7e1c966d
+created_at: 2026-07-28T23:47:57-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/182
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass for PR #182 (`WI-RELEASE-0037` content
+update). Independently verified both unresolved review threads
+(`copilot-pull-request-reviewer`, `chatgpt-codex-connector`) against the
+current `HEAD` diff, resolved both.
+
+# Result
+
+Both threads classified Clear-satisfied against the diff at commit
+`7e1c966d`:
+
+- `discussion_r3670775631` (Risk Notes "moving GitHub repo" wording) —
+  resolved
+- `discussion_r3670777395` (vendoring file list incompleteness) —
+  resolved
+
+No exceptions surfaced. Thread-resolution verdict: **green**.
+
+Both threads resolved via `resolveReviewThread` GraphQL mutation.
+
+# Validation
+
+- CI on `7e1c966d`: `test`, `coverage`, `lint` all `SUCCESS`
+- `lrh validate` — 0 errors
+
+# Follow-up
+
+- Final verdict: **All threads resolved, CI green on `7e1c966d` → ready
+  to merge.**
+  `gh pr merge https://github.com/xenotaur/LCATS/pull/182 --squash --match-head-commit 7e1c966d`
+- Next: report to user for the merge gate; `/lrh-closeout` after merge.

--- a/lcats/project/work_items/proposed/WI-RELEASE-0037.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0037.md
@@ -95,10 +95,14 @@ internal to gutenbergpy's own pipeline:
 `gutenbergpy/parse/cachefields.py`, `gutenbergpy/caches/sqlitecache.py`,
 and `gutenbergpy/caches/gutenbergindex.db.sql`. Because there is no seam
 to attach a small patch to, both vendoring and forking-and-publishing
-mean owning a modified copy of these five files going forward — they
-differ in *where* that fork lives and how it's packaged, not in whether
-a fork is required. See Required Changes 3 and 4 below, revised
-accordingly.
+mean owning a modified copy of gutenbergpy's cache-construction
+dependency closure going forward — a closure larger than just these
+five diffed files, since the orchestrating `GutenbergCache` class and
+several further transitive dependencies live outside the diff (see
+Required Change 3 for the fuller, still-provisional list). Vendoring
+and forking-and-publishing differ in *where* that fork lives and how
+it's packaged, not in whether a fork is required. See Required Changes
+3 and 4 below, revised accordingly.
 
 ### Duplication search
 - In-repo: No existing implementation or decision record found (grepped
@@ -109,7 +113,8 @@ accordingly.
 - Sibling repos: None identified — this is LCATS-specific.
 - External libraries: None identified as an alternative; the two
   realistic implementation paths (vendoring in-tree vs. publishing a
-  maintained fork) both require forking the same five upstream files —
+  maintained fork) both require forking the same gutenbergpy
+  cache-construction dependency closure —
   see Problem/Context.
 - Recommendation: Proceed.
 
@@ -122,11 +127,12 @@ accordingly.
 ## Scope
 
 - Decide among: (a) wait for upstream to cut a new PyPI release (contact
-  already made, response pending), (b) fork the five affected
-  gutenbergpy internals into LCATS's own tree and point
+  already made, response pending), (b) fork gutenbergpy's cache-
+  construction dependency closure into LCATS's own tree and point
   `lcats/src/lcats/gettenberg/cache.py` at that local copy instead of
   the installed package, (c) publish and maintain a distinct-named
-  LCATS-controlled PyPI fork of the same five files.
+  LCATS-controlled PyPI fork of the same closure. That closure is
+  larger than just the two PRs' diff — see Required Change 3.
 - Update `lcats/pyproject.toml`'s and `lcats/environment.yml`'s
   dependency declarations to remove the direct VCS reference, per
   whichever path is chosen.
@@ -150,23 +156,42 @@ accordingly.
    contributors recreating the documented conda environment continue
    pulling the old fork commit, and tests run in that environment could
    mask a broken vendored or PyPI dependency.
-3. If vendoring: copy the five affected upstream files
+3. If vendoring: the two upstream PRs' diff touches five files
    (`gutenbergpy/parse/rdfparser.py`, `gutenbergpy/parse/book.py`,
    `gutenbergpy/parse/cachefields.py`, `gutenbergpy/caches/sqlitecache.py`,
-   `gutenbergpy/caches/gutenbergindex.db.sql`), with the merged fixes
-   already applied, into a local module tree under
-   `lcats/src/lcats/gettenberg/` (e.g. a `_vendor_gutenbergpy/`
-   subpackage), attributing the source PRs in a header comment. Update
-   `lcats/src/lcats/gettenberg/cache.py:11,128,144` to call the
-   vendored copy's `GutenbergCache.create()`/`.get_cache()` instead of
-   the installed `gutenbergpy` package's — there is no constructor
-   parameter or other extension point on `GutenbergCache.create()` to
-   substitute a patched `RdfParser`/`SQLiteCache` without doing this,
-   since it imports and instantiates both by name internally. This is
-   an in-tree fork of gutenbergpy's cache-construction subsystem, not a
-   small patch file; treat future upstream changes to these five files
-   as needing manual re-porting (see Risk Notes). Add a real
-   parser/cache-writer regression test alongside the fork —
+   `gutenbergpy/caches/gutenbergindex.db.sql`), but the file list
+   actually needed to run the cache-construction pipeline standalone is
+   larger, since `SQLiteCache.create_cache()` also reads
+   `gutenbergpy/caches/gutenbergindex_indices.db.sql` (a second SQL
+   resource, not part of the PR diff), and the orchestrating
+   `GutenbergCache` class referenced below lives in a sixth file,
+   `gutenbergpy/gutenbergcache.py`, not in the diff either. A closer
+   read of `gutenbergpy/caches/sqlitecache.py`'s own imports turns up
+   further transitive dependencies not yet enumerated here —
+   `gutenbergpy/caches/cache.py` (the abstract `Cache` base class
+   `SQLiteCache` extends), `gutenbergpy/gutenbergcachesettings.py`, and
+   `gutenbergpy/utils.py`. Do not treat any file list in this work item
+   as complete: at implementation time, trace gutenbergpy's actual
+   import graph from `GutenbergCache.create()` (e.g. via
+   `python -m py_compile` / `importlib` tooling, or by reading each
+   module's imports transitively) to determine the real vendoring
+   closure, rather than trusting a hand-enumerated list — this list has
+   already grown twice from independent review, which is itself
+   evidence hand-enumeration is unreliable here. Vendor that verified
+   closure, with the merged fixes already applied, into a local module
+   tree under `lcats/src/lcats/gettenberg/` (e.g. a
+   `_vendor_gutenbergpy/` subpackage), attributing the source PRs in a
+   header comment. Update `lcats/src/lcats/gettenberg/cache.py:11,128,144`
+   to call the vendored copy's `GutenbergCache.create()`/`.get_cache()`
+   instead of the installed `gutenbergpy` package's — there is no
+   constructor parameter or other extension point on
+   `GutenbergCache.create()` to substitute a patched
+   `RdfParser`/`SQLiteCache` without doing this, since it imports and
+   instantiates both by name internally. This is an in-tree fork of
+   gutenbergpy's cache-construction subsystem, not a small patch file;
+   treat future upstream changes to this closure as needing manual
+   re-porting (see Risk Notes). Add a real parser/cache-writer
+   regression test alongside the fork —
    `tests/gettenberg_tests/cache_test.py` mocks `GutenbergCache.create`
    and `metadata_test.py` injects fake query rows via `_FakeCache`, so
    rerunning the existing suite alone cannot demonstrate the forked
@@ -221,16 +246,19 @@ accordingly.
   `environment.yml:263`) is updated to the same replacement, so the
   documented conda environment doesn't silently keep installing the old
   fork.
-- If vendoring: the five affected upstream files (`rdfparser.py`,
-  `book.py`, `cachefields.py`, `sqlitecache.py`,
-  `gutenbergindex.db.sql`), with the merged fixes applied, are present
-  as a local module tree under `lcats/src/lcats/gettenberg/` with clear
-  attribution pointing at PR #25/#26; `cache.py:11,128,144` call the
-  vendored copy, not the installed `gutenbergpy` package, for cache
-  construction; and a new regression test exercises the real
-  parser/cache-writer path (not the mocked `GutenbergCache.create` or
-  fake-row `_FakeCache` paths already in the suite) and asserts on the
-  resulting title associations and alias tables.
+- If vendoring: gutenbergpy's actual, traced (not hand-guessed) import
+  closure for `GutenbergCache.create()` — starting from the two PRs'
+  five diffed files but confirmed to also include at least
+  `gutenbergcache.py`, `gutenbergindex_indices.db.sql`, `cache.py`,
+  `gutenbergcachesettings.py`, and `utils.py` — with the merged fixes
+  applied, is present as a local module tree under
+  `lcats/src/lcats/gettenberg/` with clear attribution pointing at PR
+  #25/#26; `cache.py:11,128,144` call the vendored copy, not the
+  installed `gutenbergpy` package, for cache construction; and a new
+  regression test exercises the real parser/cache-writer path (not the
+  mocked `GutenbergCache.create` or fake-row `_FakeCache` paths already
+  in the suite) and asserts on the resulting title associations and
+  alias tables.
 - If re-fork-and-publish: a distinct PyPI project name is reserved (not
   `gutenbergpy`, to avoid squatting the upstream maintainer's
   namespace); the fork's own packaging (upstream's legacy `setup.py`/
@@ -263,9 +291,13 @@ accordingly.
   private inside LCATS's own tree; re-fork-and-publish makes it a
   second, independently versioned, installable PyPI project. Neither
   option is a small patch.
-- Vendoring permanently diverges LCATS's copy from upstream; future
-  upstream fixes to those five files must be manually re-ported by
-  diffing against a moving GitHub repo rather than a real git history.
+- Vendoring permanently diverges LCATS's copy from upstream. The
+  vendored files, copied in rather than pulled via a git dependency,
+  won't carry upstream's own commit history or tags with them into
+  LCATS's tree — so any future upstream fix to this closure has to be
+  found and manually compared against upstream (e.g. via `git blame`/
+  `git log` on the upstream repo directly) and re-applied by hand, not
+  picked up by a version bump the way a real dependency would be.
 - A separate LCATS-controlled PyPI fork adds an ongoing maintenance and
   security surface (a second package to keep current) plus a second,
   independent release pipeline (Trusted Publishing, versioning, a

--- a/lcats/project/work_items/proposed/WI-RELEASE-0037.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0037.md
@@ -60,11 +60,45 @@ merged upstream into `raduangelescu/gutenbergpy:master` via
 [PR #26](https://github.com/raduangelescu/gutenbergpy/pull/26), both
 authored by `xenotaur`. However, the published `gutenbergpy` PyPI package
 is still 0.3.5 (released 2023-03-27), predating that merge — there is no
-PyPI release containing the needed fixes, and no ETA for one, since
-cutting a release is the upstream maintainer's call, not LCATS's. As
-currently pinned, LCATS cannot be uploaded to PyPI with this dependency.
-This blocks any real (non-placeholder) PyPI release regardless of how the
-rest of release-readiness work proceeds.
+PyPI release containing the needed fixes. As currently pinned, LCATS
+cannot be uploaded to PyPI with this dependency: PyPI's upload validation
+(`pypi/warehouse`'s `warehouse/forklift/metadata.py`, in
+`_validate_metadata`) rejects any `Requires-Dist` entry whose parsed
+`Requirement.url` is not `None` — i.e. any direct URL/VCS reference —
+with `Can't have direct dependency: <req>`, which is exactly the shape of
+`gutenbergpy @ git+https://...`. This blocks any real (non-placeholder)
+PyPI release regardless of how the rest of release-readiness work
+proceeds.
+
+As of this work item's authoring, LCATS has contacted the upstream
+maintainer to ask about their release schedule (the "wait on upstream"
+option below) — response pending. One encouraging, but non-committal,
+signal: `raduangelescu/gutenbergpy:master`'s own `setup.cfg` already
+declares `version = 0.3.6`, one version ahead of what's actually
+published on PyPI (0.3.5) — the maintainer has already bumped the
+in-repo version, just not cut/published the release.
+
+Two implementation options (vendor, re-fork-and-publish) were assessed in
+more depth than originally scoped, and turned out more coupled than
+first assumed. `lcats/src/lcats/gettenberg/cache.py:11` imports the
+installed `gutenbergpy` package's own `gutenbergcache` module and calls
+its `GutenbergCache.create(...)` (`cache.py:128`) and `.get_cache()`
+(`cache.py:144`) directly — LCATS never re-implements any RDF-parsing or
+cache-writing logic itself. `GutenbergCache.create()` (in gutenbergpy's
+own `gutenbergcache.py`) hardcodes `from gutenbergpy.parse.rdfparser
+import RdfParser` and `from gutenbergpy.caches.sqlitecache import
+SQLiteCache` at module scope and instantiates them directly, with no
+constructor parameter or other extension point to substitute a patched
+parser or cache-writer. Both PR #25 and PR #26 touch five files entirely
+internal to gutenbergpy's own pipeline:
+`gutenbergpy/parse/rdfparser.py`, `gutenbergpy/parse/book.py`,
+`gutenbergpy/parse/cachefields.py`, `gutenbergpy/caches/sqlitecache.py`,
+and `gutenbergpy/caches/gutenbergindex.db.sql`. Because there is no seam
+to attach a small patch to, both vendoring and forking-and-publishing
+mean owning a modified copy of these five files going forward — they
+differ in *where* that fork lives and how it's packaged, not in whether
+a fork is required. See Required Changes 3 and 4 below, revised
+accordingly.
 
 ### Duplication search
 - In-repo: No existing implementation or decision record found (grepped
@@ -74,8 +108,9 @@ rest of release-readiness work proceeds.
   design/execution docs referencing the dependency in passing).
 - Sibling repos: None identified — this is LCATS-specific.
 - External libraries: None identified as an alternative; the two
-  realistic paths are vendoring the small diff or publishing a
-  maintained fork.
+  realistic implementation paths (vendoring in-tree vs. publishing a
+  maintained fork) both require forking the same five upstream files —
+  see Problem/Context.
 - Recommendation: Proceed.
 
 ### Demand search
@@ -86,16 +121,22 @@ rest of release-readiness work proceeds.
 
 ## Scope
 
-- Decide among: (a) wait for upstream to cut a new PyPI release, (b)
-  vendor the merged diff directly into `lcats/src/lcats/gettenberg/`,
-  (c) publish and maintain a distinct-named LCATS-controlled PyPI fork.
+- Decide among: (a) wait for upstream to cut a new PyPI release (contact
+  already made, response pending), (b) fork the five affected
+  gutenbergpy internals into LCATS's own tree and point
+  `lcats/src/lcats/gettenberg/cache.py` at that local copy instead of
+  the installed package, (c) publish and maintain a distinct-named
+  LCATS-controlled PyPI fork of the same five files.
 - Update `lcats/pyproject.toml`'s and `lcats/environment.yml`'s
   dependency declarations to remove the direct VCS reference, per
   whichever path is chosen.
-- If vendoring, add a real (non-mocked) regression test covering the
-  ported parser/cache-writer logic.
+- If vendoring (b) or forking-and-publishing (c), add a real
+  (non-mocked) regression test covering the forked parser/cache-writer
+  logic — both options carry the same code-ownership burden.
 - If re-fork-and-publish, scope the fork's actual PyPI publish as a
-  separate prerequisite work item rather than performing it here.
+  separate prerequisite work item rather than performing it here, and
+  budget for the fork's own packaging/dependency modernization (see
+  Required Change 4).
 - Verify existing Gutenberg-fetching functionality is unaffected.
 
 ## Required Changes
@@ -109,27 +150,51 @@ rest of release-readiness work proceeds.
    contributors recreating the documented conda environment continue
    pulling the old fork commit, and tests run in that environment could
    mask a broken vendored or PyPI dependency.
-3. If vendoring: port the alias-table/title-fix logic into
-   `lcats/src/lcats/gettenberg/`, with a comment attributing it to the
-   upstream PR, and stop depending on any gutenbergpy fork/commit for
-   that behavior. Add a real parser/cache-writer regression test
-   alongside the port — `tests/gettenberg_tests/cache_test.py` mocks
-   `GutenbergCache.create` and `metadata_test.py` injects fake query
-   rows via `_FakeCache`, so rerunning the existing suite alone cannot
-   demonstrate the ported alias-table/title logic is actually correct;
-   an incomplete port could satisfy "tests pass unchanged" while newly
-   built caches remain wrong. Per `AGENTS.md`'s mocking/test philosophy
-   ("avoid heavy mocking... validate behavior, not that mocks were
-   called"), the new test should exercise the real parsing/cache-write
-   path and assert on the resulting title associations and alias
-   tables, not a mocked stand-in.
-4. If forking-and-publishing: reserve a distinct PyPI project name.
+3. If vendoring: copy the five affected upstream files
+   (`gutenbergpy/parse/rdfparser.py`, `gutenbergpy/parse/book.py`,
+   `gutenbergpy/parse/cachefields.py`, `gutenbergpy/caches/sqlitecache.py`,
+   `gutenbergpy/caches/gutenbergindex.db.sql`), with the merged fixes
+   already applied, into a local module tree under
+   `lcats/src/lcats/gettenberg/` (e.g. a `_vendor_gutenbergpy/`
+   subpackage), attributing the source PRs in a header comment. Update
+   `lcats/src/lcats/gettenberg/cache.py:11,128,144` to call the
+   vendored copy's `GutenbergCache.create()`/`.get_cache()` instead of
+   the installed `gutenbergpy` package's — there is no constructor
+   parameter or other extension point on `GutenbergCache.create()` to
+   substitute a patched `RdfParser`/`SQLiteCache` without doing this,
+   since it imports and instantiates both by name internally. This is
+   an in-tree fork of gutenbergpy's cache-construction subsystem, not a
+   small patch file; treat future upstream changes to these five files
+   as needing manual re-porting (see Risk Notes). Add a real
+   parser/cache-writer regression test alongside the fork —
+   `tests/gettenberg_tests/cache_test.py` mocks `GutenbergCache.create`
+   and `metadata_test.py` injects fake query rows via `_FakeCache`, so
+   rerunning the existing suite alone cannot demonstrate the forked
+   alias-table/title logic is actually correct; an incomplete fork
+   could satisfy "tests pass unchanged" while newly built caches remain
+   wrong. Per `AGENTS.md`'s mocking/test philosophy ("avoid heavy
+   mocking... validate behavior, not that mocks were called"), the new
+   test should exercise the real parsing/cache-write path and assert on
+   the resulting title associations and alias tables, not a mocked
+   stand-in.
+4. If forking-and-publishing: reserve a distinct PyPI project name (not
+   `gutenbergpy` — confirmed MIT-licensed, so forking and republishing
+   under a new name with the copyright/license notice preserved is
+   legally clean, but the name itself must not squat the upstream
+   maintainer's active namespace). Budget for upstream's own packaging
+   being legacy-style — a bare `setup.py` plus metadata in `setup.cfg`,
+   no PEP 621 `pyproject.toml` project table — and for dated
+   dependencies (`future`, `httpsproxy-urllib2`, `lxml`, `pymongo`,
+   `chardet`) inherited by the fork. Set up a second, independent
+   release pipeline (Trusted Publishing, versioning, a runbook) for the
+   fork, duplicating `WI-RELEASE-0038`'s scope for a second package.
    This work item's `forbidden_actions` includes `publish_package`
    (scoped to `lcats` itself, the actual release blocker this item
    exists to unblock) — so the fork's own publish is out of scope for
    this item regardless of which path is chosen; if re-fork-and-publish
-   is selected, scope the fork's publish as an explicit, separate
-   prerequisite work item rather than performing it inline here.
+   is selected, scope the fork's publish (including the packaging and
+   release-pipeline work above) as an explicit, separate prerequisite
+   work item rather than performing it inline here.
 5. Run `lcats/src/lcats/gettenberg/`'s test suite, including the new
    regression test from step 3, to confirm no behavior regression.
 
@@ -156,19 +221,24 @@ rest of release-readiness work proceeds.
   `environment.yml:263`) is updated to the same replacement, so the
   documented conda environment doesn't silently keep installing the old
   fork.
-- If vendoring: the alias-table/title-index logic from
-  `raduangelescu/gutenbergpy` PR #26 is present in
-  `lcats/src/lcats/gettenberg/` with clear attribution/comment pointing
-  at the upstream PR, and a new regression test exercises the real
+- If vendoring: the five affected upstream files (`rdfparser.py`,
+  `book.py`, `cachefields.py`, `sqlitecache.py`,
+  `gutenbergindex.db.sql`), with the merged fixes applied, are present
+  as a local module tree under `lcats/src/lcats/gettenberg/` with clear
+  attribution pointing at PR #25/#26; `cache.py:11,128,144` call the
+  vendored copy, not the installed `gutenbergpy` package, for cache
+  construction; and a new regression test exercises the real
   parser/cache-writer path (not the mocked `GutenbergCache.create` or
   fake-row `_FakeCache` paths already in the suite) and asserts on the
   resulting title associations and alias tables.
 - If re-fork-and-publish: a distinct PyPI project name is reserved (not
   `gutenbergpy`, to avoid squatting the upstream maintainer's
-  namespace); the actual publish is scoped as a separate prerequisite
-  work item, consistent with this item's own `forbidden_actions:
-  publish_package`; once published, `lcats/pyproject.toml` pins it by
-  version, not URL.
+  namespace); the fork's own packaging (upstream's legacy `setup.py`/
+  `setup.cfg`) builds cleanly and its dependency list has been reviewed
+  for staleness; a release pipeline for the fork exists; the actual
+  publish is scoped as a separate prerequisite work item, consistent
+  with this item's own `forbidden_actions: publish_package`; once
+  published, `lcats/pyproject.toml` pins it by version, not URL.
 - `lcats/src/lcats/gettenberg/` tests, including the new regression
   test where applicable, pass unchanged in behavior after
   the change.
@@ -185,10 +255,38 @@ rest of release-readiness work proceeds.
 
 ## Risk Notes
 
+- Vendoring and re-fork-and-publish share the same underlying cost:
+  both require forking the same five gutenbergpy-internal files, since
+  `GutenbergCache.create()` has no extension point for substituting a
+  patched parser/cache-writer (see Problem/Context). They differ only
+  in where that fork lives and how it's packaged — vendoring keeps it
+  private inside LCATS's own tree; re-fork-and-publish makes it a
+  second, independently versioned, installable PyPI project. Neither
+  option is a small patch.
 - Vendoring permanently diverges LCATS's copy from upstream; future
-  upstream fixes must be manually re-ported.
+  upstream fixes to those five files must be manually re-ported by
+  diffing against a moving GitHub repo rather than a real git history.
 - A separate LCATS-controlled PyPI fork adds an ongoing maintenance and
-  security surface (a second package to keep current).
-- "Wait on upstream" has no ETA and, left unresolved, blocks the real
-  release indefinitely — list explicitly as a considered-and-likely-
-  rejected option, not silently dropped.
+  security surface (a second package to keep current) plus a second,
+  independent release pipeline (Trusted Publishing, versioning, a
+  runbook) — effectively duplicating `WI-RELEASE-0038`'s scope for a
+  package that isn't LCATS's actual deliverable. It also inherits
+  upstream's legacy packaging (`setup.py`/`setup.cfg`, no PEP 621
+  project table) and dated dependencies (`future`,
+  `httpsproxy-urllib2`, `lxml`, `pymongo`, `chardet`).
+- "Wait on upstream" now has an active maintainer contact in progress
+  (as of this work item's latest update) but still no committed ETA —
+  `raduangelescu/gutenbergpy:master`'s `setup.cfg` already shows an
+  unreleased `version = 0.3.6` bump, a mildly encouraging but
+  non-committal signal. Continue to treat this as a
+  considered-and-possibly-rejected option pending the maintainer's
+  response, not a settled plan to wait indefinitely.
+
+## Open Questions
+
+- Maintainer response on release timing (Option A) is pending as of
+  this update; revisit this work item's decision once it arrives.
+- PyPI project-name availability for a re-fork-and-publish path (e.g.
+  `lcats-gutenbergpy` or similar) has not been confirmed — a check
+  attempt was blocked by PyPI's bot-challenge page and needs to be
+  redone before that option could actually proceed.


### PR DESCRIPTION
## Summary
- Deepens `WI-RELEASE-0037`'s Problem/Context, Scope, Required Changes, Acceptance Criteria, and Risk Notes with findings from a follow-up analysis session
- Documents that Option A (wait on upstream) now has an active maintainer contact in progress, plus a mildly encouraging signal (`setup.cfg` already shows an unreleased `version = 0.3.6`)
- Corrects the vendoring (B) vs. re-fork-and-publish (C) framing: both require forking the same five gutenbergpy-internal files (`rdfparser.py`, `book.py`, `cachefields.py`, `sqlitecache.py`, `gutenbergindex.db.sql`), since `GutenbergCache.create()` hardcodes its parser/cache-writer with no extension point — grounded in `lcats/src/lcats/gettenberg/cache.py:11,128,144`
- Grounds the PyPI direct-dependency rejection in the actual `pypi/warehouse` source (`warehouse/forklift/metadata.py`'s `_validate_metadata`)
- Adds an Open Questions section: maintainer response pending, fork PyPI name availability unconfirmed

**Type:** deliverable (WI content update, no code changes)
**Related workstream:** none

## Test plan
- [x] `lrh validate` — 0 errors, only pre-existing unrelated warnings
