### PR TITLE
Implement WI-EVENT-0032: harden ERW tool-schema reliability

### DIFF
--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -485,15 +485,18 @@ def _run_erw_pipeline(
                 context=f"pipeline {story_id} story-relation",
                 usage_rows=[u.to_dict() for u in all_usage],
             )
-        cross_segment_relations, weakly_inferred_cross_segment_relations = (
-            erw_story_relation.build_story_relations(
-                story_relation_result.get("extracted_output") or {}, story
-            )
+        (
+            cross_segment_relations,
+            weakly_inferred_cross_segment_relations,
+            story_relation_item_errors,
+        ) = erw_story_relation.build_story_relations(
+            story_relation_result.get("extracted_output") or {}, story
         )
         story.cross_segment_relations = cross_segment_relations
         story.weakly_inferred_cross_segment_relations = (
             weakly_inferred_cross_segment_relations
         )
+        story.extraction_errors.extend(story_relation_item_errors)
         story.validation_errors = erw_schema.validate_story_annotation(story)
 
     return {

--- a/experiments/03_cross_segment_relation_pilot/run_pilot.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot.py
@@ -334,89 +334,23 @@ def _compute_story_metrics(
     }
 
 
-def _close_schema_objects(node: Any) -> Any:
-    """Recursively return a deep copy of a JSON Schema fragment with
-    additionalProperties: false set on every object (top-level and
-    nested) - required by Anthropic's strict tool use before strict: true
-    takes effect. See _strict_tool_schema()'s docstring for why this is
-    needed.
-
-    Sets additionalProperties unconditionally (not via setdefault) so an
-    existing, looser value (e.g. additionalProperties: true, or a schema
-    rather than a bare bool) can't silently defeat the requirement this
-    exists to enforce. Also matches "object" inside a union `type` list
-    (e.g. `type: ["object", "null"]`), not just a bare `type: "object"`
-    string, since JSON Schema permits either form.
-    """
-    if isinstance(node, dict):
-        closed = {key: _close_schema_objects(value) for key, value in node.items()}
-        node_type = closed.get("type")
-        is_object = node_type == "object" or (
-            isinstance(node_type, list) and "object" in node_type
-        )
-        if is_object:
-            closed["additionalProperties"] = False
-        return closed
-    if isinstance(node, list):
-        return [_close_schema_objects(item) for item in node]
-    return node
-
-
-def _strict_tool_schema(tool_schema: Dict[str, Any]) -> Dict[str, Any]:
-    """Return a deep copy of `tool_schema` with strict: true enabled.
-
-    Without strict: true, Anthropic's tool use does not guarantee the
-    model's tool_use input matches input_schema - "Claude might return
-    incompatible types ... or omit required fields, breaking your
-    functions and causing runtime errors" (Anthropic docs, Strict tool
-    use). This is exactly what happened live: a relations array item came
-    back as a plain string instead of the required object, crashing
-    relation_extractor.build_relations()'s `raw.get("quote", ...)` with
-    AttributeError. Enabling strict: true constrains the model's token
-    sampling to schema-valid output via grammar-constrained sampling,
-    which would have prevented that malformed item outright.
-
-    strict: true additionally requires additionalProperties: false on
-    every object in the schema, including nested ones inside array items
-    (Anthropic docs, JSON Schema limitations) - none of the ERW tool
-    schemas set this today, so _close_schema_objects() adds it here rather
-    than editing each schema's module (forbidden by this work item; see
-    _build_erw_extractors()'s docstring for the same constraint applied to
-    default_model).
-    """
-    schema = _close_schema_objects(tool_schema)
-    schema["strict"] = True
-    return schema
-
-
-def _build_erw_extractors(
-    backend: Any, model: str, backend_name: str
-) -> Dict[str, Any]:
+def _build_erw_extractors(backend: Any, model: str) -> Dict[str, Any]:
     """Build the Event-Role-World extractors, with `model` overriding each
-    factory's own hardcoded default_model (e.g. "gpt-4o"), max_tokens raised
-    to _ERW_MAX_TOKENS (each factory's own default of 4096 is too low for
-    content-dense segments and risks TruncatedResponseError - see
-    lcats.llm.backend), and, for --backend anthropic only, each extractor's
-    tool_schema upgraded to strict: true (see _strict_tool_schema()).
+    factory's own hardcoded default_model (e.g. "gpt-4o") and max_tokens
+    raised to _ERW_MAX_TOKENS (each factory's own default of 4096 is too
+    low for content-dense segments and risks TruncatedResponseError - see
+    lcats.llm.backend). Each extractor's tool_schema is already strict at
+    the source (WI-EVENT-0032) - this function used to additionally apply
+    a runtime strict-schema override for --backend anthropic only, now
+    removed as redundant.
 
-    processor.process_segments() has no model parameter - it builds these
-    same extractors internally with each factory's hardcoded default,
-    which sends an invalid model ID whenever the caller's backend/model
-    choice differs (e.g. --backend anthropic with the default gpt-4o
-    baked into every ERW extractor). Building them here instead, then
-    driving processor.process_segment() (singular - it accepts pre-built
-    extractor instances) per segment ourselves, fixes this without
-    touching processor.py or any event_role_world module (forbidden by
-    this work item).
-
-    The strict-schema override is gated to backend_name == "anthropic"
-    because it is not a no-op for OpenAI: AnthropicBackend.complete()
-    forwards the whole tool dict verbatim, so an added top-level `strict`
-    key is inert there unless read, but OpenAIBackend.complete() forwards
-    `tool["input_schema"]` directly as its function `parameters` - the
-    `additionalProperties: false` this same override adds to input_schema
-    would reach OpenAI's schema too and could change its behavior in ways
-    this fix was never intended to touch or test.
+    processor.process_segments() now accepts a model= override too
+    (WI-EVENT-0032), but not a per-extractor max_tokens override, which
+    this pilot also needs (see the comment above _ERW_MAX_TOKENS).
+    Building the extractors here and driving processor.process_segment()
+    (singular - it accepts pre-built extractor instances) per segment
+    ourselves keeps both overrides available, without waiting on
+    process_segments() to grow a max_tokens parameter of its own.
     """
     entity = erw_entity.make_entity_extractor(backend)
     event = erw_event.make_event_extractor(backend)
@@ -426,8 +360,6 @@ def _build_erw_extractors(
     for extractor in (entity, event, relation, discourse, story_relation):
         extractor.default_model = model
         extractor.max_tokens = _ERW_MAX_TOKENS
-        if backend_name == "anthropic" and extractor.tool_schema is not None:
-            extractor.tool_schema = _strict_tool_schema(extractor.tool_schema)
     return {
         "entity": entity,
         "event": event,
@@ -812,7 +744,7 @@ def main() -> int:
     # per-story timer starts below, so per-story elapsed_seconds no longer
     # includes it - print an explicit confirmation instead, since spaCy
     # (unlike Stanza) prints no loading banner of its own.
-    extractors = _build_erw_extractors(backend, model, args.backend)
+    extractors = _build_erw_extractors(backend, model)
     print(f"Loading NLP backend: {args.nlp_backend}...")
     nlp_backend = _make_nlp_backend(args.nlp_backend)
     print(f"NLP backend ready: {args.nlp_backend}")
@@ -852,6 +784,32 @@ def main() -> int:
                 )
                 aborted = True
                 break
+            except Exception as exc:  # noqa: BLE001 - see docstring below
+                # Any exception other than FatalPilotError is an
+                # unexpected, per-story failure - not an account-level
+                # one. Previously this propagated straight out of main(),
+                # skipping the write block below entirely and discarding
+                # every already-completed, already-paid-for story's
+                # results, not just this one's (WI-EVENT-0032, audit's
+                # Category B update finding). Record a minimal excluded
+                # row (matching run_story()'s own row shape - see its
+                # "could not read/parse story JSON" branch) and continue
+                # to the next story instead.
+                print(
+                    f"  error: unexpected failure on {path.name}: {exc}",
+                    file=sys.stderr,
+                )
+                rows.append(
+                    {
+                        "path": str(path),
+                        "story_id": path.stem,
+                        "genre": genre,
+                        "excluded": True,
+                        "exclude_reason": f"unexpected error: {exc!r}",
+                        "elapsed_seconds": time.monotonic() - t0,
+                    }
+                )
+                continue
             row["elapsed_seconds"] = time.monotonic() - t0
             rows.append(row)
             usage_rows.extend(story_usage_rows)

--- a/experiments/03_cross_segment_relation_pilot/run_pilot_test.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot_test.py
@@ -1,0 +1,113 @@
+"""Unit tests for run_pilot.py.
+
+Not part of the installed lcats package (this script lives under
+experiments/, not lcats/lcats/), so it is not discovered by lcats'
+scripts/test (which only walks tests/) - run explicitly:
+
+    python -m unittest experiments/03_cross_segment_relation_pilot/run_pilot_test.py
+
+or:
+
+    python -m pytest experiments/03_cross_segment_relation_pilot/run_pilot_test.py
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+from unittest.mock import patch
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import run_pilot  # noqa: E402 - see sys.path.insert above
+
+
+class TestMainUnexpectedPerStoryException(unittest.TestCase):
+    """WI-EVENT-0032 (audit's Category B update finding): main()'s per-story
+    loop previously caught only FatalPilotError - any other exception
+    propagated straight out of main(), skipping the write block entirely
+    and discarding every already-completed, already-paid-for story's
+    results, not just the one that failed."""
+
+    def _write_story(self, data_dir: pathlib.Path, name: str, body: str) -> None:
+        (data_dir / f"{name}.json").write_text(
+            json.dumps({"name": name, "author": "Test Author", "body": body}),
+            encoding="utf-8",
+        )
+
+    def test_unexpected_exception_on_one_story_preserves_other_results(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data_dir = pathlib.Path(tmp) / "data"
+            data_dir.mkdir()
+            output_dir = pathlib.Path(tmp) / "results"
+            self._write_story(data_dir, "story_a", "Story A body text.")
+            self._write_story(data_dir, "story_b", "Story B body text.")
+
+            real_row = {
+                "path": str(data_dir / "story_a.json"),
+                "story_id": "story_a",
+                "genre": "science fiction",
+                "excluded": False,
+                "exclude_reason": "",
+                "word_count": 3,
+                "segment_count": 1,
+                "cross_segment_density_per_1000_words": 0.0,
+                "weakly_inferred_cross_segment_density_per_1000_words": 0.0,
+                "folded_relations_per_1000_words": 0.0,
+                "folded_weakly_inferred_relations_per_1000_words": 0.0,
+            }
+
+            def fake_run_story(path, genre, *args, **kwargs):
+                if path.stem == "story_b":
+                    raise RuntimeError("simulated unexpected per-story failure")
+                return dict(real_row), []
+
+            argv = [
+                "run_pilot.py",
+                "--dry-run",
+                "--data-dir",
+                str(data_dir),
+                "--sample-size",
+                "1",
+                "--output",
+                str(output_dir),
+            ]
+            with patch.object(sys, "argv", argv), patch.object(
+                run_pilot, "run_story", side_effect=fake_run_story
+            ):
+                exit_code = run_pilot.main()
+
+            self.assertEqual(exit_code, 0)
+
+            stories_path = output_dir / "pilot_stories.jsonl"
+            self.assertTrue(stories_path.exists())
+            rows = [
+                json.loads(line)
+                for line in stories_path.read_text(encoding="utf-8").splitlines()
+            ]
+            rows_by_story_id = {row["story_id"]: row for row in rows}
+
+            # story_a's real, already-completed result must still be
+            # written - not discarded because story_b crashed later.
+            self.assertIn("story_a", rows_by_story_id)
+            self.assertFalse(rows_by_story_id["story_a"]["excluded"])
+
+            # story_b is recorded as excluded with the unexpected error,
+            # not silently dropped and not aborting the whole run.
+            self.assertIn("story_b", rows_by_story_id)
+            self.assertTrue(rows_by_story_id["story_b"]["excluded"])
+            self.assertIn(
+                "unexpected error", rows_by_story_id["story_b"]["exclude_reason"]
+            )
+            self.assertIn(
+                "simulated unexpected per-story failure",
+                rows_by_story_id["story_b"]["exclude_reason"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/03_cross_segment_relation_pilot/run_pilot_test.py
+++ b/experiments/03_cross_segment_relation_pilot/run_pilot_test.py
@@ -1,7 +1,7 @@
 """Unit tests for run_pilot.py.
 
 Not part of the installed lcats package (this script lives under
-experiments/, not lcats/lcats/), so it is not discovered by lcats'
+experiments/, not lcats/src/lcats/), so it is not discovered by lcats'
 scripts/test (which only walks tests/) - run explicitly:
 
     python -m unittest experiments/03_cross_segment_relation_pilot/run_pilot_test.py
@@ -24,6 +24,124 @@ from unittest.mock import patch
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 import run_pilot  # noqa: E402 - see sys.path.insert above
+
+from lcats.llm import backend as llm_backend  # noqa: E402
+
+
+class _SequencedFakeBackend:
+    """Returns a fixed sequence of tool results, one per complete() call -
+    same pattern as tests/analysis_tests/event_role_world_test.py's own
+    double, needed here since a single story's pipeline makes several
+    distinct LLM-backed passes in order."""
+
+    def __init__(self, tool_results):
+        self._results = list(tool_results)
+        self.calls = []
+
+    def complete(self, **kwargs):
+        self.calls.append(kwargs)
+        return llm_backend.BackendResponse(
+            text="",
+            tool_result=self._results.pop(0),
+            model="fake-1.0",
+            input_tokens=5,
+            output_tokens=2,
+            raw=None,
+        )
+
+
+class TestRunErwPipelineStoryRelationCallSite(unittest.TestCase):
+    """Regression test for a real review finding on PR #187: this script's
+    own _run_erw_pipeline() has a second, separate call site for
+    build_story_relations() (distinct from processor.process_segments()'s
+    own call site, already covered by
+    tests/analysis_tests/event_role_world_test.py) - widening
+    build_story_relations()'s return signature to a 3-tuple broke this
+    site's 2-value unpack with ValueError: too many values to unpack,
+    which would have silently excluded every story reaching the
+    cross-segment relation pass."""
+
+    def test_cross_segment_pass_does_not_raise_on_widened_return(self):
+        segment_1_text = "The old machine hummed."
+        segment_2_text = "It shut off forever."
+        body = segment_1_text + " " + segment_2_text
+
+        entity_result = {"entities": []}
+        event_result_1 = {
+            "events": [
+                {
+                    "event_id": "ev1",
+                    "predicate": "hummed",
+                    "event_type": "sound_emission",
+                    "quote": "hummed",
+                }
+            ]
+        }
+        event_result_2 = {
+            "events": [
+                {
+                    "event_id": "ev2",
+                    "predicate": "shut off",
+                    "event_type": "mechanical_failure",
+                    "quote": "shut off",
+                }
+            ]
+        }
+        empty_result = {}
+        story_relation_result = {
+            "relations": [
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "2:ev2",
+                    "relation_type": "causes",
+                    "certainty": "explicit",
+                }
+            ]
+        }
+
+        fake = _SequencedFakeBackend(
+            [
+                entity_result,  # segment 1: entity
+                event_result_1,  # segment 1: event
+                empty_result,  # segment 1: relation
+                empty_result,  # segment 1: discourse
+                # No hypothesis call: _run_erw_pipeline always passes
+                # include_hypotheses=False (this pilot does not use
+                # hypothesis data), so process_segment skips stage 8
+                # entirely for both segments.
+                entity_result,  # segment 2: entity
+                event_result_2,  # segment 2: event
+                empty_result,  # segment 2: relation
+                empty_result,  # segment 2: discourse
+                story_relation_result,  # story-level cross-segment pass
+            ]
+        )
+        extractors = run_pilot._build_erw_extractors(fake, "fake-model")
+        nlp_backend = run_pilot._make_nlp_backend("fake")
+        segments = [
+            {
+                "segment_id": 1,
+                "start_char": 0,
+                "end_char": len(segment_1_text),
+            },
+            {
+                "segment_id": 2,
+                "start_char": len(segment_1_text) + 1,
+                "end_char": len(body),
+            },
+        ]
+
+        # Must not raise ValueError: too many values to unpack.
+        result = run_pilot._run_erw_pipeline(
+            body, segments, extractors, nlp_backend, "fake", "test_story"
+        )
+
+        self.assertEqual(len(result["story"]["cross_segment_relations"]), 1)
+        self.assertEqual(
+            result["story"]["cross_segment_relations"][0]["relation_id"],
+            "story:r1",
+        )
 
 
 class TestMainUnexpectedPerStoryException(unittest.TestCase):

--- a/lcats/project/executions/AD_HOC/2026_07_29_05_08_48_WI_EVENT_0032_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_29_05_08_48_WI_EVENT_0032_REVIEW.md
@@ -1,0 +1,79 @@
+---
+execution_id: 2026_07_29_05_08_48_WI_EVENT_0032_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_EVENT_0032_REVIEW)[2026-07-29T05:08:34-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_29_04_47_46_WI_EVENT_0032
+pr: https://github.com/xenotaur/LCATS/pull/187
+commit: fb5c079a
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/187
+session_transcript: pending
+created_at: 2026-07-29T05:08:48-04:00
+---
+
+# Summary
+
+Address review feedback on PR #187 (WI-EVENT-0032 implementation).
+
+# Result
+
+Three review comments, all verified directly against the code before
+fixing:
+
+1. **P1 (chatgpt-codex-connector)**: `run_pilot.py`'s own
+   `_run_erw_pipeline()` has a second, separate call site for
+   `build_story_relations()` (distinct from
+   `processor.process_segments()`'s own call site, which was already
+   updated in the primary implementation) that still unpacked only 2
+   values. Confirmed as a real regression — this would raise
+   `ValueError: too many values to unpack` on every story reaching the
+   cross-segment relation pass, and the new catch-all exception handler
+   (this same PR's own uncaught-exception fix) would silently record
+   every such story as excluded rather than crashing loudly. Fixed by
+   destructuring all 3 return values and extending
+   `story.extraction_errors` with the `item_errors`, matching
+   `processor.py`'s own pattern exactly. Added a dedicated regression
+   test (`TestRunErwPipelineStoryRelationCallSite`) that exercises this
+   exact call site with 2 segments producing events in different
+   segments, confirming no crash and a correctly-resolved cross-segment
+   relation.
+2. **copilot-pull-request-reviewer**: `_record_extraction_error` appended
+   the whole structured `api_error` dict (including its `raw` field,
+   which can be a large `repr(backend_response)`) into the plain-string
+   `extraction_errors` via an f-string, risking flooding logs/output
+   files; `structured_extraction_errors` entries also carried no
+   indication of which pass produced them. Confirmed valid by reading
+   `llm_extractor._normalize_api_error`'s `"raw": repr(backend_response)`
+   sites. Fixed: the plain-string message now uses only the dict's
+   `"message"` field (falling back to `repr()` only for non-dict
+   errors), and each `structured_extraction_errors` entry is tagged with
+   `"pass": <pass_label>`. Added a direct unit test for both fixes.
+3. **copilot-pull-request-reviewer**: `run_pilot_test.py`'s module
+   docstring still referenced the pre-src-layout path (`lcats/lcats/`).
+   Corrected to `lcats/src/lcats/`.
+
+# Validation
+
+- `pytest tests/analysis_tests/event_role_world_test.py` (from `lcats/`)
+  — 110 passed (up from 108), including the 2 new tests for the
+  structured-error fixes.
+- `pytest experiments/03_cross_segment_relation_pilot/run_pilot_test.py`
+  — 2 passed (up from 1), including the new
+  `TestRunErwPipelineStoryRelationCallSite` regression test proving the
+  P1 fix actually resolves the crash (first run without the fixture
+  correction failed with `AssertionError: 0 != 1` due to a test-authoring
+  mistake — `include_hypotheses=False` means only 4 LLM calls per segment,
+  not 5 — corrected before it passed cleanly).
+- `scripts/test` (from `lcats/`) — full suite, 1493 passed (up from
+  1492).
+- `scripts/lint` (from `lcats/`) plus a direct `black`/`ruff` check on
+  the two `experiments/` files (outside `scripts/lint`'s `src`/`tests`
+  targets) — all clean.
+- `lrh validate` (from `lcats/`) — 0 errors.
+- All 3 review threads resolved via `gh api graphql resolveReviewThread`
+  after the fixes landed.
+
+# Follow-up
+
+None beyond what the primary execution record already lists.

--- a/lcats/project/executions/WI-EVENT-0032/2026_07_29_04_47_46_WI_EVENT_0032.md
+++ b/lcats/project/executions/WI-EVENT-0032/2026_07_29_04_47_46_WI_EVENT_0032.md
@@ -1,0 +1,109 @@
+---
+execution_id: 2026_07_29_04_47_46_WI_EVENT_0032
+prompt_id: PROMPT(WI-EVENT-0032:WI_EVENT_0032)[2026-07-29T03:12:05-04:00]
+work_item: WI-EVENT-0032
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/187
+commit: 4b0f4a73
+agent: claude_app
+instruction_source: lcats/project/work_items/proposed/WI-EVENT-0032.md
+session_transcript: pending
+created_at: 2026-07-29T04:47:46-04:00
+---
+
+# Summary
+
+Implement WI-EVENT-0032 (Categories A/B/D of the 2026-07-27 ERW pipeline
+structured-output reliability audit): harden all seven ERW-adjacent tool
+schemas to Anthropic strict mode at the source, add defensive array-item
+checks with explicit error surfacing at all twelve identified malformed-
+item sites, and fix processor.py's hardcoded model and discarded
+structured error info — plus the audit's Category B update finding
+(run_pilot.py's uncaught-exception data loss).
+
+# Result
+
+- Discovered mid-implementation that the concurrent packaging thread's
+  src-layout move (PR #175) had already landed on `main`, moving the
+  package from `lcats/lcats/` to `lcats/src/lcats/`. Fixed WI-EVENT-0032's
+  own stale path references (and, incidentally, WI-EVENT-0033's and the
+  workstream's) before implementing. Also added a `## Required Changes`
+  section WI-EVENT-0032 was missing, which `lrh work-items readiness` had
+  flagged as blocking prompt-readiness.
+- **Category A**: new `lcats/lcats/llm/tool_schema.py` (`close_schema_objects`/
+  `strict_tool_schema`, ported verbatim from `run_pilot.py`'s proven
+  runtime override). All seven schemas (`ENTITY_TOOL_SCHEMA`,
+  `EVENT_TOOL_SCHEMA`, `RELATION_TOOL_SCHEMA`, `DISCOURSE_TOOL_SCHEMA`,
+  `STORY_RELATION_TOOL_SCHEMA`, `HYPOTHESIS_TOOL_SCHEMA`,
+  `ASSESSMENT_TOOL`) now wrap themselves with `strict_tool_schema(...)` at
+  definition time — confirmed via direct import that all seven report
+  `strict: True`/`additionalProperties: False`. `run_pilot.py`'s
+  `_strict_tool_schema()`/`_close_schema_objects()` and the
+  `--backend anthropic` gate on `_build_erw_extractors` removed as
+  redundant; the function's signature dropped its now-unused
+  `backend_name` parameter (verified only one call site existed).
+- **Category B**: added `schema.describe_malformed_item(path, item)` (a
+  shared helper, truncates long reprs to 200 chars — the actual failure
+  mode that crashed live twice was a multi-KB truncated-JSON string). All
+  six `build_*()` functions (`build_entities`, `build_events_and_anchors`,
+  `build_relations`, `build_discourse`, `build_hypotheses`,
+  `build_story_relations`) now check `isinstance(item, dict)` at each of
+  the twelve identified sites, skip and record a malformed item instead of
+  crashing, and return an additional `item_errors: List[str]`.
+  `build_hypotheses` changed from a bare-list return to a 2-tuple.
+  Updated all 6 `processor.py` call sites to extend `extraction_errors`
+  with each pass's `item_errors`, and updated ~24 existing test call sites
+  in `event_role_world_test.py` to destructure the widened tuples.
+- **Category D**: `process_segments()` gained a `model: Optional[str] =
+  None` parameter, applied to all 6 extractors it builds (entity, event,
+  relation, discourse, hypothesis, story_relation) when not None,
+  preserving existing behavior when omitted. Added a new, additive
+  `structured_extraction_errors: List[Dict[str, Any]]` field to both
+  `SegmentWorldAnnotation` and `StoryWorldAnnotation` (schema.py),
+  populated via a new `_record_extraction_error()` helper in
+  `processor.py` alongside the existing plain-string
+  `extraction_errors` (left completely untouched, so
+  `run_pilot.py:673`'s `"; ".join(extraction_errors)` and all existing
+  callers/tests are unaffected).
+- **Uncaught-exception fix**: `run_pilot.py`'s `main()` per-story loop
+  gained a second `except Exception` branch (after the existing
+  `FatalPilotError` one) that records a minimal excluded row
+  (`path`/`story_id`/`genre`/`excluded`/`exclude_reason`) and continues to
+  the next story, instead of propagating out of `main()` and skipping the
+  write block entirely.
+
+# Validation
+
+- `pytest tests/analysis_tests/event_role_world_test.py` (from `lcats/`)
+  — 108 passed, including 7 new malformed-item tests (one per Category B
+  site grouping) and 2 new `process_segments(model=...)`/`model=None`
+  tests, plus an existing-behavior assertion that `structured_extraction_errors`
+  is populated alongside `extraction_errors` on a failed pass.
+- `scripts/test` (from `lcats/`) — full suite, 1492 passed (up from 1483
+  pre-change).
+- New `experiments/03_cross_segment_relation_pilot/run_pilot_test.py`
+  (this script has zero prior test coverage and isn't part of
+  `scripts/test`'s `tests/`-only sweep) — verifies an unexpected per-story
+  exception preserves other stories' already-written results; run
+  explicitly via `python -m pytest experiments/03_cross_segment_relation_pilot/run_pilot_test.py`.
+- `scripts/lint` (from `lcats/`) — ruff and black clean on all touched
+  files.
+- `lrh validate` (from `lcats/`) — 0 errors, 47 warnings (unchanged from
+  pre-existing baseline).
+- Manual end-to-end smoke test:
+  `python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run --data-dir corpora --sample-size 1`
+  completes cleanly across all 4 genres with no regressions.
+
+# Follow-up
+
+- WI-EVENT-0033 (Category C) is still separate, unimplemented work.
+- WI-EVENT-0030's real pilot run still needs a fresh attempt with this
+  fix (plus PR #170's max_tokens fix) in place — still the next concrete
+  step for that item, now with three of the four reliability fixes the
+  audit identified in place (only Category C/E remain).
+- No decision has been made yet on whether the malformed-item detection
+  added here will actually reduce real-run crashes, since the audit's own
+  postmortem could not fully resolve why strict mode alone didn't prevent
+  the third live crash — this fix is the correct response regardless, but
+  worth watching on the next real run.

--- a/lcats/project/work_items/proposed/WI-EVENT-0032.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0032.md
@@ -43,22 +43,22 @@ required_evidence:
   - lrh_validate
   - test_output
 artifacts_expected:
-  - lcats/lcats/analysis/event_role_world/entity_extractor.py
-  - lcats/lcats/analysis/event_role_world/event_extractor.py
-  - lcats/lcats/analysis/event_role_world/relation_extractor.py
-  - lcats/lcats/analysis/event_role_world/discourse_extractor.py
-  - lcats/lcats/analysis/event_role_world/story_relation_extractor.py
-  - lcats/lcats/analysis/event_role_world/hypothesis_extractor.py
-  - lcats/lcats/analysis/event_role_world/processor.py
-  - lcats/lcats/analysis/event_role_world/schema.py
-  - lcats/lcats/analysis/corpus/assess.py
+  - lcats/src/lcats/analysis/event_role_world/entity_extractor.py
+  - lcats/src/lcats/analysis/event_role_world/event_extractor.py
+  - lcats/src/lcats/analysis/event_role_world/relation_extractor.py
+  - lcats/src/lcats/analysis/event_role_world/discourse_extractor.py
+  - lcats/src/lcats/analysis/event_role_world/story_relation_extractor.py
+  - lcats/src/lcats/analysis/event_role_world/hypothesis_extractor.py
+  - lcats/src/lcats/analysis/event_role_world/processor.py
+  - lcats/src/lcats/analysis/event_role_world/schema.py
+  - lcats/src/lcats/analysis/corpus/assess.py
   - experiments/03_cross_segment_relation_pilot/run_pilot.py
 ---
 
 ## Summary
 
 Fix, at the source, the three related reliability gaps the 2026-07-27 ERW
-pipeline audit found inside `lcats/lcats/analysis/event_role_world/` and its
+pipeline audit found inside `lcats/src/lcats/analysis/event_role_world/` and its
 `processor.py`: none of the module's tool schemas set Anthropic's
 `strict: true`/`additionalProperties: false`; all six extractors share an
 identical unguarded-array-item pattern that has already caused two real
@@ -112,59 +112,83 @@ it.
 
 ## Scope
 
-- **Category A (strict-mode schemas):** add `strict: true` and
-  `additionalProperties: false` (at every object level, including nested
-  array-item objects) to all seven schemas: the six `event_role_world/`
-  extractors' own `*_TOOL_SCHEMA` module constants, plus
-  `corpus/assess.py`'s `ASSESSMENT_TOOL`. Once these are strict at the
-  source, remove `run_pilot.py`'s `_strict_tool_schema()`/
-  `_close_schema_objects()` runtime override and its `--backend anthropic`
-  gate — it becomes dead code once the schemas it patches are already
-  strict.
-- **Category B (defensive array-item checks):** at each of the twelve
-  identified sites, detect a non-dict array item, preserve the raw
-  offending item (e.g. write it to a diagnosis log or attach it to the
-  returned extraction error) rather than discarding it silently, and
-  surface an explicit extraction error for the affected segment/story. A
-  guard that merely skips the malformed item and continues is **not**
-  sufficient — per the audit's own review correction, that would make a
-  segment with a dropped entity/event/relation look like a *successful*
-  partial extraction instead of a failed one, biasing density figures
-  exactly the way WI-EVENT-0030's acceptance criteria warn against.
-- **Category D (`processor.py`):** add a `model` parameter to
-  `process_segments()` that overrides each extractor's factory-hardcoded
-  default (matching the override `run_pilot.py` already applies by
-  building extractors itself and calling `process_segment()` directly);
-  and change each pass's error handling to preserve the structured
-  `api_error` dict instead of stringifying it, so a caller can read
-  `category`/`can_retry`/`should_abort_batch` directly instead of
-  re-deriving fatality via substring matching. This requires a schema
-  change: `SegmentWorldAnnotation`/`StoryWorldAnnotation`'s
-  `extraction_errors` field is currently `List[str]`
-  (`schema.py:426,767`) and cannot hold a structured dict as-is. Decide
-  and implement one of: (a) widen `extraction_errors`' element type to
-  accept either a string or a structured-error dict, or (b) add a
-  separate, additive field (e.g. `structured_extraction_errors`) alongside
-  the existing string list, left untouched for backward compatibility.
-  Whichever is chosen, update `run_pilot.py:673`'s
-  `"; ".join(extraction_errors)` call (which assumes a list of strings)
-  to match the new representation, and confirm no other caller of
-  `extraction_errors` breaks.
-- **Uncaught-exception data loss (audit's Category B update):**
-  `run_pilot.py`'s `main()` per-story loop only catches `FatalPilotError`
-  around `run_story()` — any other exception propagates uncaught, and the
-  code that writes `pilot_stories.jsonl`/`pilot_usage.jsonl`/
-  `pilot_summary.json` never runs, discarding every already-completed,
-  already-paid-for story in the run, not just the one that failed. Wrap
-  the per-story loop to catch any exception, log/record it the same way a
-  non-fatal per-story failure is handled today, and still write out
-  whatever results completed before the failure.
-- Add test coverage for both the strict-schema change and at least one
-  malformed-array-item scenario per extractor module (six extractors, one
-  scenario each at minimum), plus a `process_segments(model=...)` override
-  test, a structured-error-preserved test for `processor.py`, and a test
-  confirming an unexpected per-story exception still yields written
-  partial results.
+- Harden all seven ERW-adjacent tool schemas to Anthropic's `strict` mode
+  at the source (Category A).
+- Add defensive array-item checks with explicit extraction-error surfacing
+  at every identified malformed-tool-result site across the six
+  `event_role_world/` extractors (Category B).
+- Fix `processor.py`'s hardcoded model and its discarding of structured
+  API error information (Category D).
+- Fix the audit's Category B update finding: `run_pilot.py`'s uncaught
+  per-story exception handling discards an entire run's already-paid-for
+  results.
+- Add test coverage for every change above.
+
+## Required Changes
+
+1. **Category A (strict-mode schemas):** add `strict: true` and
+   `additionalProperties: false` (at every object level, including nested
+   array-item objects) to all seven schemas: `entity_extractor.py`'s
+   `ENTITY_TOOL_SCHEMA`, `event_extractor.py`'s `EVENT_TOOL_SCHEMA`,
+   `relation_extractor.py`'s `RELATION_TOOL_SCHEMA`,
+   `discourse_extractor.py`'s `DISCOURSE_TOOL_SCHEMA`,
+   `story_relation_extractor.py`'s `STORY_RELATION_TOOL_SCHEMA`,
+   `hypothesis_extractor.py`'s `HYPOTHESIS_TOOL_SCHEMA`, and
+   `corpus/assess.py`'s `ASSESSMENT_TOOL`.
+2. Once those seven schemas are strict at the source, remove
+   `run_pilot.py`'s `_strict_tool_schema()`/`_close_schema_objects()`
+   runtime override and its `--backend anthropic` gate — it becomes dead
+   code once the schemas it patches are already strict.
+3. **Category B (defensive array-item checks):** at each of the twelve
+   identified sites (`entity_extractor.py:142,144`;
+   `event_extractor.py:185,203,219,225`; `relation_extractor.py:131`;
+   `discourse_extractor.py:196,213,232`; `story_relation_extractor.py:205`;
+   `hypothesis_extractor.py:146`), detect a non-dict array item, preserve
+   the raw offending item (e.g. write it to a diagnosis log or attach it
+   to the returned extraction error) rather than discarding it silently,
+   and surface an explicit extraction error for the affected
+   segment/story. A guard that merely skips the malformed item and
+   continues is **not** sufficient — per the audit's own review
+   correction, that would make a segment with a dropped entity/event/
+   relation look like a *successful* partial extraction instead of a
+   failed one, biasing density figures exactly the way WI-EVENT-0030's
+   acceptance criteria warn against.
+4. **Category D (`processor.py` model override):** add a `model`
+   parameter to `process_segments()` that overrides each extractor's
+   factory-hardcoded default, matching the override `run_pilot.py`
+   already applies by building extractors itself and calling
+   `process_segment()` directly.
+5. **Category D (`processor.py` structured error preservation):** change
+   each pass's error handling to preserve the structured `api_error` dict
+   instead of stringifying it, so a caller can read
+   `category`/`can_retry`/`should_abort_batch` directly instead of
+   re-deriving fatality via substring matching. This requires a schema
+   change: `SegmentWorldAnnotation`/`StoryWorldAnnotation`'s
+   `extraction_errors` field is currently `List[str]`
+   (`schema.py:426,767`) and cannot hold a structured dict as-is. Decide
+   and implement one of: (a) widen `extraction_errors`' element type to
+   accept either a string or a structured-error dict, or (b) add a
+   separate, additive field (e.g. `structured_extraction_errors`)
+   alongside the existing string list, left untouched for backward
+   compatibility. Whichever is chosen, update `run_pilot.py:673`'s
+   `"; ".join(extraction_errors)` call (which assumes a list of strings)
+   to match the new representation, and confirm no other caller of
+   `extraction_errors` breaks.
+6. **Uncaught-exception data loss (audit's Category B update):**
+   `run_pilot.py`'s `main()` per-story loop only catches `FatalPilotError`
+   around `run_story()` — any other exception propagates uncaught, and
+   the code that writes `pilot_stories.jsonl`/`pilot_usage.jsonl`/
+   `pilot_summary.json` never runs, discarding every already-completed,
+   already-paid-for story in the run, not just the one that failed. Wrap
+   the per-story loop to catch any exception, log/record it the same way
+   a non-fatal per-story failure is handled today, and still write out
+   whatever results completed before the failure.
+7. Add test coverage for both the strict-schema change and at least one
+   malformed-array-item scenario per extractor module (six extractors,
+   one scenario each at minimum), plus a `process_segments(model=...)`
+   override test, a structured-error-preserved test for `processor.py`,
+   and a test confirming an unexpected per-story exception still yields
+   written partial results.
 
 ## Non-Goals
 

--- a/lcats/project/work_items/proposed/WI-EVENT-0033.md
+++ b/lcats/project/work_items/proposed/WI-EVENT-0033.md
@@ -40,9 +40,9 @@ required_evidence:
   - lrh_validate
   - test_output
 artifacts_expected:
-  - lcats/lcats/analysis/scene_analysis.py
-  - lcats/lcats/analysis/story_analysis.py
-  - lcats/lcats/analysis/story_processors.py
+  - lcats/src/lcats/analysis/scene_analysis.py
+  - lcats/src/lcats/analysis/story_analysis.py
+  - lcats/src/lcats/analysis/story_processors.py
   - experiments/03_cross_segment_relation_pilot/run_pilot.py
 ---
 

--- a/lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
+++ b/lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
@@ -5,7 +5,7 @@ title: Event-Role-World pipeline structured-output reliability
 status: proposed
 stage: designed
 origin: design_review
-summary: Fix the systemic structured-output reliability gaps found by the 2026-07-27 ERW pipeline audit — missing strict-mode tool schemas, unguarded array-item type assumptions, unconstrained extractors with no tool schema at all, and processor.py's model/error-handling gaps — across two work items split by whether the fix touches lcats/lcats/analysis/event_role_world/ directly.
+summary: Fix the systemic structured-output reliability gaps found by the 2026-07-27 ERW pipeline audit — missing strict-mode tool schemas, unguarded array-item type assumptions, unconstrained extractors with no tool schema at all, and processor.py's model/error-handling gaps — across two work items split by whether the fix touches lcats/src/lcats/analysis/event_role_world/ directly.
 related_focus:
   - FOCUS-WORLDCON-2026
 related_roadmap: []

--- a/lcats/src/lcats/analysis/corpus/assess.py
+++ b/lcats/src/lcats/analysis/corpus/assess.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pathlib
 from dataclasses import asdict, dataclass, field
 
+from lcats.llm import tool_schema as tool_schema_module
+
 VALID_GENRES = ("science fiction", "horror", "western", "romance")
 
 _GENRE_DEFINITIONS = """\
@@ -28,118 +30,125 @@ QUALITY ISSUES: Flag any:
   - Tables of contents, chapter listings, or front matter inside the text
   - Significant formatting artifacts (stray markup, repeated separators, etc.)"""
 
-ASSESSMENT_TOOL = {
-    "name": "record_story_assessment",
-    "description": "Record a structured quality and genre assessment for a story.",
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "verdict": {
-                "type": "string",
-                "enum": ["include", "exclude", "review"],
-                "description": (
-                    "include: wellformed + correct genre + no disqualifying issues. "
-                    "exclude: incomplete story, wrong genre, or serious quality problems. "
-                    "review: borderline — reasonable people could disagree."
-                ),
-            },
-            "exclude_reason": {
-                "type": "string",
-                "description": (
-                    "If verdict is exclude or review, a brief explanation. "
-                    "Omit or leave empty for include."
-                ),
-            },
-            "wellformed": {
-                "type": "boolean",
-                "description": (
-                    "True if the story has a clear beginning and ending and reads "
-                    "as a complete standalone narrative."
-                ),
-            },
-            "detected_genre": {
-                "type": "string",
-                "enum": list(VALID_GENRES) + ["other"],
-                "description": (
-                    "The genre this story most likely belongs to, determined by "
-                    "independent analysis without reference to any claimed genre. "
-                    "Use 'other' if the story does not fit any of the four target genres."
-                ),
-            },
-            "detected_genre_confidence": {
-                "type": "number",
-                "minimum": 0.0,
-                "maximum": 1.0,
-                "description": "Confidence in the detected genre, 0.0 to 1.0.",
-            },
-            "genre_verdict": {
-                "type": "string",
-                "enum": ["confirmed", "disputed", "wrong", "detected"],
-                "description": (
-                    "confirmed: story belongs to the claimed target genre. "
-                    "disputed: story has genre elements but is borderline or mixed. "
-                    "wrong: story does not belong to the claimed genre. "
-                    "detected: no genre was claimed; use this value in detect-only mode."
-                ),
-            },
-            "genre_suggestion": {
-                "type": "string",
-                "description": (
-                    "If genre_verdict is wrong or disputed, any additional nuance "
-                    "about the actual genre beyond the detected_genre enum value "
-                    "(e.g. 'Gothic mystery-horror hybrid'). Omit or leave empty otherwise."
-                ),
-            },
-            "specials_verdict": {
-                "type": "string",
-                "enum": ["author_intentional", "extraction_artifact", "error", "none"],
-                "description": (
-                    "Assessment of any non-ASCII or unusual characters in the text. "
-                    "author_intentional: dialect, verse, period typography, accented names. "
-                    "extraction_artifact: mojibake, garbled encoding, OCR errors. "
-                    "error: clearly corrupted, unreadable passages. "
-                    "none: no unusual characters present."
-                ),
-            },
-            "summary": {
-                "type": "string",
-                "description": "One to two sentence plot summary of the story.",
-            },
-            "issues": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": (
-                                "Issue category: transcriber_note, copyright_notice, "
-                                "toc_remnant, formatting_artifact, incomplete_text, or other."
-                            ),
-                        },
-                        "severity": {
-                            "type": "string",
-                            "enum": ["low", "medium", "high"],
-                        },
-                        "description": {"type": "string"},
-                    },
-                    "required": ["type", "severity", "description"],
+ASSESSMENT_TOOL = tool_schema_module.strict_tool_schema(
+    {
+        "name": "record_story_assessment",
+        "description": "Record a structured quality and genre assessment for a story.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "verdict": {
+                    "type": "string",
+                    "enum": ["include", "exclude", "review"],
+                    "description": (
+                        "include: wellformed + correct genre + no disqualifying issues. "
+                        "exclude: incomplete story, wrong genre, or serious quality problems. "
+                        "review: borderline — reasonable people could disagree."
+                    ),
                 },
-                "description": "Quality issues found in the story text.",
+                "exclude_reason": {
+                    "type": "string",
+                    "description": (
+                        "If verdict is exclude or review, a brief explanation. "
+                        "Omit or leave empty for include."
+                    ),
+                },
+                "wellformed": {
+                    "type": "boolean",
+                    "description": (
+                        "True if the story has a clear beginning and ending and reads "
+                        "as a complete standalone narrative."
+                    ),
+                },
+                "detected_genre": {
+                    "type": "string",
+                    "enum": list(VALID_GENRES) + ["other"],
+                    "description": (
+                        "The genre this story most likely belongs to, determined by "
+                        "independent analysis without reference to any claimed genre. "
+                        "Use 'other' if the story does not fit any of the four target genres."
+                    ),
+                },
+                "detected_genre_confidence": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                    "description": "Confidence in the detected genre, 0.0 to 1.0.",
+                },
+                "genre_verdict": {
+                    "type": "string",
+                    "enum": ["confirmed", "disputed", "wrong", "detected"],
+                    "description": (
+                        "confirmed: story belongs to the claimed target genre. "
+                        "disputed: story has genre elements but is borderline or mixed. "
+                        "wrong: story does not belong to the claimed genre. "
+                        "detected: no genre was claimed; use this value in detect-only mode."
+                    ),
+                },
+                "genre_suggestion": {
+                    "type": "string",
+                    "description": (
+                        "If genre_verdict is wrong or disputed, any additional nuance "
+                        "about the actual genre beyond the detected_genre enum value "
+                        "(e.g. 'Gothic mystery-horror hybrid'). Omit or leave empty otherwise."
+                    ),
+                },
+                "specials_verdict": {
+                    "type": "string",
+                    "enum": [
+                        "author_intentional",
+                        "extraction_artifact",
+                        "error",
+                        "none",
+                    ],
+                    "description": (
+                        "Assessment of any non-ASCII or unusual characters in the text. "
+                        "author_intentional: dialect, verse, period typography, accented names. "
+                        "extraction_artifact: mojibake, garbled encoding, OCR errors. "
+                        "error: clearly corrupted, unreadable passages. "
+                        "none: no unusual characters present."
+                    ),
+                },
+                "summary": {
+                    "type": "string",
+                    "description": "One to two sentence plot summary of the story.",
+                },
+                "issues": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": (
+                                    "Issue category: transcriber_note, copyright_notice, "
+                                    "toc_remnant, formatting_artifact, incomplete_text, or other."
+                                ),
+                            },
+                            "severity": {
+                                "type": "string",
+                                "enum": ["low", "medium", "high"],
+                            },
+                            "description": {"type": "string"},
+                        },
+                        "required": ["type", "severity", "description"],
+                    },
+                    "description": "Quality issues found in the story text.",
+                },
             },
+            "required": [
+                "verdict",
+                "wellformed",
+                "detected_genre",
+                "detected_genre_confidence",
+                "genre_verdict",
+                "specials_verdict",
+                "summary",
+                "issues",
+            ],
         },
-        "required": [
-            "verdict",
-            "wellformed",
-            "detected_genre",
-            "detected_genre_confidence",
-            "genre_verdict",
-            "specials_verdict",
-            "summary",
-            "issues",
-        ],
-    },
-}
+    }
+)
 
 # Detect mode: no claimed genre; model identifies genre independently.
 DETECT_SYSTEM_PROMPT = f"""\

--- a/lcats/src/lcats/analysis/event_role_world/discourse_extractor.py
+++ b/lcats/src/lcats/analysis/event_role_world/discourse_extractor.py
@@ -13,113 +13,117 @@ from typing import Any, Dict, List, Tuple
 
 from lcats.analysis import llm_extractor
 from lcats.analysis.event_role_world import schema
+from lcats.llm import tool_schema as tool_schema_module
 
-DISCOURSE_TOOL_SCHEMA: Dict[str, Any] = {
-    "name": "extract_discourse",
-    "description": (
-        "Extract speech acts, explanatory passages, and SF world-model "
-        "tags from a story segment."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "speech_acts": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "speech_act_id": {"type": "string"},
-                        "act_type": {
-                            "type": "string",
-                            "description": (
-                                "e.g. assertion, question, command, promise, " "warning"
-                            ),
+DISCOURSE_TOOL_SCHEMA: Dict[str, Any] = tool_schema_module.strict_tool_schema(
+    {
+        "name": "extract_discourse",
+        "description": (
+            "Extract speech acts, explanatory passages, and SF world-model "
+            "tags from a story segment."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "speech_acts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "speech_act_id": {"type": "string"},
+                            "act_type": {
+                                "type": "string",
+                                "description": (
+                                    "e.g. assertion, question, command, promise, "
+                                    "warning"
+                                ),
+                            },
+                            "quote": {"type": "string"},
+                            "speaker_entity_id": {"type": "string"},
+                            "addressee_entity_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "linked_event_id": {"type": "string"},
+                            "confidence": {"type": "number"},
                         },
-                        "quote": {"type": "string"},
-                        "speaker_entity_id": {"type": "string"},
-                        "addressee_entity_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "linked_event_id": {"type": "string"},
-                        "confidence": {"type": "number"},
+                        "required": ["speech_act_id", "act_type", "quote"],
                     },
-                    "required": ["speech_act_id", "act_type", "quote"],
+                },
+                "explanations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "explanation_id": {"type": "string"},
+                            "topic": {"type": "string"},
+                            "mechanism_or_rationale_type": {
+                                "type": "string",
+                                "description": (
+                                    "e.g. scientific_mechanism, technical_operation, "
+                                    "personal_rationale, historical_cause"
+                                ),
+                            },
+                            "quote": {"type": "string"},
+                            "linked_entity_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "linked_event_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "confidence": {"type": "number"},
+                        },
+                        "required": [
+                            "explanation_id",
+                            "topic",
+                            "mechanism_or_rationale_type",
+                            "quote",
+                        ],
+                    },
+                },
+                "sf_tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "tag_id": {"type": "string"},
+                            "tag": {
+                                "type": "string",
+                                "description": (
+                                    "Controlled tag, e.g. anomaly_or_novum, "
+                                    "ontological_rule, technology_as_agent, "
+                                    "nonhuman_actant"
+                                ),
+                            },
+                            "quote": {"type": "string"},
+                            "linked_entity_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "linked_event_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "status": {
+                                "type": "string",
+                                "enum": ["extractive", "hypothesis"],
+                                "description": (
+                                    "extractive if the text states the tag "
+                                    "explicitly, hypothesis if inferred"
+                                ),
+                            },
+                            "confidence": {"type": "number"},
+                        },
+                        "required": ["tag_id", "tag", "quote"],
+                    },
                 },
             },
-            "explanations": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "explanation_id": {"type": "string"},
-                        "topic": {"type": "string"},
-                        "mechanism_or_rationale_type": {
-                            "type": "string",
-                            "description": (
-                                "e.g. scientific_mechanism, technical_operation, "
-                                "personal_rationale, historical_cause"
-                            ),
-                        },
-                        "quote": {"type": "string"},
-                        "linked_entity_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "linked_event_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "confidence": {"type": "number"},
-                    },
-                    "required": [
-                        "explanation_id",
-                        "topic",
-                        "mechanism_or_rationale_type",
-                        "quote",
-                    ],
-                },
-            },
-            "sf_tags": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "tag_id": {"type": "string"},
-                        "tag": {
-                            "type": "string",
-                            "description": (
-                                "Controlled tag, e.g. anomaly_or_novum, "
-                                "ontological_rule, technology_as_agent, "
-                                "nonhuman_actant"
-                            ),
-                        },
-                        "quote": {"type": "string"},
-                        "linked_entity_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "linked_event_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "status": {
-                            "type": "string",
-                            "enum": ["extractive", "hypothesis"],
-                            "description": (
-                                "extractive if the text states the tag "
-                                "explicitly, hypothesis if inferred"
-                            ),
-                        },
-                        "confidence": {"type": "number"},
-                    },
-                    "required": ["tag_id", "tag", "quote"],
-                },
-            },
+            "required": [],
         },
-        "required": [],
-    },
-}
+    }
+)
 
 DISCOURSE_SYSTEM_PROMPT = """You are extracting discourse-level features from
 a segment of a story for structured narrative analysis: speech acts
@@ -169,6 +173,7 @@ def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
     List[schema.SpeechAct],
     List[schema.ExplanationDiscourse],
     List[schema.SFWorldModelTag],
+    List[str],
 ]:
     """Convert a raw extract_discourse tool result into schema objects.
 
@@ -177,23 +182,31 @@ def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
         segment_text: The segment text quotes are resolved against.
 
     Returns:
-        (speech_acts, explanations, sf_tags) — any item whose quote cannot
-        be located in `segment_text` is dropped (not fabricated with a
-        guessed span). Each layer gets its own EvidenceCursor rather than
-        sharing one: a single passage can legitimately be claimed by more
-        than one layer at once (e.g. the same quoted line is both a speech
-        act and an SF-tagged phrase), and a shared cursor would let the
-        first layer's claim consume the only occurrence, silently starving
-        a later layer's otherwise-valid claim on that same span. Within one
-        layer, repeated identical quotes still resolve to successive
-        occurrences via that layer's own cursor.
+        (speech_acts, explanations, sf_tags, item_errors) — any item whose
+        quote cannot be located in `segment_text` is dropped (not
+        fabricated with a guessed span). Each layer gets its own
+        EvidenceCursor rather than sharing one: a single passage can
+        legitimately be claimed by more than one layer at once (e.g. the
+        same quoted line is both a speech act and an SF-tagged phrase),
+        and a shared cursor would let the first layer's claim consume the
+        only occurrence, silently starving a later layer's otherwise-valid
+        claim on that same span. Within one layer, repeated identical
+        quotes still resolve to successive occurrences via that layer's
+        own cursor. item_errors describes any "speech_acts"/
+        "explanations"/"sf_tags" array item that was not a dict - skipped
+        rather than crashing, but surfaced explicitly (see
+        schema.describe_malformed_item).
     """
     speech_act_cursor = schema.EvidenceCursor()
     explanation_cursor = schema.EvidenceCursor()
     sf_tag_cursor = schema.EvidenceCursor()
+    item_errors: List[str] = []
 
     speech_acts: List[schema.SpeechAct] = []
-    for raw in tool_result.get("speech_acts") or []:
+    for i, raw in enumerate(tool_result.get("speech_acts") or []):
+        if not isinstance(raw, dict):
+            item_errors.append(schema.describe_malformed_item(f"speech_acts[{i}]", raw))
+            continue
         evidence = speech_act_cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
@@ -210,7 +223,12 @@ def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
         )
 
     explanations: List[schema.ExplanationDiscourse] = []
-    for raw in tool_result.get("explanations") or []:
+    for i, raw in enumerate(tool_result.get("explanations") or []):
+        if not isinstance(raw, dict):
+            item_errors.append(
+                schema.describe_malformed_item(f"explanations[{i}]", raw)
+            )
+            continue
         evidence = explanation_cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
@@ -229,7 +247,10 @@ def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
         )
 
     sf_tags: List[schema.SFWorldModelTag] = []
-    for raw in tool_result.get("sf_tags") or []:
+    for i, raw in enumerate(tool_result.get("sf_tags") or []):
+        if not isinstance(raw, dict):
+            item_errors.append(schema.describe_malformed_item(f"sf_tags[{i}]", raw))
+            continue
         evidence = sf_tag_cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
@@ -245,4 +266,4 @@ def build_discourse(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
             )
         )
 
-    return speech_acts, explanations, sf_tags
+    return speech_acts, explanations, sf_tags, item_errors

--- a/lcats/src/lcats/analysis/event_role_world/entity_extractor.py
+++ b/lcats/src/lcats/analysis/event_role_world/entity_extractor.py
@@ -11,74 +11,77 @@ from typing import Any, Dict, List, Tuple
 
 from lcats.analysis import llm_extractor
 from lcats.analysis.event_role_world import schema
+from lcats.llm import tool_schema as tool_schema_module
 
-ENTITY_TOOL_SCHEMA: Dict[str, Any] = {
-    "name": "extract_entities",
-    "description": (
-        "Extract salient entities, participants, and aliases from a story "
-        "segment, with actant roles and quoted evidence for each mention."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "entities": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "entity_id": {"type": "string"},
-                        "canonical_name": {"type": "string"},
-                        "entity_type": {
-                            "type": "string",
-                            "description": (
-                                "e.g. human, nonhuman_animal, alien, "
-                                "machine_or_artifact, institution, "
-                                "environment, abstract_force"
-                            ),
-                        },
-                        "aliases": {"type": "array", "items": {"type": "string"}},
-                        "actant_roles": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": (
-                                "e.g. protagonist, opponent, helper, "
-                                "instrument, victim, observer"
-                            ),
-                        },
-                        "confidence": {"type": "number"},
-                        "mentions": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "mention_id": {"type": "string"},
-                                    "text": {"type": "string"},
-                                    "quote": {
-                                        "type": "string",
-                                        "description": (
-                                            "Exact substring of the segment "
-                                            "text this mention refers to."
-                                        ),
+ENTITY_TOOL_SCHEMA: Dict[str, Any] = tool_schema_module.strict_tool_schema(
+    {
+        "name": "extract_entities",
+        "description": (
+            "Extract salient entities, participants, and aliases from a story "
+            "segment, with actant roles and quoted evidence for each mention."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "entities": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "entity_id": {"type": "string"},
+                            "canonical_name": {"type": "string"},
+                            "entity_type": {
+                                "type": "string",
+                                "description": (
+                                    "e.g. human, nonhuman_animal, alien, "
+                                    "machine_or_artifact, institution, "
+                                    "environment, abstract_force"
+                                ),
+                            },
+                            "aliases": {"type": "array", "items": {"type": "string"}},
+                            "actant_roles": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": (
+                                    "e.g. protagonist, opponent, helper, "
+                                    "instrument, victim, observer"
+                                ),
+                            },
+                            "confidence": {"type": "number"},
+                            "mentions": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "mention_id": {"type": "string"},
+                                        "text": {"type": "string"},
+                                        "quote": {
+                                            "type": "string",
+                                            "description": (
+                                                "Exact substring of the segment "
+                                                "text this mention refers to."
+                                            ),
+                                        },
+                                        "mention_form": {"type": "string"},
+                                        "grammatical_role": {"type": "string"},
                                     },
-                                    "mention_form": {"type": "string"},
-                                    "grammatical_role": {"type": "string"},
+                                    "required": ["mention_id", "text", "quote"],
                                 },
-                                "required": ["mention_id", "text", "quote"],
                             },
                         },
+                        "required": [
+                            "entity_id",
+                            "canonical_name",
+                            "entity_type",
+                            "mentions",
+                        ],
                     },
-                    "required": [
-                        "entity_id",
-                        "canonical_name",
-                        "entity_type",
-                        "mentions",
-                    ],
-                },
-            }
+                }
+            },
+            "required": ["entities"],
         },
-        "required": ["entities"],
-    },
-}
+    }
+)
 
 ENTITY_SYSTEM_PROMPT = """You are extracting entities and participants from a
 segment of a story for structured narrative analysis. Identify every salient
@@ -117,7 +120,7 @@ def make_entity_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
 
 def build_entities(
     tool_result: Dict[str, Any], segment_text: str
-) -> Tuple[List[schema.Entity], List[schema.EntityMention]]:
+) -> Tuple[List[schema.Entity], List[schema.EntityMention], List[str]]:
     """Convert a raw extract_entities tool result into schema objects.
 
     Args:
@@ -126,22 +129,38 @@ def build_entities(
         segment_text: The segment text mention quotes are resolved against.
 
     Returns:
-        (entities, mentions) — mentions whose quote cannot be located in
-        `segment_text` are dropped (not fabricated with a guessed span).
-        An entity whose every mention was dropped this way is itself
-        dropped: an entity with zero grounded mentions is ungrounded and
-        would otherwise inflate entity-rate metrics for output the
-        evidence check already rejected. Repeated identical quotes within
-        one entity's mentions resolve to successive occurrences via a
-        per-segment EvidenceCursor, not all onto the first match.
+        (entities, mentions, item_errors) — mentions whose quote cannot be
+        located in `segment_text` are dropped (not fabricated with a
+        guessed span). An entity whose every mention was dropped this way
+        is itself dropped: an entity with zero grounded mentions is
+        ungrounded and would otherwise inflate entity-rate metrics for
+        output the evidence check already rejected. Repeated identical
+        quotes within one entity's mentions resolve to successive
+        occurrences via a per-segment EvidenceCursor, not all onto the
+        first match. item_errors describes any "entities"/"mentions"
+        array item that was not a dict - skipped rather than crashing,
+        but surfaced explicitly (see schema.describe_malformed_item).
     """
     entities: List[schema.Entity] = []
     mentions: List[schema.EntityMention] = []
+    item_errors: List[str] = []
     cursor = schema.EvidenceCursor()
 
-    for raw_entity in tool_result.get("entities") or []:
+    for i, raw_entity in enumerate(tool_result.get("entities") or []):
+        if not isinstance(raw_entity, dict):
+            item_errors.append(
+                schema.describe_malformed_item(f"entities[{i}]", raw_entity)
+            )
+            continue
         mention_ids: List[str] = []
-        for raw_mention in raw_entity.get("mentions") or []:
+        for j, raw_mention in enumerate(raw_entity.get("mentions") or []):
+            if not isinstance(raw_mention, dict):
+                item_errors.append(
+                    schema.describe_malformed_item(
+                        f"entities[{i}].mentions[{j}]", raw_mention
+                    )
+                )
+                continue
             evidence = cursor.resolve(raw_mention.get("quote", ""), segment_text)
             if evidence is None:
                 continue
@@ -174,4 +193,4 @@ def build_entities(
             )
         )
 
-    return entities, mentions
+    return entities, mentions, item_errors

--- a/lcats/src/lcats/analysis/event_role_world/event_extractor.py
+++ b/lcats/src/lcats/analysis/event_role_world/event_extractor.py
@@ -12,116 +12,119 @@ from typing import Any, Dict, List, Tuple
 
 from lcats.analysis import llm_extractor
 from lcats.analysis.event_role_world import schema
+from lcats.llm import tool_schema as tool_schema_module
 
-EVENT_TOOL_SCHEMA: Dict[str, Any] = {
-    "name": "extract_events_and_anchors",
-    "description": (
-        "Extract salient events with semantic roles, and the temporal/"
-        "spatial anchors those events occur within, from a story segment."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "temporal_anchors": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "anchor_id": {"type": "string"},
-                        "text": {"type": "string"},
-                        "quote": {"type": "string"},
-                        "normalized": {"type": "string"},
-                        "granularity": {"type": "string"},
-                        "relative_or_absolute": {
-                            "type": "string",
-                            "enum": ["relative", "absolute"],
+EVENT_TOOL_SCHEMA: Dict[str, Any] = tool_schema_module.strict_tool_schema(
+    {
+        "name": "extract_events_and_anchors",
+        "description": (
+            "Extract salient events with semantic roles, and the temporal/"
+            "spatial anchors those events occur within, from a story segment."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "temporal_anchors": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "anchor_id": {"type": "string"},
+                            "text": {"type": "string"},
+                            "quote": {"type": "string"},
+                            "normalized": {"type": "string"},
+                            "granularity": {"type": "string"},
+                            "relative_or_absolute": {
+                                "type": "string",
+                                "enum": ["relative", "absolute"],
+                            },
+                            "scale": {"type": "string"},
+                            "confidence": {"type": "number"},
                         },
-                        "scale": {"type": "string"},
-                        "confidence": {"type": "number"},
+                        "required": ["anchor_id", "text", "quote"],
                     },
-                    "required": ["anchor_id", "text", "quote"],
                 },
-            },
-            "spatial_anchors": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "anchor_id": {"type": "string"},
-                        "text": {"type": "string"},
-                        "quote": {"type": "string"},
-                        "linked_entity_id": {"type": "string"},
-                        "containment_or_scale": {"type": "string"},
-                        "confidence": {"type": "number"},
+                "spatial_anchors": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "anchor_id": {"type": "string"},
+                            "text": {"type": "string"},
+                            "quote": {"type": "string"},
+                            "linked_entity_id": {"type": "string"},
+                            "containment_or_scale": {"type": "string"},
+                            "confidence": {"type": "number"},
+                        },
+                        "required": ["anchor_id", "text", "quote"],
                     },
-                    "required": ["anchor_id", "text", "quote"],
                 },
-            },
-            "events": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "event_id": {"type": "string"},
-                        "predicate": {"type": "string"},
-                        "lemma": {"type": "string"},
-                        "event_type": {"type": "string"},
-                        "quote": {
-                            "type": "string",
-                            "description": (
-                                "Exact substring of the segment text this "
-                                "event's predicate occurs in."
-                            ),
-                        },
-                        "modality": {
-                            "type": "string",
-                            "enum": [
-                                "actual",
-                                "hypothetical",
-                                "negated",
-                                "future",
-                                "counterfactual",
-                            ],
-                        },
-                        "confidence": {"type": "number"},
-                        "temporal_anchor_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "spatial_anchor_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "semantic_roles": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "role": {
-                                        "type": "string",
-                                        "description": (
-                                            "e.g. agent, patient, theme, "
-                                            "experiencer, instrument, "
-                                            "source, goal, location, "
-                                            "cause, result"
-                                        ),
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "event_id": {"type": "string"},
+                            "predicate": {"type": "string"},
+                            "lemma": {"type": "string"},
+                            "event_type": {"type": "string"},
+                            "quote": {
+                                "type": "string",
+                                "description": (
+                                    "Exact substring of the segment text this "
+                                    "event's predicate occurs in."
+                                ),
+                            },
+                            "modality": {
+                                "type": "string",
+                                "enum": [
+                                    "actual",
+                                    "hypothetical",
+                                    "negated",
+                                    "future",
+                                    "counterfactual",
+                                ],
+                            },
+                            "confidence": {"type": "number"},
+                            "temporal_anchor_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "spatial_anchor_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "semantic_roles": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "role": {
+                                            "type": "string",
+                                            "description": (
+                                                "e.g. agent, patient, theme, "
+                                                "experiencer, instrument, "
+                                                "source, goal, location, "
+                                                "cause, result"
+                                            ),
+                                        },
+                                        "filler_entity_id": {"type": "string"},
+                                        "filler_text": {"type": "string"},
+                                        "quote": {"type": "string"},
+                                        "confidence": {"type": "number"},
                                     },
-                                    "filler_entity_id": {"type": "string"},
-                                    "filler_text": {"type": "string"},
-                                    "quote": {"type": "string"},
-                                    "confidence": {"type": "number"},
+                                    "required": ["role", "quote"],
                                 },
-                                "required": ["role", "quote"],
                             },
                         },
+                        "required": ["event_id", "predicate", "event_type", "quote"],
                     },
-                    "required": ["event_id", "predicate", "event_type", "quote"],
                 },
             },
+            "required": ["events"],
         },
-        "required": ["events"],
-    },
-}
+    }
+)
 
 EVENT_SYSTEM_PROMPT = """You are extracting events, semantic roles, and
 temporal/spatial anchors from a segment of a story for structured narrative
@@ -161,9 +164,12 @@ def make_event_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
     )
 
 
-def build_events_and_anchors(
-    tool_result: Dict[str, Any], segment_text: str
-) -> Tuple[List[schema.Event], List[schema.TemporalAnchor], List[schema.SpatialAnchor]]:
+def build_events_and_anchors(tool_result: Dict[str, Any], segment_text: str) -> Tuple[
+    List[schema.Event],
+    List[schema.TemporalAnchor],
+    List[schema.SpatialAnchor],
+    List[str],
+]:
     """Convert a raw extract_events_and_anchors tool result into schema objects.
 
     Args:
@@ -172,17 +178,27 @@ def build_events_and_anchors(
         segment_text: The segment text quotes are resolved against.
 
     Returns:
-        (events, temporal_anchors, spatial_anchors). Events, semantic roles,
-        and anchors whose quote cannot be located in `segment_text` are
-        dropped (not fabricated with a guessed span). Repeated identical
-        quotes across anchors/events/roles resolve to successive
-        occurrences via a per-segment EvidenceCursor shared across all
-        three, not all onto the first match.
+        (events, temporal_anchors, spatial_anchors, item_errors). Events,
+        semantic roles, and anchors whose quote cannot be located in
+        `segment_text` are dropped (not fabricated with a guessed span).
+        Repeated identical quotes across anchors/events/roles resolve to
+        successive occurrences via a per-segment EvidenceCursor shared
+        across all three, not all onto the first match. item_errors
+        describes any "temporal_anchors"/"spatial_anchors"/"events"/
+        "semantic_roles" array item that was not a dict - skipped rather
+        than crashing, but surfaced explicitly (see
+        schema.describe_malformed_item).
     """
     cursor = schema.EvidenceCursor()
+    item_errors: List[str] = []
 
     temporal_anchors: List[schema.TemporalAnchor] = []
-    for raw in tool_result.get("temporal_anchors") or []:
+    for i, raw in enumerate(tool_result.get("temporal_anchors") or []):
+        if not isinstance(raw, dict):
+            item_errors.append(
+                schema.describe_malformed_item(f"temporal_anchors[{i}]", raw)
+            )
+            continue
         evidence = cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
@@ -200,7 +216,12 @@ def build_events_and_anchors(
         )
 
     spatial_anchors: List[schema.SpatialAnchor] = []
-    for raw in tool_result.get("spatial_anchors") or []:
+    for i, raw in enumerate(tool_result.get("spatial_anchors") or []):
+        if not isinstance(raw, dict):
+            item_errors.append(
+                schema.describe_malformed_item(f"spatial_anchors[{i}]", raw)
+            )
+            continue
         evidence = cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
@@ -216,13 +237,25 @@ def build_events_and_anchors(
         )
 
     events: List[schema.Event] = []
-    for raw_event in tool_result.get("events") or []:
+    for i, raw_event in enumerate(tool_result.get("events") or []):
+        if not isinstance(raw_event, dict):
+            item_errors.append(
+                schema.describe_malformed_item(f"events[{i}]", raw_event)
+            )
+            continue
         event_evidence = cursor.resolve(raw_event.get("quote", ""), segment_text)
         if event_evidence is None:
             continue
 
         semantic_roles: List[schema.SemanticRole] = []
-        for raw_role in raw_event.get("semantic_roles") or []:
+        for j, raw_role in enumerate(raw_event.get("semantic_roles") or []):
+            if not isinstance(raw_role, dict):
+                item_errors.append(
+                    schema.describe_malformed_item(
+                        f"events[{i}].semantic_roles[{j}]", raw_role
+                    )
+                )
+                continue
             role_evidence = cursor.resolve(raw_role.get("quote", ""), segment_text)
             if role_evidence is None:
                 continue
@@ -251,4 +284,4 @@ def build_events_and_anchors(
             )
         )
 
-    return events, temporal_anchors, spatial_anchors
+    return events, temporal_anchors, spatial_anchors, item_errors

--- a/lcats/src/lcats/analysis/event_role_world/hypothesis_extractor.py
+++ b/lcats/src/lcats/analysis/event_role_world/hypothesis_extractor.py
@@ -7,79 +7,83 @@ per the governing proposal's Implementation prerequisites section.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from lcats.analysis import llm_extractor
 from lcats.analysis.event_role_world import schema
+from lcats.llm import tool_schema as tool_schema_module
 
-HYPOTHESIS_TOOL_SCHEMA: Dict[str, Any] = {
-    "name": "extract_hypotheses",
-    "description": (
-        "Extract optional belief, uncertainty, perspective, or emotion/"
-        "appraisal annotations from a story segment. These are never "
-        "extractive facts, even when confidently stated."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "hypotheses": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "hypothesis_id": {"type": "string"},
-                        "hypothesis_type": {
-                            "type": "string",
-                            "enum": [
-                                "belief",
-                                "uncertainty",
-                                "perspective",
-                                "emotion_appraisal",
-                            ],
+HYPOTHESIS_TOOL_SCHEMA: Dict[str, Any] = tool_schema_module.strict_tool_schema(
+    {
+        "name": "extract_hypotheses",
+        "description": (
+            "Extract optional belief, uncertainty, perspective, or emotion/"
+            "appraisal annotations from a story segment. These are never "
+            "extractive facts, even when confidently stated."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "hypotheses": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "hypothesis_id": {"type": "string"},
+                            "hypothesis_type": {
+                                "type": "string",
+                                "enum": [
+                                    "belief",
+                                    "uncertainty",
+                                    "perspective",
+                                    "emotion_appraisal",
+                                ],
+                            },
+                            "proposition_or_target": {
+                                "type": "string",
+                                "description": (
+                                    "The claim's content: a proposition (for "
+                                    "belief/uncertainty) or a target (for "
+                                    "perspective/emotion_appraisal)."
+                                ),
+                            },
+                            "quote": {
+                                "type": "string",
+                                "description": (
+                                    "Exact substring of the segment text that "
+                                    "grounds this hypothesis."
+                                ),
+                            },
+                            "subject_entity_id": {
+                                "type": "string",
+                                "description": (
+                                    "Entity who holds the belief/perspective, "
+                                    "if known."
+                                ),
+                            },
+                            "linked_entity_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "linked_event_ids": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "confidence": {"type": "number"},
                         },
-                        "proposition_or_target": {
-                            "type": "string",
-                            "description": (
-                                "The claim's content: a proposition (for "
-                                "belief/uncertainty) or a target (for "
-                                "perspective/emotion_appraisal)."
-                            ),
-                        },
-                        "quote": {
-                            "type": "string",
-                            "description": (
-                                "Exact substring of the segment text that "
-                                "grounds this hypothesis."
-                            ),
-                        },
-                        "subject_entity_id": {
-                            "type": "string",
-                            "description": (
-                                "Entity who holds the belief/perspective, " "if known."
-                            ),
-                        },
-                        "linked_entity_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "linked_event_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "confidence": {"type": "number"},
+                        "required": [
+                            "hypothesis_id",
+                            "hypothesis_type",
+                            "proposition_or_target",
+                            "quote",
+                        ],
                     },
-                    "required": [
-                        "hypothesis_id",
-                        "hypothesis_type",
-                        "proposition_or_target",
-                        "quote",
-                    ],
-                },
-            }
+                }
+            },
+            "required": ["hypotheses"],
         },
-        "required": ["hypotheses"],
-    },
-}
+    }
+)
 
 HYPOTHESIS_SYSTEM_PROMPT = """You are extracting optional interpretive
 hypotheses from a segment of a story for structured narrative analysis:
@@ -126,7 +130,7 @@ def make_hypothesis_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor
 
 def build_hypotheses(
     tool_result: Dict[str, Any], segment_text: str
-) -> List[schema.Hypothesis]:
+) -> Tuple[List[schema.Hypothesis], List[str]]:
     """Convert a raw extract_hypotheses tool result into schema objects.
 
     Args:
@@ -134,16 +138,23 @@ def build_hypotheses(
         segment_text: The segment text quotes are resolved against.
 
     Returns:
-        Hypotheses whose quote cannot be located in `segment_text` are
-        dropped (not fabricated with a guessed span). Repeated identical
-        quotes resolve to successive occurrences via a per-segment
-        EvidenceCursor, private to this pass — not shared with any other
-        stage's cursor.
+        (hypotheses, item_errors) — hypotheses whose quote cannot be
+        located in `segment_text` are dropped (not fabricated with a
+        guessed span). Repeated identical quotes resolve to successive
+        occurrences via a per-segment EvidenceCursor, private to this
+        pass — not shared with any other stage's cursor. item_errors
+        describes any "hypotheses" array item that was not a dict -
+        skipped rather than crashing, but surfaced explicitly (see
+        schema.describe_malformed_item).
     """
     cursor = schema.EvidenceCursor()
 
     hypotheses: List[schema.Hypothesis] = []
-    for raw in tool_result.get("hypotheses") or []:
+    item_errors: List[str] = []
+    for i, raw in enumerate(tool_result.get("hypotheses") or []):
+        if not isinstance(raw, dict):
+            item_errors.append(schema.describe_malformed_item(f"hypotheses[{i}]", raw))
+            continue
         evidence = cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
@@ -160,4 +171,4 @@ def build_hypotheses(
             )
         )
 
-    return hypotheses
+    return hypotheses, item_errors

--- a/lcats/src/lcats/analysis/event_role_world/processor.py
+++ b/lcats/src/lcats/analysis/event_role_world/processor.py
@@ -317,10 +317,25 @@ def _record_extraction_error(
     `error` may be a plain string (e.g. "No tool_result returned by
     backend...") or the classified api_error dict; only the latter is
     structured enough to preserve as-is.
+
+    A dict error's own "raw" field can be large (e.g.
+    llm_extractor._normalize_api_error sets it to repr(backend_response),
+    which can include a full tool_result) - the plain-string
+    extraction_errors entry uses only the dict's "message" field, not the
+    whole dict, so a single failed pass cannot flood extraction_errors/a
+    caller's exclude_reason with megabytes of noise. The full dict
+    (including "raw") is still preserved in structured_extraction_errors
+    for anyone who needs it. Each structured_extraction_errors entry is
+    also tagged with which pass it came from ("pass": pass_label), since
+    multiple passes can each contribute an entry and the dict itself
+    carries no pass identity of its own.
     """
-    extraction_errors.append(f"{pass_label} extraction failed: {error}")
     if isinstance(error, dict):
-        structured_extraction_errors.append(error)
+        message = error.get("message") or repr(error)
+        extraction_errors.append(f"{pass_label} extraction failed: {message}")
+        structured_extraction_errors.append({"pass": pass_label, **error})
+    else:
+        extraction_errors.append(f"{pass_label} extraction failed: {error}")
 
 
 def _extract_with_placeholders(

--- a/lcats/src/lcats/analysis/event_role_world/processor.py
+++ b/lcats/src/lcats/analysis/event_role_world/processor.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import dataclasses
 import time
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from lcats.analysis.event_role_world import (
     discourse_extractor as discourse_extractor_module,
@@ -120,6 +120,7 @@ def process_segment(
     )
 
     extraction_errors: List[str] = []
+    structured_extraction_errors: List[Dict[str, Any]] = []
 
     # Stage 3: entities/participants (LLM-backed).
     t0 = time.monotonic()
@@ -134,10 +135,13 @@ def process_segment(
         # A failed entity pass must not silently read as "zero entities
         # found" — an empty result here is meaningfully different from an
         # extraction that never ran/succeeded.
-        extraction_errors.append(f"entity extraction failed: {entity_error}")
-    entities, mentions = entity_extractor_module.build_entities(
+        _record_extraction_error(
+            extraction_errors, structured_extraction_errors, "entity", entity_error
+        )
+    entities, mentions, entity_item_errors = entity_extractor_module.build_entities(
         entity_result.get("extracted_output") or {}, segment_text
     )
+    extraction_errors.extend(entity_item_errors)
 
     # Stages 4-5: events/semantic-roles + temporal/spatial anchors (LLM-backed).
     # JSONPromptExtractor.extract() only substitutes {story_text}/
@@ -157,12 +161,18 @@ def process_segment(
     )
     event_error = event_result.get("api_error") or event_result.get("extraction_error")
     if event_error:
-        extraction_errors.append(f"event/anchor extraction failed: {event_error}")
-    events, temporal_anchors, spatial_anchors = (
+        _record_extraction_error(
+            extraction_errors,
+            structured_extraction_errors,
+            "event/anchor",
+            event_error,
+        )
+    events, temporal_anchors, spatial_anchors, event_item_errors = (
         event_extractor_module.build_events_and_anchors(
             event_result.get("extracted_output") or {}, segment_text
         )
     )
+    extraction_errors.extend(event_item_errors)
 
     # Stage 6: relations between events (LLM-backed). Same routed-through-
     # extract() pattern as the event/anchor pass, so a transient failure is
@@ -179,10 +189,18 @@ def process_segment(
         "extraction_error"
     )
     if relation_error:
-        extraction_errors.append(f"relation extraction failed: {relation_error}")
-    relations, weakly_inferred_relations = relation_extractor_module.build_relations(
-        relation_result.get("extracted_output") or {}, segment_text
+        _record_extraction_error(
+            extraction_errors,
+            structured_extraction_errors,
+            "relation",
+            relation_error,
+        )
+    relations, weakly_inferred_relations, relation_item_errors = (
+        relation_extractor_module.build_relations(
+            relation_result.get("extracted_output") or {}, segment_text
+        )
     )
+    extraction_errors.extend(relation_item_errors)
 
     # Stage 7: speech acts, explanations, and SF world-model tags (LLM-backed).
     t0 = time.monotonic()
@@ -198,10 +216,18 @@ def process_segment(
         "extraction_error"
     )
     if discourse_error:
-        extraction_errors.append(f"discourse extraction failed: {discourse_error}")
-    speech_acts, explanations, sf_tags = discourse_extractor_module.build_discourse(
-        discourse_result.get("extracted_output") or {}, segment_text
+        _record_extraction_error(
+            extraction_errors,
+            structured_extraction_errors,
+            "discourse",
+            discourse_error,
+        )
+    speech_acts, explanations, sf_tags, discourse_item_errors = (
+        discourse_extractor_module.build_discourse(
+            discourse_result.get("extracted_output") or {}, segment_text
+        )
     )
+    extraction_errors.extend(discourse_item_errors)
 
     # Stage 8 (optional): belief, uncertainty, perspective, and emotion/
     # appraisal hypotheses (LLM-backed). Same routed-through-extract()
@@ -224,12 +250,18 @@ def process_segment(
             "extraction_error"
         )
         if hypothesis_error:
-            extraction_errors.append(
-                f"hypothesis extraction failed: {hypothesis_error}"
+            _record_extraction_error(
+                extraction_errors,
+                structured_extraction_errors,
+                "hypothesis",
+                hypothesis_error,
             )
-        hypotheses = hypothesis_extractor_module.build_hypotheses(
-            hypothesis_result.get("extracted_output") or {}, segment_text
+        hypotheses, hypothesis_item_errors = (
+            hypothesis_extractor_module.build_hypotheses(
+                hypothesis_result.get("extracted_output") or {}, segment_text
+            )
         )
+        extraction_errors.extend(hypothesis_item_errors)
 
     annotation = schema.SegmentWorldAnnotation(
         segment_id=segment_id,
@@ -246,6 +278,7 @@ def process_segment(
         sf_tags=sf_tags,
         hypotheses=hypotheses,
         extraction_errors=extraction_errors,
+        structured_extraction_errors=structured_extraction_errors,
     )
     annotation.validation_errors = schema.validate_segment_annotation(
         annotation, segment_text
@@ -268,6 +301,26 @@ def _pass_usage_from_extraction(
         output_tokens=usage.get("output_tokens", 0),
         elapsed_seconds=time.monotonic() - t0,
     )
+
+
+def _record_extraction_error(
+    extraction_errors: List[str],
+    structured_extraction_errors: List[Dict[str, Any]],
+    pass_label: str,
+    error: Any,
+) -> None:
+    """Append a pass failure to both extraction_errors and, when the error
+    is a structured api_error dict (from llm_extractor._classify_api_error),
+    also to structured_extraction_errors - see
+    SegmentWorldAnnotation.structured_extraction_errors (WI-EVENT-0032).
+
+    `error` may be a plain string (e.g. "No tool_result returned by
+    backend...") or the classified api_error dict; only the latter is
+    structured enough to preserve as-is.
+    """
+    extraction_errors.append(f"{pass_label} extraction failed: {error}")
+    if isinstance(error, dict):
+        structured_extraction_errors.append(error)
 
 
 def _extract_with_placeholders(
@@ -318,6 +371,7 @@ def process_segments(
     *,
     nlp_backend_name: str,
     llm_backend: Any,
+    model: Optional[str] = None,
     story_id: Any = None,
     include_hypotheses: bool = True,
     include_cross_segment_relations: bool = True,
@@ -333,6 +387,15 @@ def process_segments(
         nlp_backend_name: "stanza" or "spacy".
         llm_backend: LLMBackend for the entity/event/relation/discourse/
             hypothesis/story-relation extraction passes.
+        model: Optional model override applied to every extractor built
+            here, replacing each factory's own hardcoded default (e.g.
+            "gpt-4o"). Defaults to None, preserving each factory's own
+            default for existing callers. Any non-OpenAI llm_backend
+            combined with the default None previously sent an invalid
+            model ID on every request (WI-EVENT-0032) -
+            experiments/03_cross_segment_relation_pilot/run_pilot.py
+            worked around this by building extractors itself; this
+            parameter is the source-level fix.
         story_id: Identifier carried onto the reconciled StoryWorldAnnotation.
             Defaults to None if the caller has no natural story ID.
         include_hypotheses: Whether to run the optional stage-8 hypothesis
@@ -381,6 +444,18 @@ def process_segments(
         if include_cross_segment_relations
         else None
     )
+
+    if model is not None:
+        for extractor in (
+            entity_llm_extractor,
+            event_llm_extractor,
+            relation_llm_extractor,
+            discourse_llm_extractor,
+            hypothesis_llm_extractor,
+            story_relation_llm_extractor,
+        ):
+            if extractor is not None:
+                extractor.default_model = model
 
     annotations: List[schema.SegmentWorldAnnotation] = []
     all_usage: List[PassUsage] = []
@@ -439,18 +514,24 @@ def process_segments(
             # A failed story-relation pass must not silently read as "zero
             # cross-segment relations found" — mirrors the segment-level
             # extraction_errors/validation_errors distinction.
-            story.extraction_errors.append(
-                f"story relation extraction failed: {story_relation_error}"
+            _record_extraction_error(
+                story.extraction_errors,
+                story.structured_extraction_errors,
+                "story relation",
+                story_relation_error,
             )
-        cross_segment_relations, weakly_inferred_cross_segment_relations = (
-            story_relation_extractor_module.build_story_relations(
-                story_relation_result.get("extracted_output") or {}, story
-            )
+        (
+            cross_segment_relations,
+            weakly_inferred_cross_segment_relations,
+            story_relation_item_errors,
+        ) = story_relation_extractor_module.build_story_relations(
+            story_relation_result.get("extracted_output") or {}, story
         )
         story.cross_segment_relations = cross_segment_relations
         story.weakly_inferred_cross_segment_relations = (
             weakly_inferred_cross_segment_relations
         )
+        story.extraction_errors.extend(story_relation_item_errors)
         story.validation_errors = schema.validate_story_annotation(story)
 
     return {

--- a/lcats/src/lcats/analysis/event_role_world/relation_extractor.py
+++ b/lcats/src/lcats/analysis/event_role_world/relation_extractor.py
@@ -11,58 +11,65 @@ from typing import Any, Dict, List, Tuple
 
 from lcats.analysis import llm_extractor
 from lcats.analysis.event_role_world import schema
+from lcats.llm import tool_schema as tool_schema_module
 
-RELATION_TOOL_SCHEMA: Dict[str, Any] = {
-    "name": "extract_relations",
-    "description": (
-        "Extract causal, enabling, preventing, temporal, motivational, and "
-        "explanatory links between events already identified in a story "
-        "segment."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "relations": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "relation_id": {"type": "string"},
-                        "source_event_id": {"type": "string"},
-                        "target_event_id": {"type": "string"},
-                        "relation_type": {
-                            "type": "string",
-                            "description": (
-                                "e.g. causes, enables, prevents, precedes, "
-                                "motivates, explains"
-                            ),
+RELATION_TOOL_SCHEMA: Dict[str, Any] = tool_schema_module.strict_tool_schema(
+    {
+        "name": "extract_relations",
+        "description": (
+            "Extract causal, enabling, preventing, temporal, motivational, and "
+            "explanatory links between events already identified in a story "
+            "segment."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "relations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "relation_id": {"type": "string"},
+                            "source_event_id": {"type": "string"},
+                            "target_event_id": {"type": "string"},
+                            "relation_type": {
+                                "type": "string",
+                                "description": (
+                                    "e.g. causes, enables, prevents, precedes, "
+                                    "motivates, explains"
+                                ),
+                            },
+                            "quote": {
+                                "type": "string",
+                                "description": (
+                                    "Exact substring of the segment text that "
+                                    "grounds this relation."
+                                ),
+                            },
+                            "certainty": {
+                                "type": "string",
+                                "enum": [
+                                    "explicit",
+                                    "strongly_implied",
+                                    "weakly_inferred",
+                                ],
+                            },
+                            "confidence": {"type": "number"},
                         },
-                        "quote": {
-                            "type": "string",
-                            "description": (
-                                "Exact substring of the segment text that "
-                                "grounds this relation."
-                            ),
-                        },
-                        "certainty": {
-                            "type": "string",
-                            "enum": ["explicit", "strongly_implied", "weakly_inferred"],
-                        },
-                        "confidence": {"type": "number"},
+                        "required": [
+                            "relation_id",
+                            "source_event_id",
+                            "target_event_id",
+                            "relation_type",
+                            "quote",
+                        ],
                     },
-                    "required": [
-                        "relation_id",
-                        "source_event_id",
-                        "target_event_id",
-                        "relation_type",
-                        "quote",
-                    ],
-                },
-            }
+                }
+            },
+            "required": ["relations"],
         },
-        "required": ["relations"],
-    },
-}
+    }
+)
 
 RELATION_SYSTEM_PROMPT = """You are extracting causal and temporal relations
 between events from a segment of a story for structured narrative analysis.
@@ -106,7 +113,7 @@ def make_relation_extractor(backend: Any) -> llm_extractor.JSONPromptExtractor:
 
 def build_relations(
     tool_result: Dict[str, Any], segment_text: str
-) -> Tuple[List[schema.EventRelation], List[schema.EventRelation]]:
+) -> Tuple[List[schema.EventRelation], List[schema.EventRelation], List[str]]:
     """Convert a raw extract_relations tool result into schema objects.
 
     Args:
@@ -114,21 +121,28 @@ def build_relations(
         segment_text: The segment text quotes are resolved against.
 
     Returns:
-        (relations, weakly_inferred_relations) — relations whose quote
-        cannot be located in `segment_text` are dropped (not fabricated
-        with a guessed span). Relations with certainty "explicit" or
-        "strongly_implied" go in the first list (the main relations
-        layer); "weakly_inferred" relations are partitioned into the
-        second list per the proposal's causality tradeoff table. Repeated
-        identical quotes resolve to successive occurrences via a
-        per-segment EvidenceCursor.
+        (relations, weakly_inferred_relations, item_errors) — relations
+        whose quote cannot be located in `segment_text` are dropped (not
+        fabricated with a guessed span). Relations with certainty
+        "explicit" or "strongly_implied" go in the first list (the main
+        relations layer); "weakly_inferred" relations are partitioned into
+        the second list per the proposal's causality tradeoff table.
+        Repeated identical quotes resolve to successive occurrences via a
+        per-segment EvidenceCursor. item_errors describes any
+        "relations" array item that was not a dict - skipped rather than
+        crashing (the AttributeError this pattern originally crashed
+        with), but surfaced explicitly (see schema.describe_malformed_item).
     """
     cursor = schema.EvidenceCursor()
 
     relations: List[schema.EventRelation] = []
     weakly_inferred_relations: List[schema.EventRelation] = []
+    item_errors: List[str] = []
 
-    for raw in tool_result.get("relations") or []:
+    for i, raw in enumerate(tool_result.get("relations") or []):
+        if not isinstance(raw, dict):
+            item_errors.append(schema.describe_malformed_item(f"relations[{i}]", raw))
+            continue
         evidence = cursor.resolve(raw.get("quote", ""), segment_text)
         if evidence is None:
             continue
@@ -147,4 +161,4 @@ def build_relations(
         else:
             relations.append(relation)
 
-    return relations, weakly_inferred_relations
+    return relations, weakly_inferred_relations, item_errors

--- a/lcats/src/lcats/analysis/event_role_world/schema.py
+++ b/lcats/src/lcats/analysis/event_role_world/schema.py
@@ -16,6 +16,39 @@ import dataclasses
 
 from typing import Any, Dict, List, Optional
 
+_MALFORMED_ITEM_REPR_MAX_CHARS = 200
+
+
+def describe_malformed_item(path: str, item: Any) -> str:
+    """Return a one-line description of a non-dict tool-result array item.
+
+    Used by every build_*() function in this package (entity_extractor,
+    event_extractor, relation_extractor, discourse_extractor,
+    story_relation_extractor, hypothesis_extractor) at each array-item
+    site where the tool result is iterated - see WI-EVENT-0032. A
+    malformed item is skipped rather than crashing (the
+    AttributeError: 'str' object has no attribute 'get' class of bug this
+    guards against), but the skip must still surface as an explicit
+    extraction error, not silently read as a clean, complete result -
+    see this repo's ERW pipeline structured-output reliability audit,
+    Category B.
+
+    Args:
+        path: Dotted/bracketed location of the item, e.g.
+            "entities[2]" or "entities[0].mentions[1]".
+        item: The malformed item itself (any non-dict value).
+
+    Returns:
+        A single-line string naming the path, the item's actual type, and
+        a truncated repr - long enough to diagnose, short enough not to
+        flood a log with a multi-kilobyte truncated-JSON string (the
+        actual failure mode this was built to describe).
+    """
+    item_repr = repr(item)
+    if len(item_repr) > _MALFORMED_ITEM_REPR_MAX_CHARS:
+        item_repr = item_repr[:_MALFORMED_ITEM_REPR_MAX_CHARS] + "...<truncated>"
+    return f"{path} is not an object (got {type(item).__name__}): {item_repr}"
+
 
 @dataclasses.dataclass
 class EvidenceSpan:
@@ -403,6 +436,16 @@ class SegmentWorldAnnotation:
             extraction_error means a pass may not have run at all — its
             "zero results" must not be read as "the pass ran and found
             nothing."
+        structured_extraction_errors: The subset of extraction_errors that
+            originated as a structured api_error dict (from
+            llm_extractor.JSONPromptExtractor._classify_api_error) rather
+            than an item-level string description - carrying its
+            category/can_retry/should_abort_batch fields so a caller can
+            act on them directly instead of re-deriving fatality by
+            substring-matching extraction_errors' plain-text messages
+            (WI-EVENT-0032). Purely additive: extraction_errors keeps
+            every failure as a human-readable string as before; this list
+            is a parallel, structured view of the ones that have one.
         validation_errors: ID-resolution and evidence-alignment failures
             found by validate_segment_annotation, given whatever entities/
             events/anchors/relations/discourse were actually extracted.
@@ -424,6 +467,9 @@ class SegmentWorldAnnotation:
     sf_tags: List[SFWorldModelTag] = dataclasses.field(default_factory=list)
     hypotheses: List[Hypothesis] = dataclasses.field(default_factory=list)
     extraction_errors: List[str] = dataclasses.field(default_factory=list)
+    structured_extraction_errors: List[Dict[str, Any]] = dataclasses.field(
+        default_factory=list
+    )
     validation_errors: List[str] = dataclasses.field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -446,6 +492,7 @@ class SegmentWorldAnnotation:
             "sf_tags": [t.to_dict() for t in self.sf_tags],
             "hypotheses": [h.to_dict() for h in self.hypotheses],
             "extraction_errors": self.extraction_errors,
+            "structured_extraction_errors": self.structured_extraction_errors,
             "validation_errors": self.validation_errors,
         }
 
@@ -747,6 +794,10 @@ class StoryWorldAnnotation:
             Distinct from validation_errors: an extraction_error means the
             story-level pass may not have run at all — its "zero results"
             must not be read as "the pass ran and found nothing."
+        structured_extraction_errors: The subset of extraction_errors that
+            originated as a structured api_error dict, mirroring
+            SegmentWorldAnnotation.structured_extraction_errors at story
+            scope (WI-EVENT-0032).
         validation_errors: Story-level validation failures (see
             validate_story_annotation).
     """
@@ -765,6 +816,9 @@ class StoryWorldAnnotation:
         default_factory=list
     )
     extraction_errors: List[str] = dataclasses.field(default_factory=list)
+    structured_extraction_errors: List[Dict[str, Any]] = dataclasses.field(
+        default_factory=list
+    )
     validation_errors: List[str] = dataclasses.field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -781,6 +835,7 @@ class StoryWorldAnnotation:
                 r.to_dict() for r in self.weakly_inferred_cross_segment_relations
             ],
             "extraction_errors": self.extraction_errors,
+            "structured_extraction_errors": self.structured_extraction_errors,
             "validation_errors": self.validation_errors,
         }
 

--- a/lcats/src/lcats/analysis/event_role_world/story_relation_extractor.py
+++ b/lcats/src/lcats/analysis/event_role_world/story_relation_extractor.py
@@ -27,64 +27,71 @@ from typing import Any, Dict, List, Set, Tuple
 
 from lcats.analysis import llm_extractor
 from lcats.analysis.event_role_world import schema
+from lcats.llm import tool_schema as tool_schema_module
 
-STORY_RELATION_TOOL_SCHEMA: Dict[str, Any] = {
-    "name": "extract_story_relations",
-    "description": (
-        "Extract causal, enabling, preventing, temporal, motivational, and "
-        "explanatory links between events that belong to DIFFERENT segments "
-        "of the same story. Same-segment relations are already handled by a "
-        "separate pass and must not be repeated here."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "relations": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "relation_id": {"type": "string"},
-                        "source_event_id": {
-                            "type": "string",
-                            "description": (
-                                'Qualified event ID ("segment_id:event_id") '
-                                "from the known events list."
-                            ),
+STORY_RELATION_TOOL_SCHEMA: Dict[str, Any] = tool_schema_module.strict_tool_schema(
+    {
+        "name": "extract_story_relations",
+        "description": (
+            "Extract causal, enabling, preventing, temporal, motivational, and "
+            "explanatory links between events that belong to DIFFERENT segments "
+            "of the same story. Same-segment relations are already handled by a "
+            "separate pass and must not be repeated here."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "relations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "relation_id": {"type": "string"},
+                            "source_event_id": {
+                                "type": "string",
+                                "description": (
+                                    'Qualified event ID ("segment_id:event_id") '
+                                    "from the known events list."
+                                ),
+                            },
+                            "target_event_id": {
+                                "type": "string",
+                                "description": (
+                                    'Qualified event ID ("segment_id:event_id") '
+                                    "from the known events list, in a DIFFERENT "
+                                    "segment than source_event_id."
+                                ),
+                            },
+                            "relation_type": {
+                                "type": "string",
+                                "description": (
+                                    "e.g. causes, enables, prevents, precedes, "
+                                    "motivates, explains"
+                                ),
+                            },
+                            "certainty": {
+                                "type": "string",
+                                "enum": [
+                                    "explicit",
+                                    "strongly_implied",
+                                    "weakly_inferred",
+                                ],
+                            },
+                            "confidence": {"type": "number"},
                         },
-                        "target_event_id": {
-                            "type": "string",
-                            "description": (
-                                'Qualified event ID ("segment_id:event_id") '
-                                "from the known events list, in a DIFFERENT "
-                                "segment than source_event_id."
-                            ),
-                        },
-                        "relation_type": {
-                            "type": "string",
-                            "description": (
-                                "e.g. causes, enables, prevents, precedes, "
-                                "motivates, explains"
-                            ),
-                        },
-                        "certainty": {
-                            "type": "string",
-                            "enum": ["explicit", "strongly_implied", "weakly_inferred"],
-                        },
-                        "confidence": {"type": "number"},
+                        "required": [
+                            "relation_id",
+                            "source_event_id",
+                            "target_event_id",
+                            "relation_type",
+                        ],
                     },
-                    "required": [
-                        "relation_id",
-                        "source_event_id",
-                        "target_event_id",
-                        "relation_type",
-                    ],
-                },
-            }
+                }
+            },
+            "required": ["relations"],
         },
-        "required": ["relations"],
-    },
-}
+    }
+)
 
 STORY_RELATION_SYSTEM_PROMPT = """You are extracting cross-segment causal and
 temporal relations between events from different segments of the same story,
@@ -158,7 +165,7 @@ def build_event_index(story: schema.StoryWorldAnnotation) -> str:
 
 def build_story_relations(
     tool_result: Dict[str, Any], story: schema.StoryWorldAnnotation
-) -> Tuple[List[schema.EventRelation], List[schema.EventRelation]]:
+) -> Tuple[List[schema.EventRelation], List[schema.EventRelation], List[str]]:
     """Convert a raw extract_story_relations tool result into schema objects.
 
     Args:
@@ -169,8 +176,9 @@ def build_story_relations(
             after schema.reconcile_story_annotations.
 
     Returns:
-        (cross_segment_relations, weakly_inferred_cross_segment_relations)
-        — relations whose source_event_id/target_event_id do not both
+        (cross_segment_relations, weakly_inferred_cross_segment_relations,
+        item_errors) — relations whose source_event_id/target_event_id do
+        not both
         resolve to known qualified event IDs are dropped, as are relations
         whose source and target resolve to the SAME segment (the model may
         occasionally violate its instructions; this pass's contract is
@@ -190,7 +198,9 @@ def build_story_relations(
         already-resolved EvidenceSpan (the "already-resolved evidence
         spans" reuse WI-EVENT-0028's evaluation recommended), not a fresh
         quote search — there is no single text blob to search across
-        segments against.
+        segments against. item_errors describes any "relations" array
+        item that was not a dict - skipped rather than crashing, but
+        surfaced explicitly (see schema.describe_malformed_item).
     """
     event_by_qualified_id: Dict[str, schema.Event] = {
         f"{segment.segment_id}:{event.event_id}": event
@@ -201,8 +211,12 @@ def build_story_relations(
     cross_segment_relations: List[schema.EventRelation] = []
     weakly_inferred_cross_segment_relations: List[schema.EventRelation] = []
     seen_raw_relation_ids: Set[str] = set()
+    item_errors: List[str] = []
 
-    for raw in tool_result.get("relations") or []:
+    for i, raw in enumerate(tool_result.get("relations") or []):
+        if not isinstance(raw, dict):
+            item_errors.append(schema.describe_malformed_item(f"relations[{i}]", raw))
+            continue
         source_id = raw.get("source_event_id", "")
         target_id = raw.get("target_event_id", "")
         source_event = event_by_qualified_id.get(source_id)
@@ -235,4 +249,4 @@ def build_story_relations(
         else:
             cross_segment_relations.append(relation)
 
-    return cross_segment_relations, weakly_inferred_cross_segment_relations
+    return cross_segment_relations, weakly_inferred_cross_segment_relations, item_errors

--- a/lcats/src/lcats/llm/tool_schema.py
+++ b/lcats/src/lcats/llm/tool_schema.py
@@ -1,0 +1,68 @@
+"""Shared helpers for hardening Anthropic tool-use JSON schemas to strict mode."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def close_schema_objects(node: Any) -> Any:
+    """Recursively return a deep copy of a JSON Schema fragment with
+    additionalProperties: false set on every object (top-level and
+    nested) - required by Anthropic's strict tool use before strict: true
+    takes effect. See strict_tool_schema()'s docstring for why this is
+    needed.
+
+    Sets additionalProperties unconditionally (not via setdefault) so an
+    existing, looser value (e.g. additionalProperties: true, or a schema
+    rather than a bare bool) can't silently defeat the requirement this
+    exists to enforce. Also matches "object" inside a union `type` list
+    (e.g. `type: ["object", "null"]`), not just a bare `type: "object"`
+    string, since JSON Schema permits either form.
+    """
+    if isinstance(node, dict):
+        closed = {key: close_schema_objects(value) for key, value in node.items()}
+        node_type = closed.get("type")
+        is_object = node_type == "object" or (
+            isinstance(node_type, list) and "object" in node_type
+        )
+        if is_object:
+            closed["additionalProperties"] = False
+        return closed
+    if isinstance(node, list):
+        return [close_schema_objects(item) for item in node]
+    return node
+
+
+def strict_tool_schema(tool_schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a deep copy of `tool_schema` with strict: true enabled.
+
+    Without strict: true, Anthropic's tool use does not guarantee the
+    model's tool_use input matches input_schema - "Claude might return
+    incompatible types ... or omit required fields, breaking your
+    functions and causing runtime errors" (Anthropic docs, Strict tool
+    use). This is exactly what happened live: a relations array item came
+    back as a plain string instead of the required object, crashing
+    relation_extractor.build_relations()'s `raw.get("quote", ...)` with
+    AttributeError. Enabling strict: true constrains the model's token
+    sampling to schema-valid output via grammar-constrained sampling,
+    which would have prevented that malformed item outright.
+
+    strict: true additionally requires additionalProperties: false on
+    every object in the schema, including nested ones inside array items
+    (Anthropic docs, JSON Schema limitations) - close_schema_objects()
+    adds it here so every schema-defining module can wrap its own
+    constant at definition time instead of hand-writing
+    additionalProperties at every nesting level.
+
+    The returned dict's top-level `strict` key is inert (never read) for
+    OpenAIBackend.complete(), which only forwards `input_schema` as its
+    function `parameters` - see openai_backend.py. The
+    additionalProperties: false this adds inside input_schema does reach
+    OpenAI's schema too; this is intentional here (unlike the narrower,
+    --backend anthropic-gated runtime override this function's callers
+    replace) since the schemas are meant to be strict at the source for
+    both backends.
+    """
+    schema = close_schema_objects(tool_schema)
+    schema["strict"] = True
+    return schema

--- a/lcats/tests/analysis_tests/event_role_world_test.py
+++ b/lcats/tests/analysis_tests/event_role_world_test.py
@@ -351,7 +351,7 @@ class TestBuildEntities(unittest.TestCase):
             ]
         }
 
-        entities, mentions = entity_extractor.build_entities(tool_result, text)
+        entities, mentions, _ = entity_extractor.build_entities(tool_result, text)
 
         self.assertEqual(len(entities), 1)
         self.assertEqual(entities[0].entity_id, "e1")
@@ -374,7 +374,7 @@ class TestBuildEntities(unittest.TestCase):
             ]
         }
 
-        entities, mentions = entity_extractor.build_entities(tool_result, text)
+        entities, mentions, _ = entity_extractor.build_entities(tool_result, text)
 
         # The entity's only mention failed to resolve, leaving it with no
         # grounded evidence at all - it must be dropped entirely rather than
@@ -383,9 +383,72 @@ class TestBuildEntities(unittest.TestCase):
         self.assertEqual(entities, [])
 
     def test_empty_tool_result_produces_no_entities(self):
-        entities, mentions = entity_extractor.build_entities({}, "some text")
+        entities, mentions, _ = entity_extractor.build_entities({}, "some text")
         self.assertEqual(entities, [])
         self.assertEqual(mentions, [])
+
+    def test_malformed_entity_item_is_skipped_and_reported(self):
+        """A non-dict entities[] item (WI-EVENT-0032) must not crash - it is
+        skipped and reported in item_errors, while a valid sibling entity in
+        the same list is still processed normally."""
+        text = "The old machine hummed."
+        tool_result = {
+            "entities": [
+                "not an object",
+                {
+                    "entity_id": "e1",
+                    "canonical_name": "the machine",
+                    "entity_type": "machine_or_artifact",
+                    "mentions": [
+                        {
+                            "mention_id": "m1",
+                            "text": "the machine",
+                            "quote": "old machine",
+                        }
+                    ],
+                },
+            ]
+        }
+
+        entities, mentions, item_errors = entity_extractor.build_entities(
+            tool_result, text
+        )
+
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(entities[0].entity_id, "e1")
+        self.assertEqual(len(mentions), 1)
+        self.assertEqual(len(item_errors), 1)
+        self.assertIn("entities[0]", item_errors[0])
+        self.assertIn("not an object", item_errors[0])
+
+    def test_malformed_mention_item_is_skipped_and_reported(self):
+        text = "The old machine hummed."
+        tool_result = {
+            "entities": [
+                {
+                    "entity_id": "e1",
+                    "canonical_name": "the machine",
+                    "entity_type": "machine_or_artifact",
+                    "mentions": [
+                        {
+                            "mention_id": "m1",
+                            "text": "the machine",
+                            "quote": "old machine",
+                        },
+                        "not an object",
+                    ],
+                }
+            ]
+        }
+
+        entities, mentions, item_errors = entity_extractor.build_entities(
+            tool_result, text
+        )
+
+        self.assertEqual(len(entities), 1)
+        self.assertEqual(len(mentions), 1)
+        self.assertEqual(len(item_errors), 1)
+        self.assertIn("entities[0].mentions[1]", item_errors[0])
 
 
 # ---------------------------------------------------------------------------
@@ -424,7 +487,7 @@ class TestBuildEventsAndAnchors(unittest.TestCase):
             ],
         }
 
-        events, temporal_anchors, spatial_anchors = (
+        events, temporal_anchors, spatial_anchors, _ = (
             event_extractor.build_events_and_anchors(tool_result, text)
         )
 
@@ -447,7 +510,7 @@ class TestBuildEventsAndAnchors(unittest.TestCase):
                 }
             ]
         }
-        events, _, _ = event_extractor.build_events_and_anchors(tool_result, text)
+        events, _, _, _ = event_extractor.build_events_and_anchors(tool_result, text)
         self.assertEqual(events, [])
 
     def test_drops_semantic_role_with_unresolvable_quote_but_keeps_event(self):
@@ -465,9 +528,57 @@ class TestBuildEventsAndAnchors(unittest.TestCase):
                 }
             ]
         }
-        events, _, _ = event_extractor.build_events_and_anchors(tool_result, text)
+        events, _, _, _ = event_extractor.build_events_and_anchors(tool_result, text)
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].semantic_roles, [])
+
+    def test_malformed_items_are_skipped_and_reported(self):
+        """A non-dict item in temporal_anchors/spatial_anchors/events/
+        semantic_roles (WI-EVENT-0032) must not crash - each is skipped and
+        reported in item_errors, while valid siblings are still processed."""
+        text = "The machine hummed in the pit for decades."
+        tool_result = {
+            "temporal_anchors": [
+                "not an object",
+                {"anchor_id": "t1", "text": "decades", "quote": "for decades"},
+            ],
+            "spatial_anchors": [
+                "not an object",
+                {"anchor_id": "s1", "text": "the pit", "quote": "in the pit"},
+            ],
+            "events": [
+                "not an object",
+                {
+                    "event_id": "ev1",
+                    "predicate": "hummed",
+                    "event_type": "sound_emission",
+                    "quote": "hummed",
+                    "semantic_roles": [
+                        "not an object",
+                        {
+                            "role": "agent",
+                            "filler_entity_id": "e1",
+                            "quote": "The machine",
+                        },
+                    ],
+                },
+            ],
+        }
+
+        events, temporal_anchors, spatial_anchors, item_errors = (
+            event_extractor.build_events_and_anchors(tool_result, text)
+        )
+
+        self.assertEqual(len(temporal_anchors), 1)
+        self.assertEqual(len(spatial_anchors), 1)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(len(events[0].semantic_roles), 1)
+        self.assertEqual(len(item_errors), 4)
+        joined = "\n".join(item_errors)
+        self.assertIn("temporal_anchors[0]", joined)
+        self.assertIn("spatial_anchors[0]", joined)
+        self.assertIn("events[0]", joined)
+        self.assertIn("events[1].semantic_roles[0]", joined)
 
 
 # ---------------------------------------------------------------------------
@@ -491,7 +602,7 @@ class TestBuildRelations(unittest.TestCase):
                 }
             ]
         }
-        relations, weakly_inferred = relation_extractor.build_relations(
+        relations, weakly_inferred, _ = relation_extractor.build_relations(
             tool_result, text
         )
         self.assertEqual(len(relations), 1)
@@ -513,7 +624,7 @@ class TestBuildRelations(unittest.TestCase):
                 }
             ]
         }
-        relations, weakly_inferred = relation_extractor.build_relations(
+        relations, weakly_inferred, _ = relation_extractor.build_relations(
             tool_result, text
         )
         self.assertEqual(relations, [])
@@ -533,16 +644,46 @@ class TestBuildRelations(unittest.TestCase):
                 }
             ]
         }
-        relations, weakly_inferred = relation_extractor.build_relations(
+        relations, weakly_inferred, _ = relation_extractor.build_relations(
             tool_result, text
         )
         self.assertEqual(relations, [])
         self.assertEqual(weakly_inferred, [])
 
     def test_empty_tool_result_produces_no_relations(self):
-        relations, weakly_inferred = relation_extractor.build_relations({}, "some text")
+        relations, weakly_inferred, _ = relation_extractor.build_relations(
+            {}, "some text"
+        )
         self.assertEqual(relations, [])
         self.assertEqual(weakly_inferred, [])
+
+    def test_malformed_relation_item_is_skipped_and_reported(self):
+        """A non-dict relations[] item is the exact site that crashed live
+        with AttributeError: 'str' object has no attribute 'get'
+        (WI-EVENT-0032) - must not crash, and must surface in item_errors."""
+        text = "The machine hummed, which caused the lights to flicker."
+        tool_result = {
+            "relations": [
+                "not an object",
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "ev1",
+                    "target_event_id": "ev2",
+                    "relation_type": "causes",
+                    "quote": "hummed",
+                    "certainty": "explicit",
+                },
+            ]
+        }
+
+        relations, weakly_inferred, item_errors = relation_extractor.build_relations(
+            tool_result, text
+        )
+
+        self.assertEqual(len(relations), 1)
+        self.assertEqual(weakly_inferred, [])
+        self.assertEqual(len(item_errors), 1)
+        self.assertIn("relations[0]", item_errors[0])
 
 
 # ---------------------------------------------------------------------------
@@ -584,7 +725,7 @@ class TestBuildDiscourse(unittest.TestCase):
                 }
             ],
         }
-        speech_acts, explanations, sf_tags = discourse_extractor.build_discourse(
+        speech_acts, explanations, sf_tags, _ = discourse_extractor.build_discourse(
             tool_result, text
         )
         self.assertEqual(len(speech_acts), 1)
@@ -603,7 +744,7 @@ class TestBuildDiscourse(unittest.TestCase):
                 {"tag_id": "sf1", "tag": "anomaly_or_novum", "quote": "machine"}
             ]
         }
-        _, _, sf_tags = discourse_extractor.build_discourse(tool_result, text)
+        _, _, sf_tags, _ = discourse_extractor.build_discourse(tool_result, text)
         self.assertEqual(sf_tags[0].status, "hypothesis")
 
     def test_drops_items_with_unresolvable_quotes(self):
@@ -622,7 +763,7 @@ class TestBuildDiscourse(unittest.TestCase):
             ],
             "sf_tags": [{"tag_id": "sf1", "tag": "x", "quote": "nowhere"}],
         }
-        speech_acts, explanations, sf_tags = discourse_extractor.build_discourse(
+        speech_acts, explanations, sf_tags, _ = discourse_extractor.build_discourse(
             tool_result, text
         )
         self.assertEqual(speech_acts, [])
@@ -630,7 +771,7 @@ class TestBuildDiscourse(unittest.TestCase):
         self.assertEqual(sf_tags, [])
 
     def test_empty_tool_result_produces_nothing(self):
-        speech_acts, explanations, sf_tags = discourse_extractor.build_discourse(
+        speech_acts, explanations, sf_tags, _ = discourse_extractor.build_discourse(
             {}, "some text"
         )
         self.assertEqual(speech_acts, [])
@@ -668,12 +809,46 @@ class TestBuildDiscourse(unittest.TestCase):
                 }
             ],
         }
-        speech_acts, explanations, sf_tags = discourse_extractor.build_discourse(
+        speech_acts, explanations, sf_tags, _ = discourse_extractor.build_discourse(
             tool_result, text
         )
         self.assertEqual(len(speech_acts), 1)
         self.assertEqual(len(explanations), 1)
         self.assertEqual(len(sf_tags), 1)
+
+    def test_malformed_items_are_skipped_and_reported(self):
+        """A non-dict item in speech_acts/explanations/sf_tags (WI-EVENT-0032)
+        must not crash - each is skipped and reported in item_errors."""
+        text = "Reroute the plasma conduits, the captain commanded."
+        tool_result = {
+            "speech_acts": [
+                "not an object",
+                {
+                    "speech_act_id": "sa1",
+                    "act_type": "command",
+                    "quote": "Reroute the plasma conduits",
+                },
+            ],
+            "explanations": [
+                "not an object",
+            ],
+            "sf_tags": [
+                "not an object",
+            ],
+        }
+
+        speech_acts, explanations, sf_tags, item_errors = (
+            discourse_extractor.build_discourse(tool_result, text)
+        )
+
+        self.assertEqual(len(speech_acts), 1)
+        self.assertEqual(explanations, [])
+        self.assertEqual(sf_tags, [])
+        self.assertEqual(len(item_errors), 3)
+        joined = "\n".join(item_errors)
+        self.assertIn("speech_acts[0]", joined)
+        self.assertIn("explanations[0]", joined)
+        self.assertIn("sf_tags[0]", joined)
 
 
 # ---------------------------------------------------------------------------
@@ -697,7 +872,7 @@ class TestBuildHypotheses(unittest.TestCase):
                 }
             ]
         }
-        hypotheses = hypothesis_extractor.build_hypotheses(tool_result, text)
+        hypotheses, _ = hypothesis_extractor.build_hypotheses(tool_result, text)
         self.assertEqual(len(hypotheses), 1)
         self.assertEqual(hypotheses[0].hypothesis_type, "belief")
         self.assertEqual(hypotheses[0].subject_entity_id, "e2")
@@ -715,11 +890,12 @@ class TestBuildHypotheses(unittest.TestCase):
                 }
             ]
         }
-        hypotheses = hypothesis_extractor.build_hypotheses(tool_result, text)
+        hypotheses, _ = hypothesis_extractor.build_hypotheses(tool_result, text)
         self.assertEqual(hypotheses, [])
 
     def test_empty_tool_result_produces_no_hypotheses(self):
-        self.assertEqual(hypothesis_extractor.build_hypotheses({}, "some text"), [])
+        hypotheses, _ = hypothesis_extractor.build_hypotheses({}, "some text")
+        self.assertEqual(hypotheses, [])
 
     def test_repeated_quote_resolves_to_successive_occurrences(self):
         text = "First she feared it. Later, she feared it again."
@@ -739,11 +915,33 @@ class TestBuildHypotheses(unittest.TestCase):
                 },
             ]
         }
-        hypotheses = hypothesis_extractor.build_hypotheses(tool_result, text)
+        hypotheses, _ = hypothesis_extractor.build_hypotheses(tool_result, text)
         self.assertEqual(len(hypotheses), 2)
         self.assertLess(
             hypotheses[0].evidence.start_char, hypotheses[1].evidence.start_char
         )
+
+    def test_malformed_hypothesis_item_is_skipped_and_reported(self):
+        text = "She feared it would never work again."
+        tool_result = {
+            "hypotheses": [
+                "not an object",
+                {
+                    "hypothesis_id": "h1",
+                    "hypothesis_type": "emotion_appraisal",
+                    "proposition_or_target": "fear",
+                    "quote": "feared it",
+                },
+            ]
+        }
+
+        hypotheses, item_errors = hypothesis_extractor.build_hypotheses(
+            tool_result, text
+        )
+
+        self.assertEqual(len(hypotheses), 1)
+        self.assertEqual(len(item_errors), 1)
+        self.assertIn("hypotheses[0]", item_errors[0])
 
 
 # ---------------------------------------------------------------------------
@@ -834,7 +1032,7 @@ class TestBuildStoryRelations(unittest.TestCase):
             ]
         }
 
-        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+        relations, weakly_inferred, _ = story_relation_extractor.build_story_relations(
             tool_result, story
         )
 
@@ -860,7 +1058,7 @@ class TestBuildStoryRelations(unittest.TestCase):
             ]
         }
 
-        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+        relations, weakly_inferred, _ = story_relation_extractor.build_story_relations(
             tool_result, story
         )
 
@@ -881,7 +1079,7 @@ class TestBuildStoryRelations(unittest.TestCase):
             ]
         }
 
-        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+        relations, weakly_inferred, _ = story_relation_extractor.build_story_relations(
             tool_result, story
         )
 
@@ -905,7 +1103,7 @@ class TestBuildStoryRelations(unittest.TestCase):
             ]
         }
 
-        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+        relations, weakly_inferred, _ = story_relation_extractor.build_story_relations(
             tool_result, story
         )
 
@@ -914,7 +1112,7 @@ class TestBuildStoryRelations(unittest.TestCase):
 
     def test_empty_tool_result_produces_no_relations(self):
         story = self._story_with_two_segment_events()
-        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+        relations, weakly_inferred, _ = story_relation_extractor.build_story_relations(
             {}, story
         )
         self.assertEqual(relations, [])
@@ -936,7 +1134,7 @@ class TestBuildStoryRelations(unittest.TestCase):
                 }
             ]
         }
-        relations, _ = story_relation_extractor.build_story_relations(
+        relations, _, _ = story_relation_extractor.build_story_relations(
             tool_result, story
         )
         self.assertTrue(relations[0].relation_id.startswith("story:"))
@@ -964,11 +1162,35 @@ class TestBuildStoryRelations(unittest.TestCase):
                 },
             ]
         }
-        relations, weakly_inferred = story_relation_extractor.build_story_relations(
+        relations, weakly_inferred, _ = story_relation_extractor.build_story_relations(
             tool_result, story
         )
         self.assertEqual(len(relations), 1)
         self.assertEqual(weakly_inferred, [])
+
+    def test_malformed_relation_item_is_skipped_and_reported(self):
+        story = self._story_with_two_segment_events()
+        tool_result = {
+            "relations": [
+                "not an object",
+                {
+                    "relation_id": "r1",
+                    "source_event_id": "1:ev1",
+                    "target_event_id": "2:ev1",
+                    "relation_type": "causes",
+                    "certainty": "explicit",
+                },
+            ]
+        }
+
+        relations, weakly_inferred, item_errors = (
+            story_relation_extractor.build_story_relations(tool_result, story)
+        )
+
+        self.assertEqual(len(relations), 1)
+        self.assertEqual(weakly_inferred, [])
+        self.assertEqual(len(item_errors), 1)
+        self.assertIn("relations[0]", item_errors[0])
 
 
 # ---------------------------------------------------------------------------
@@ -1954,6 +2176,65 @@ class TestProcessSegments(unittest.TestCase):
             any("entity extraction failed" in e for e in seg["extraction_errors"]),
             seg["extraction_errors"],
         )
+        # The api_error is also preserved structured, not just stringified
+        # into extraction_errors (WI-EVENT-0032, Category D).
+        self.assertEqual(len(seg["structured_extraction_errors"]), 1)
+        self.assertEqual(
+            seg["structured_extraction_errors"][0]["code"], "empty_tool_result"
+        )
+        self.assertIn("category", seg["structured_extraction_errors"][0])
+
+    def test_model_override_applies_to_every_extractor(self):
+        """process_segments(model=...) must override every extractor's
+        factory-hardcoded default_model (e.g. "gpt-4o"), matching the
+        override run_pilot.py previously had to apply itself by building
+        extractors directly (WI-EVENT-0032, Category D)."""
+        segment_text = "The machine hummed."
+        fake = _SequencedFakeBackend(
+            [
+                {"entities": []},
+                {"events": []},
+                {"relations": []},
+                {},
+                {"hypotheses": []},
+            ]
+        )
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        processor.process_segments(
+            segment_text,
+            segments,
+            nlp_backend_name="spacy",
+            llm_backend=fake,
+            model="claude-opus-4-8",
+        )
+
+        self.assertEqual(len(fake.calls), 5)
+        for call in fake.calls:
+            self.assertEqual(call["model"], "claude-opus-4-8")
+
+    def test_model_none_preserves_each_factorys_own_default(self):
+        """The default (model=None) must not change existing behavior -
+        each extractor keeps its own factory-hardcoded default_model."""
+        segment_text = "The machine hummed."
+        fake = _SequencedFakeBackend(
+            [
+                {"entities": []},
+                {"events": []},
+                {"relations": []},
+                {},
+                {"hypotheses": []},
+            ]
+        )
+        segments = [{"segment_id": 1, "start_char": 0, "end_char": len(segment_text)}]
+
+        processor.process_segments(
+            segment_text, segments, nlp_backend_name="spacy", llm_backend=fake
+        )
+
+        self.assertEqual(len(fake.calls), 5)
+        for call in fake.calls:
+            self.assertEqual(call["model"], "gpt-4o")
 
     def test_event_pass_failure_does_not_abort_remaining_segments(self):
         """A transient failure on one segment's event pass must not lose

--- a/lcats/tests/analysis_tests/event_role_world_test.py
+++ b/lcats/tests/analysis_tests/event_role_world_test.py
@@ -2183,6 +2183,42 @@ class TestProcessSegments(unittest.TestCase):
             seg["structured_extraction_errors"][0]["code"], "empty_tool_result"
         )
         self.assertIn("category", seg["structured_extraction_errors"][0])
+        # Tagged with which pass produced it - a review finding on PR #187:
+        # without this, multiple failed passes would be indistinguishable
+        # in structured_extraction_errors.
+        self.assertEqual(seg["structured_extraction_errors"][0]["pass"], "entity")
+
+    def test_record_extraction_error_does_not_flood_plain_string_with_raw_payload(
+        self,
+    ):
+        """Another PR #187 review finding: a dict error's own "raw" field
+        can be large (llm_extractor._normalize_api_error sets it to
+        repr(backend_response), which can include a full tool_result) -
+        the plain-string extraction_errors entry must use only "message",
+        not the whole dict, so one failed pass can't flood
+        extraction_errors/a caller's exclude_reason. The full dict is
+        still preserved as-is in structured_extraction_errors."""
+        extraction_errors = []
+        structured_extraction_errors = []
+        large_raw = "x" * 10_000
+        error = {
+            "status": None,
+            "code": "empty_tool_result",
+            "message": "No tool_result returned by backend.",
+            "raw": large_raw,
+            "category": "unknown",
+        }
+
+        processor._record_extraction_error(
+            extraction_errors, structured_extraction_errors, "entity", error
+        )
+
+        self.assertEqual(len(extraction_errors), 1)
+        self.assertIn("No tool_result returned by backend.", extraction_errors[0])
+        self.assertNotIn(large_raw, extraction_errors[0])
+        self.assertEqual(len(structured_extraction_errors), 1)
+        self.assertEqual(structured_extraction_errors[0]["raw"], large_raw)
+        self.assertEqual(structured_extraction_errors[0]["pass"], "entity")
 
     def test_model_override_applies_to_every_extractor(self):
         """process_segments(model=...) must override every extractor's


### PR DESCRIPTION
## Summary
Implements **WI-EVENT-0032** (Categories A/B/D of the ERW pipeline structured-output reliability audit): fixes, at the source, the three reliability gaps inside `lcats/lcats/analysis/event_role_world/` and its `processor.py` that WI-EVENT-0030 couldn't fix itself (`forbidden_actions: modify_event_role_world_extractor`).

- **Category A** — new `lcats.llm.tool_schema` module (ported from `run_pilot.py`'s proven runtime override) applies `strict: true`/`additionalProperties: false` to all 7 ERW-adjacent tool schemas at the source. `run_pilot.py`'s now-redundant runtime override and its `--backend anthropic` gate are removed.
- **Category B** — all 12 identified array-item sites across the 6 ERW extractors now detect a non-dict item, report it via a new `schema.describe_malformed_item` helper, and continue — instead of crashing (the `AttributeError` class of bug that hit twice live) or silently treating a dropped item as a clean result. Each `build_*()` function's return signature grows by one element (an `item_errors` list); all existing call sites (`processor.py`, ~24 test call sites) updated accordingly.
- **Category D** — `process_segments()` gains a `model=` override applied to every extractor it builds. `processor.py`'s error handling now also preserves the structured `api_error` dict via a new, additive `structured_extraction_errors` field on `SegmentWorldAnnotation`/`StoryWorldAnnotation`, alongside the existing plain-string `extraction_errors` (left untouched for backward compatibility).
- Also fixes the audit's Category B update finding: `run_pilot.py`'s `main()` per-story loop now catches any exception (not just `FatalPilotError`), recording a minimal excluded row and continuing instead of discarding every already-completed, already-paid-for story's results.
- Prep fixes to WI-EVENT-0032/0033/the workstream themselves: added a missing `## Required Changes` section (readiness gate), and corrected `lcats/lcats/` → `lcats/src/lcats/` path references stale from the concurrent src-layout packaging move (PR #175, landed after these WIs were authored).

## Test plan
- [x] `pytest tests/analysis_tests/event_role_world_test.py` — 108 passed, including 7 new malformed-item tests (one per site category) and 2 new `process_segments(model=...)` tests.
- [x] `scripts/test` — full suite, 1492 passed (up from 1483).
- [x] New `experiments/03_cross_segment_relation_pilot/run_pilot_test.py` — verifies an unexpected per-story exception preserves other stories' results (not part of `scripts/test`'s `tests/` sweep, run explicitly).
- [x] `scripts/lint` — ruff and black clean.
- [x] `lrh validate` — 0 errors.
- [x] Manual end-to-end smoke test: `python experiments/03_cross_segment_relation_pilot/run_pilot.py --dry-run --data-dir corpora --sample-size 1` completes cleanly across all 4 genres.
