### PR TITLE
Add workstream WS-RELEASE: LCATS PyPI Release Readiness

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_29_03_49_34_WS_RELEASE_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_29_03_49_34_WS_RELEASE_REVIEW.md
@@ -1,0 +1,61 @@
+---
+execution_id: 2026_07_29_03_49_34_WS_RELEASE_REVIEW
+prompt_id: PROMPT(AD_HOC:WS_RELEASE_REVIEW)[2026-07-29T03:49:23-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/185
+commit: ffb74953
+created_at: 2026-07-29T03:49:34-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/185
+session_transcript: pending
+---
+
+# Summary
+
+Address review comments on PR #185 (`WS-RELEASE`) from
+`copilot-pull-request-reviewer` and `chatgpt-codex-connector`, applied
+directly per this run's review-response autonomy grant.
+
+# Result
+
+Three comments addressed:
+
+1. Copilot: an exit-criteria bullet mixed two possessives
+   (`pyproject.toml`'s and `environment.yml`'s) into one ambiguous
+   sentence, in both the frontmatter `exit_criteria:` list and the body
+   `## Exit Criteria` section. Confirmed both locations, split each into
+   two explicit bullets, one per file.
+   (https://github.com/xenotaur/LCATS/pull/185#discussion_r3671905333)
+2. Codex: `related_design` referenced `PROP-LCATS-PYPI-RELEASE-
+   READINESS`, which hadn't merged (PR #184) at review time, making it
+   a dangling reference. Resolved by merging `main` (PR #184 and #186
+   have both since merged), which also required resolving merge
+   conflicts in `WI-RELEASE-0037.md`/`WI-RELEASE-0038.md` — both files
+   had independently gained `related_design` (from #184's own
+   follow-up commit) and `related_workstreams` (from this branch's
+   earlier linking commit) edits; combined both rather than picking
+   one side.
+   (https://github.com/xenotaur/LCATS/pull/185#discussion_r3671909051)
+3. Codex: "Add reciprocal workstream links to both work items" — this
+   was already resolved by an earlier commit on this branch
+   (`186712e9`, pushed before the review ran against an older commit).
+   Verified `WI-RELEASE-0037.md`/`WI-RELEASE-0038.md` already declare
+   `related_workstreams: [WS-RELEASE]`. While resolving comment 2's
+   merge, also completed the same reciprocal link for the newly-merged
+   `WI-RELEASE-0039.md` (still `related_workstreams: []` since it was
+   created before this branch's linking commit existed) and added it
+   to `WS-RELEASE`'s own `work_items:` frontmatter list, now that it
+   exists on `main`.
+   (https://github.com/xenotaur/LCATS/pull/185#discussion_r3671909060)
+
+# Validation
+
+- `lrh validate` — 0 errors, 47 pre-existing unrelated warnings, none on
+  these files
+
+# Follow-up
+
+- None — proceeding to `/lrh-confirm-fixes`. This is the last PR in the
+  #184 → #186 → #185 sequence.

--- a/lcats/project/executions/AD_HOC/2026_07_29_03_55_35_WS_RELEASE_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_29_03_55_35_WS_RELEASE_CONFIRM.md
@@ -1,0 +1,50 @@
+---
+execution_id: 2026_07_29_03_55_35_WS_RELEASE_CONFIRM
+prompt_id: PROMPT(AD_HOC:WS_RELEASE_CONFIRM)[2026-07-29T03:55:14-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/185
+commit: e6752634
+created_at: 2026-07-29T03:55:35-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/185
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass for PR #185 (`WS-RELEASE`), the final PR in
+the #184 → #186 → #185 chain. Independently verified all 3 unresolved
+review threads against the current `HEAD` diff, resolved all 3.
+
+# Result
+
+All 3 threads classified Clear-satisfied against `HEAD` (`e6752634`):
+
+- `discussion_r3671905333` (ambiguous double-possessive exit-criteria
+  bullet) — resolved; both locations now split into two bullets each
+- `discussion_r3671909051` (dangling proposal reference) — resolved;
+  `git show HEAD:.../00_proposal.md` confirms the file now exists on
+  this branch (merged from `main`)
+- `discussion_r3671909060` (reciprocal workstream links) — resolved;
+  all three work items (`WI-RELEASE-0037`, `-0038`, `-0039`) now
+  declare `related_workstreams: [WS-RELEASE]`, and `WS-RELEASE`'s
+  `work_items:` list includes all three
+
+No exceptions surfaced. Thread-resolution verdict: **green**.
+
+All 3 threads resolved via `resolveReviewThread` GraphQL mutation.
+
+# Validation
+
+- CI on `e6752634`: `test`, `coverage`, `lint` all `SUCCESS`
+- `lrh validate` — 0 errors
+
+# Follow-up
+
+- Final verdict: **All threads resolved, CI green on `e6752634` → ready
+  to merge.**
+  `gh pr merge https://github.com/xenotaur/LCATS/pull/185 --squash --match-head-commit e67526344b387983da87e93c43df09de77ec4a5e`
+- Next: report to user for the merge gate; `/lrh-closeout` after merge.
+  This is the last PR in the #184 → #186 → #185 sequence.

--- a/lcats/project/work_items/proposed/WI-RELEASE-0037.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0037.md
@@ -12,7 +12,8 @@ contributors:
 assigned_agents: []
 related_focus: []
 related_roadmap: []
-related_workstreams: []
+related_workstreams:
+  - WS-RELEASE
 related_design: []
 depends_on: []
 blocked_by: []

--- a/lcats/project/work_items/resolved/WI-RELEASE-0038.md
+++ b/lcats/project/work_items/resolved/WI-RELEASE-0038.md
@@ -12,7 +12,8 @@ contributors:
 assigned_agents: []
 related_focus: []
 related_roadmap: []
-related_workstreams: []
+related_workstreams:
+  - WS-RELEASE
 related_design: []
 depends_on: []
 blocked_by: []

--- a/lcats/project/workstreams/proposed/WS-RELEASE.md
+++ b/lcats/project/workstreams/proposed/WS-RELEASE.md
@@ -1,0 +1,110 @@
+---
+id: WS-RELEASE
+kind: planning_node
+title: LCATS PyPI Release Readiness
+status: proposed
+stage: planned
+origin: design_review
+summary: Coordinate the work items that resolve LCATS's gutenbergpy PyPI-upload blocker, deliver minimal release-version tooling, and gate any real publish behind a pre-launch verification check, per PROP-LCATS-PYPI-RELEASE-READINESS.
+related_focus: []
+related_roadmap: []
+related_design:
+  - project/design/proposals/proposed/lcats-pypi-release-readiness/00_proposal.md
+work_items:
+  - WI-RELEASE-0037
+  - WI-RELEASE-0038
+exit_criteria:
+  - WI-RELEASE-0037 is resolved -- lcats/pyproject.toml's and lcats/environment.yml's gutenbergpy dependency no longer contains a direct URL/VCS reference
+  - WI-RELEASE-0038 is resolved (already true) -- lcats.version, --version, and scripts/version exist and pass validation
+  - A pre-launch verification work item (not yet created -- see Work Items) is resolved by actually being run, confirming the gutenbergpy resolution is still current, immediately before any real LCATS PyPI publish is attempted
+  - PROP-LCATS-PYPI-RELEASE-READINESS's implementation_status is updated to implemented once all three work items are resolved
+---
+
+# Workstream: LCATS PyPI Release Readiness
+
+## Purpose
+
+This workstream coordinates the work items that implement
+`PROP-LCATS-PYPI-RELEASE-READINESS`: resolving the `gutenbergpy`
+direct-VCS-dependency PyPI-upload blocker, delivering the minimal
+release-version tooling LCATS actually needs now, and gating any real
+publish behind a dedicated pre-launch verification step rather than a
+one-time decision. It exists to track the sequencing between "decide and
+implement the dependency fix" and "confirm that fix is still valid right
+before publish" — a distinction a single unscoped work item couldn't
+express.
+
+## Scope
+
+- Resolve `WI-RELEASE-0037` (the `gutenbergpy` dependency blocker).
+- `WI-RELEASE-0038` (version tooling) — already resolved, tracked here for
+  completeness.
+- Scope and create a new pre-launch verification work item once this
+  workstream lands.
+- Update `PROP-LCATS-PYPI-RELEASE-READINESS`'s `implementation_status`
+  once all three work items are resolved.
+
+## Prior Art Check
+
+### Duplication search
+- In-repo: No existing workstream addresses PyPI release readiness
+  (checked `project/workstreams/proposed/`, `project/workstreams/resolved/`).
+- Sibling repos: `logical_robotics_harness`'s release apparatus is the
+  comparison point used throughout the governing proposal, not duplicated
+  work.
+- External libraries: None applicable.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: Found — `WI-RELEASE-0037`, `WI-RELEASE-0038` (already
+  linked above).
+- Proposals: `PROP-LCATS-PYPI-RELEASE-READINESS` is this workstream's own
+  originating proposal, not a duplicate.
+- Backlog: No `project/design/backlog.md` in this repo.
+- Recommendation: No action.
+
+## Work Items
+
+- **WI-RELEASE-0037** — Resolve the `gutenbergpy` VCS-pin PyPI-publish
+  blocker (vendor vs. re-fork-and-publish vs. wait-on-upstream). Proposed,
+  open.
+- **WI-RELEASE-0038** — `lcats.version` module, `--version` CLI flag,
+  `scripts/version` helper. Resolved, merged (PR #183).
+- **Pre-launch verification gate** (not yet created) — re-checks the
+  `gutenbergpy` dependency-blocker's resolution status (upstream release
+  state, or the continued validity of whatever fix `WI-RELEASE-0037`
+  lands on) immediately before any real LCATS PyPI publish is attempted.
+  To be scoped via `/lrh-work-item` after this workstream lands.
+
+## Exit Criteria
+
+- `WI-RELEASE-0037` is resolved: `lcats/pyproject.toml`'s and
+  `lcats/environment.yml`'s `gutenbergpy` dependency no longer contains a
+  direct URL/VCS reference.
+- `WI-RELEASE-0038` is resolved (already true): `lcats.version`,
+  `--version`, and `scripts/version` exist and pass validation.
+- The pre-launch verification work item is resolved — actually run,
+  confirming the `gutenbergpy` resolution is still current, immediately
+  before any real LCATS PyPI publish is attempted.
+- `PROP-LCATS-PYPI-RELEASE-READINESS`'s `implementation_status` is
+  updated to `implemented` once all three work items are resolved.
+
+## Non-Goals
+
+- Does not include actually publishing LCATS to PyPI — no
+  `publish_package` action happens under this workstream, per the
+  governing proposal's Non-Goals.
+- Does not scope `scripts/release-smoke`, a release runbook, or PyPI
+  Trusted Publishing setup — deferred to future work items once a real
+  publish is imminent.
+- Does not decide vendor vs. fork-and-publish vs. wait for
+  `WI-RELEASE-0037` — that decision is that work item's own scope.
+
+## Relationship to Design
+
+- Design proposal:
+  `project/design/proposals/proposed/lcats-pypi-release-readiness/00_proposal.md`
+  (PR #184, not yet merged; proposal `status` remains `proposed` on disk
+  until this workstream closes and adopts it, per LRH convention).
+- Prior workstream: `project/workstreams/resolved/WS-PACKAGING.md` (the
+  model this workstream follows).

--- a/lcats/project/workstreams/proposed/WS-RELEASE.md
+++ b/lcats/project/workstreams/proposed/WS-RELEASE.md
@@ -16,7 +16,7 @@ work_items:
 exit_criteria:
   - WI-RELEASE-0037 is resolved -- lcats/pyproject.toml's and lcats/environment.yml's gutenbergpy dependency no longer contains a direct URL/VCS reference
   - WI-RELEASE-0038 is resolved (already true) -- lcats.version, --version, and scripts/version exist and pass validation
-  - A pre-launch verification work item (not yet created -- see Work Items) is resolved by actually being run, confirming the gutenbergpy resolution is still current, immediately before any real LCATS PyPI publish is attempted
+  - WI-RELEASE-0039 is resolved by actually being run, confirming the gutenbergpy resolution is still current, immediately before any real LCATS PyPI publish is attempted -- not resolved merely as a formality shortly after WI-RELEASE-0037
   - PROP-LCATS-PYPI-RELEASE-READINESS's implementation_status is updated to implemented once all three work items are resolved
 ---
 
@@ -39,8 +39,8 @@ express.
 - Resolve `WI-RELEASE-0037` (the `gutenbergpy` dependency blocker).
 - `WI-RELEASE-0038` (version tooling) — already resolved, tracked here for
   completeness.
-- Scope and create a new pre-launch verification work item once this
-  workstream lands.
+- Run `WI-RELEASE-0039` (pre-launch verification) immediately before any
+  real PyPI publish attempt.
 - Update `PROP-LCATS-PYPI-RELEASE-READINESS`'s `implementation_status`
   once all three work items are resolved.
 
@@ -70,11 +70,11 @@ express.
   open.
 - **WI-RELEASE-0038** — `lcats.version` module, `--version` CLI flag,
   `scripts/version` helper. Resolved, merged (PR #183).
-- **Pre-launch verification gate** (not yet created) — re-checks the
+- **WI-RELEASE-0039** — Pre-launch verification gate: re-checks the
   `gutenbergpy` dependency-blocker's resolution status (upstream release
   state, or the continued validity of whatever fix `WI-RELEASE-0037`
   lands on) immediately before any real LCATS PyPI publish is attempted.
-  To be scoped via `/lrh-work-item` after this workstream lands.
+  `depends_on: WI-RELEASE-0037`. Proposed.
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary
- Adds `WS-RELEASE`, the governing workstream for `PROP-LCATS-PYPI-RELEASE-READINESS` (#184), mirroring `WS-PACKAGING`'s pattern.
- Links `WI-RELEASE-0037` (gutenbergpy blocker, open) and `WI-RELEASE-0038` (version tooling, resolved).
- Exit criteria explicitly include a not-yet-created pre-launch verification work item — the "check back in before launch" item requested — rather than treating the gutenbergpy blocker's resolution as a one-time decision.
- Does not include actually publishing to PyPI, `scripts/release-smoke`, a runbook, or Trusted Publishing setup — all deferred per the governing proposal's Non-Goals.

**Stage:** planned
**Work items:** WI-RELEASE-0037, WI-RELEASE-0038 (+ one pre-launch-verification item to be scoped after this lands)

## Test plan
- [x] `lrh validate` — 0 errors, only pre-existing unrelated warnings
