### PR TITLE
Add work item WI-RELEASE-0039: pre-launch gutenbergpy verification gate

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_29_03_40_53_WI_RELEASE_0039_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_29_03_40_53_WI_RELEASE_0039_REVIEW.md
@@ -1,0 +1,49 @@
+---
+execution_id: 2026_07_29_03_40_53_WI_RELEASE_0039_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0039_REVIEW)[2026-07-29T03:40:42-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/186
+commit: ea99a929
+created_at: 2026-07-29T03:40:53-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/186
+session_transcript: pending
+---
+
+# Summary
+
+Address review comments on PR #186 (`WI-RELEASE-0039`) from
+`chatgpt-codex-connector` and `copilot-pull-request-reviewer`, both
+flagging the same underlying issue: a dangling `related_design`
+reference.
+
+# Result
+
+One comment addressed (both reviewers raised the identical issue
+independently):
+
+1. Both flagged that `related_design` points to
+   `project/design/proposals/proposed/lcats-pypi-release-readiness/00_proposal.md`,
+   which didn't exist in this PR's branch/repo state at review time —
+   this branch was created from `main` before `PROP-LCATS-PYPI-RELEASE-
+   READINESS` (PR #184) had merged. Verified the file now exists on
+   `main` (PR #184 merged earlier in this session) and resolved by
+   merging `main` into this branch rather than editing the reference
+   away — the reference was always correct in intent, just temporarily
+   dangling due to merge-order timing in a 3-PR dependency chain
+   (#184 → #186 → #185).
+   (https://github.com/xenotaur/LCATS/pull/186#discussion_r3671948092,
+   https://github.com/xenotaur/LCATS/pull/186#discussion_r3671950339)
+
+# Validation
+
+- `lrh validate` — 0 errors, 47 pre-existing unrelated warnings, none on
+  this file
+- Confirmed via `git ls-tree origin/main` that both the proposal file
+  and its `README.md` exist on `main` before merging
+
+# Follow-up
+
+- None — proceeding to `/lrh-confirm-fixes`.

--- a/lcats/project/executions/AD_HOC/2026_07_29_03_44_21_WI_RELEASE_0039_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_29_03_44_21_WI_RELEASE_0039_CONFIRM.md
@@ -1,0 +1,46 @@
+---
+execution_id: 2026_07_29_03_44_21_WI_RELEASE_0039_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_RELEASE_0039_CONFIRM)[2026-07-29T03:43:58-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/186
+commit: cd9b31f4
+created_at: 2026-07-29T03:44:21-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/186
+session_transcript: pending
+---
+
+# Summary
+
+Pre-merge verification pass for PR #186 (`WI-RELEASE-0039`). Independently
+verified both unresolved review threads against the current `HEAD` diff,
+resolved both.
+
+# Result
+
+Both threads classified Clear-satisfied against `HEAD` (`cd9b31f4`):
+`git show HEAD:.../00_proposal.md` confirms the previously-dangling
+`related_design` target now exists on this branch (merged in from `main`
+after PR #184 landed).
+
+- `discussion_r3671948092` — resolved
+- `discussion_r3671950339` — resolved
+
+No exceptions surfaced. Thread-resolution verdict: **green**.
+
+Both threads resolved via `resolveReviewThread` GraphQL mutation.
+
+# Validation
+
+- CI on `cd9b31f4`: `test`, `coverage`, `lint` all `SUCCESS`
+- `lrh validate` — 0 errors
+
+# Follow-up
+
+- Final verdict: **All threads resolved, CI green on `cd9b31f4` → ready
+  to merge.**
+  `gh pr merge https://github.com/xenotaur/LCATS/pull/186 --squash --match-head-commit cd9b31f4`
+- Next: report to user for the merge gate; `/lrh-closeout` after merge.
+  This PR merges second in the #184 → #186 → #185 sequence.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -20,6 +20,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 - `proposed/WI-EVENT-0032.md` — Harden Event-Role-World tool-schema reliability and processor error/model handling
 - `proposed/WI-EVENT-0033.md` — Add schema-hardened structured output to scene/story analysis extractors
 - `proposed/WI-RELEASE-0037.md` — Resolve gutenbergpy VCS-pin PyPI-publish blocker
+- `proposed/WI-RELEASE-0039.md` — Pre-launch verification of the gutenbergpy dependency resolution before real PyPI publish
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-RELEASE-0039.md
+++ b/lcats/project/work_items/proposed/WI-RELEASE-0039.md
@@ -1,0 +1,165 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-RELEASE-0039
+title: Pre-launch verification of the gutenbergpy dependency resolution before real PyPI publish
+type: evaluation
+status: proposed
+owner: xenotaur
+contributors:
+  - xenotaur
+assigned_agents: []
+related_focus: []
+related_roadmap: []
+related_workstreams: []
+related_design:
+  - project/design/proposals/proposed/lcats-pypi-release-readiness/00_proposal.md
+depends_on:
+  - WI-RELEASE-0037
+blocked_by: []
+expected_actions:
+  - create_report
+  - edit_file
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - publish_package
+  - modify_ci_pipeline
+acceptance:
+  - A verification report exists confirming, as of a date immediately preceding the real PyPI publish attempt, whether gutenbergpy has a newer PyPI release incorporating PR #25/#26 (which would make "wait on upstream" viable even if WI-RELEASE-0037 originally chose otherwise)
+  - If WI-RELEASE-0037 chose vendoring - the report confirms the vendored copy in lcats/src/lcats/gettenberg/ still matches what was verified at implementation time, and checks for any new upstream commits to the vendored files that should be considered for re-porting
+  - If WI-RELEASE-0037 chose re-fork-and-publish - the report confirms the LCATS-controlled fork's PyPI package is still current, its own dependency pin in lcats/pyproject.toml resolves correctly, and the fork has not fallen behind any relevant upstream security fixes
+  - If findings suggest WI-RELEASE-0037's original decision should be revisited, that discrepancy is surfaced to the user before any publish proceeds - this item does not unilaterally change the dependency pin or re-decide vendor vs. fork vs. wait
+  - This item is not resolved until it has actually been run and reported on in the same work session as an imminent real PyPI publish attempt - an early dry run does not satisfy its purpose
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+artifacts_expected:
+  - project/executions/WI-RELEASE-0039/
+---
+
+## Summary
+
+Re-verify, immediately before any real LCATS PyPI publish is attempted,
+that `WI-RELEASE-0037`'s `gutenbergpy` dependency-blocker resolution is
+still current — catching upstream releases, drift in a vendored/forked
+copy, or other changes that could make the original decision stale.
+
+## Problem / Context
+
+`PROP-LCATS-PYPI-RELEASE-READINESS`'s Design Decision 1 ("How to keep the
+dependency-blocker resolution honest over time") identified that
+resolving `WI-RELEASE-0037` once and treating it as permanently settled
+has a real gap: the interval between that resolution and an actual
+publish attempt could be long enough for upstream `gutenbergpy` state to
+change (a new PyPI release could land, making a chosen vendor/fork
+solution unnecessary or reversible), or for a vendored/forked copy to
+have silently drifted from what was verified at implementation time. A
+one-time decision recorded in a now-closed work item has no built-in
+mechanism to force a second look before the point where drift actually
+matters — the moment of real publish. This work item is that standing
+mechanism, per the proposal's and governing workstream's
+(`WS-RELEASE`) explicit design.
+
+### Duplication search
+- In-repo: No existing implementation or decision record found (grepped
+  `project/work_items/`, `project/design/proposals/` for
+  "pre-launch"/"pre-publish"/"release gate"/"publish verification").
+- Sibling repos: None identified — this is LCATS-specific.
+- External libraries: None applicable — this is a manual verification
+  gate, not a library concern.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found beyond the originating proposal/workstream
+  themselves.
+- Proposals: `PROP-LCATS-PYPI-RELEASE-READINESS` is this item's own
+  originating proposal, not a duplicate demand.
+- Backlog: No `project/design/backlog.md` in this repo.
+- Recommendation: No action.
+
+## Scope
+
+- Confirm `gutenbergpy`'s current PyPI release status against the
+  upstream fixes (`raduangelescu/gutenbergpy` PR #25/#26).
+- If `WI-RELEASE-0037` chose vendoring or forking-and-publishing, confirm
+  that solution is still intact and current.
+- Surface any discrepancy to the user before a real publish proceeds —
+  do not silently re-decide or auto-correct.
+
+## Required Changes
+
+1. Check the current `gutenbergpy` PyPI release version and changelog
+   for whether it now includes the alias-table/title-index fixes from
+   PR #25/#26 — if so, "wait on upstream" may now be viable even if
+   `WI-RELEASE-0037` originally chose otherwise, and that should be
+   surfaced as a live option, not silently ignored.
+2. If `WI-RELEASE-0037` chose vendoring: diff the vendored copy in
+   `lcats/src/lcats/gettenberg/` against its recorded origin to confirm
+   no accidental drift, and check `raduangelescu/gutenbergpy:master` for
+   any new commits to the vendored files' upstream originals since
+   `WI-RELEASE-0037` was resolved.
+3. If `WI-RELEASE-0037` chose re-fork-and-publish: confirm the
+   LCATS-controlled fork's PyPI package is still installable and
+   current, and that `lcats/pyproject.toml`'s pin to it still resolves.
+4. Write findings into this work item's execution record. If findings
+   suggest the original `WI-RELEASE-0037` decision should be revisited,
+   stop and report to the user — do not change the dependency pin or
+   re-decide vendor/fork/wait as part of this item.
+5. Do not perform the actual PyPI publish as part of this work item.
+
+## Non-Goals
+
+- Does not implement or change the `gutenbergpy` dependency fix itself —
+  that remains `WI-RELEASE-0037`'s scope, even if this item's findings
+  suggest revisiting it.
+- Does not perform the actual PyPI publish — `forbidden_actions` bars
+  `publish_package`.
+- Does not set up ongoing or automated monitoring of `gutenbergpy`'s
+  release status — this is a one-time manual gate run immediately before
+  a specific publish attempt, not continuous integration.
+
+## Acceptance Criteria
+
+- A verification report exists confirming, as of a date immediately
+  preceding the real PyPI publish attempt, whether `gutenbergpy` has a
+  newer PyPI release incorporating PR #25/#26.
+- If vendoring was chosen: the report confirms the vendored copy still
+  matches what was verified at implementation time, and checks for new
+  upstream commits worth re-porting.
+- If re-fork-and-publish was chosen: the report confirms the fork's
+  PyPI package is still current and its dependency pin resolves
+  correctly.
+- If findings suggest the original decision should be revisited, that
+  is surfaced to the user before any publish proceeds — this item does
+  not unilaterally act on it.
+- This item is not resolved until it has actually been run and reported
+  on in the same work session as an imminent real PyPI publish attempt.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `lrh validate`
+- Manual check documented against `https://pypi.org/project/gutenbergpy/`
+  (or the chosen alternative package, if `WI-RELEASE-0037` published a
+  fork)
+
+## Risk Notes
+
+- This item's value depends entirely on being run at the right time.
+  Resolving it prematurely — e.g., immediately after `WI-RELEASE-0037`
+  without an actual imminent publish — defeats its purpose. Whoever
+  executes it should confirm a real publish is genuinely about to happen
+  before treating this item as satisfied.
+- Cannot be meaningfully executed until `WI-RELEASE-0037` has resolved —
+  see `depends_on`.
+
+## Dependencies / Order
+
+Depends on `WI-RELEASE-0037` (cannot meaningfully run before that
+item's vendor/fork/wait decision is made). Should run as the final step
+before any real PyPI publish attempt, not scheduled to a fixed date —
+timing is tied to the publish event itself, not the calendar.


### PR DESCRIPTION
## Summary
- Adds `WI-RELEASE-0039`, the "check back in before launch" work item requested against `WS-RELEASE`/`PROP-LCATS-PYPI-RELEASE-READINESS`: re-verifies the `gutenbergpy` dependency-blocker resolution (upstream release status, or the continued validity of a vendored/forked fix) immediately before any real LCATS PyPI publish is attempted.
- `depends_on: WI-RELEASE-0037` — cannot meaningfully run before that item resolves.
- `related_workstreams: []` for now — `WS-RELEASE` (PR #185) hasn't merged to main yet, and `lrh validate` checks `related_workstreams` IDs against known files; will link once #185 lands.
- Registered in `project/work_items/README.md`'s Proposed Items index up front (this repo has a recurring gap where new WIs go unregistered — caught 4 times already this session).

**Type:** evaluation
**Related workstream:** WS-RELEASE (to be linked post-merge, see above)

## Test plan
- [x] `lrh validate` — 0 errors, only pre-existing unrelated warnings
