### PR TITLE
Add Stage-1-only segmentation reliability check for WI-EVENT-0033

### DIFF
--- a/experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py
+++ b/experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py
@@ -19,10 +19,38 @@ hundred (1 genre-detect call per candidate scanned, plus 1 segmentation +
 accumulates all results in memory and writes only after its whole per-story
 loop finishes, so a crash (or Ctrl-C, which is not an `Exception` subclass
 and so escapes its catch-all) discards every already-paid-for result. This
-script deliberately avoids all of that: it writes each story's outcome,
-including the raw LLM output, to its own file immediately, so an
-interrupted run keeps everything it already paid for and can be re-run
-over the remainder.
+script deliberately avoids all of that: it writes each story's outcome to
+its own file immediately, and skips any story whose output file already
+exists on a subsequent run (see RESUMING below).
+
+ABOUT THE COHORT (review finding, PR #189)
+-------------------------------------------
+The 65% baseline came from `run_pilot.py`'s genre-detected, stratified
+`build_stratified_sample()` - not from a shuffle over all of `corpora/`.
+That baseline's exact story list was never persisted anywhere in this repo
+(confirmed: no `pilot_stories.jsonl` survives from any real run), so this
+script CANNOT reproduce the literal baseline cohort. Reproducing the
+original stratified *procedure* would cost ~200 genre-detection calls
+(measured separately), defeating this script's entire purpose.
+
+This is a real, honest limitation, not swept under the rug: a shuffle-based
+sample can differ from the baseline in genre mix and story length, and
+either could independently affect the exclusion rate. Two mitigations:
+
+  1. `--story-list FILE` accepts an explicit list of story paths (one per
+     line, `#`-prefixed lines ignored) if you have a specific cohort in
+     mind - e.g. from a future run_pilot.py run whose sample IS persisted.
+  2. Absent `--story-list`, the report always includes the sampled
+     cohort's word-count distribution, so a large rate change can be
+     sanity-checked against whether the cohort skewed unusually
+     short/long relative to the corpus median (per
+     `estimate_stage2.py`-style stats: corpora/ overall median is ~4,881
+     words - not hardcoded here since the actual sampled cohort is what
+     matters for this run).
+
+Treat a shuffle-sampled result as suggestive, not as a strictly controlled
+before/after comparison - and prefer `--story-list` when a real comparison
+matters.
 
 READING THE RESULT
 ------------------
@@ -31,12 +59,33 @@ Do NOT compare `parsing_error` counts. On the `tool_schema` path
 ("there is no JSON-text parse step"), so a post-fix `parsing_error` rate is
 0% by construction - a tautology, not evidence. This script instead reports
 the *segmentation exclusion rate for any cause*, broken down by cause,
-which is the honest comparison against the 65% baseline.
+which is the honest comparison against the 65% baseline. The exclusion
+rate's denominator is stories that actually reached an extraction attempt
+(`llm_calls_made`), not the raw sample size - a story skipped for an
+unreadable file or empty body never made a call and would otherwise
+silently understate the rate (or, worse, divide by zero if every sampled
+file were unreadable).
+
+If a batch-fatal error is hit (bad/expired API key, exhausted account
+balance - `api_error.get("should_abort_batch")` on the classified error),
+the run stops immediately rather than reporting every remaining story as
+"excluded", which would otherwise look like a real reliability finding
+instead of an account problem.
+
+RESUMING
+--------
+Re-running the same command with the same `--output` skips any story whose
+output file already exists, regardless of that story's prior outcome (a
+completed failure, like a completed success, does not need re-computation
+here - this script does not retry). Delete specific files under `--output`
+to force re-running just those stories, or pass a fresh `--output` to start
+clean.
 
 USAGE
 -----
 Needs a real API key (see `lcats/docs/secrets-setup.md`); costs ~1 LLM call
-per story. Run from the repo root with the conda environment active:
+per story that hasn't already been persisted. Run from the repo root with
+the conda environment active:
 
     python experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py \
         --data-dir corpora --sample-size 20 --model claude-haiku-4-5-20251001 \
@@ -45,7 +94,9 @@ per story. Run from the repo root with the conda environment active:
 `--model` defaults to the baseline's `claude-haiku-4-5-20251001` so the
 comparison is like-for-like; the cheaper model is what exposed the failure.
 `--seed` reuses `run_pilot._iter_candidate_files`'s shuffle convention, so a
-given seed selects a reproducible story set.
+given seed selects a reproducible story set (subject to the COHORT caveat
+above). Pass `--story-list FILE` instead of `--data-dir`/`--sample-size`/
+`--seed` to use an explicit cohort.
 """
 
 from __future__ import annotations
@@ -55,6 +106,7 @@ import collections
 import json
 import pathlib
 import random
+import statistics
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "lcats" / "src"))
@@ -85,6 +137,20 @@ def classify(result: dict, segments: list) -> str:
     return "included"
 
 
+def select_files(args) -> list[pathlib.Path]:
+    """Return the story files to run, per --story-list or the shuffle sample."""
+    if args.story_list:
+        lines = pathlib.Path(args.story_list).read_text("utf-8").splitlines()
+        return [
+            pathlib.Path(line.strip())
+            for line in lines
+            if line.strip() and not line.strip().startswith("#")
+        ]
+    files = sorted(pathlib.Path(args.data_dir).rglob("*.json"))
+    random.Random(args.seed).shuffle(files)
+    return files[: args.sample_size]
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -94,6 +160,15 @@ def main() -> int:
     parser.add_argument("--model", default="claude-haiku-4-5-20251001")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--output", default="/tmp/segmentation_reliability")
+    parser.add_argument(
+        "--story-list",
+        default=None,
+        help=(
+            "Path to a text file of explicit story paths (one per line, "
+            "'#'-prefixed lines ignored), used instead of --data-dir/"
+            "--sample-size/--seed's shuffle sample. See ABOUT THE COHORT."
+        ),
+    )
     args = parser.parse_args()
 
     load_secrets()
@@ -102,55 +177,137 @@ def main() -> int:
     output_dir = pathlib.Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    files = sorted(pathlib.Path(args.data_dir).rglob("*.json"))
-    random.Random(args.seed).shuffle(files)
-    files = files[: args.sample_size]
+    files = select_files(args)
     if not files:
-        print(f"error: no stories found under {args.data_dir}", file=sys.stderr)
+        print("error: no stories selected", file=sys.stderr)
         return 1
 
     extractor = scene_analysis.make_segment_extractor(
         anthropic_backend.AnthropicBackend()
     )
     counts: collections.Counter = collections.Counter()
+    llm_calls_made = 0
+    word_counts: list[int] = []
 
     for i, path in enumerate(files, 1):
-        body = story_analysis.coerce_text(
-            json.loads(path.read_text("utf-8")).get("body", "")
-        )
+        result_path = output_dir / f"{path.stem}.json"
+        if result_path.exists():
+            cached = json.loads(result_path.read_text("utf-8"))
+            counts[cached["outcome"]] += 1
+            if cached.get("llm_call_made"):
+                llm_calls_made += 1
+            if cached.get("word_count") is not None:
+                word_counts.append(cached["word_count"])
+            print(f"[{i}/{len(files)}] {path.stem}: {cached['outcome']} (cached)")
+            continue
+
+        try:
+            data = json.loads(path.read_text("utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            outcome = "story_json_error"
+            record = {
+                "story_id": path.stem,
+                "outcome": outcome,
+                "llm_call_made": False,
+                "word_count": None,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+            counts[outcome] += 1
+            result_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+            print(f"[{i}/{len(files)}] {path.stem}: {outcome}")
+            continue
+
+        body = story_analysis.coerce_text(data.get("body", ""))
+        word_count = len(body.split())
+        if not body.strip():
+            outcome = "empty_story_body"
+            record = {
+                "story_id": path.stem,
+                "outcome": outcome,
+                "llm_call_made": False,
+                "word_count": word_count,
+            }
+            counts[outcome] += 1
+            result_path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+            print(f"[{i}/{len(files)}] {path.stem}: {outcome}")
+            continue
+
         result = extractor.extract(body, model_name=args.model)
+        llm_calls_made += 1
+        word_counts.append(word_count)
+        api_error = result.get("api_error")
         segments = result.get("extracted_output") or []
         outcome = classify(result, segments)
         counts[outcome] += 1
-        # Persist immediately, including the raw LLM output, so an
-        # interrupted run keeps every already-paid-for result.
-        (output_dir / f"{path.stem}.json").write_text(
-            json.dumps(
-                {
-                    "story_id": path.stem,
-                    "outcome": outcome,
-                    "segment_count": len(segments),
-                    "llm_output": result.get("extracted_output"),
-                    "api_error": result.get("api_error"),
-                    "extraction_error": result.get("extraction_error"),
-                    "usage": result.get("usage"),
-                },
-                indent=2,
-                default=str,
-            ),
-            encoding="utf-8",
+        # Persist immediately - both raw_output (empty for this extractor:
+        # AnthropicBackend.complete() sets text="" on the tool-use path, so
+        # this is included for completeness/symmetry with json_object-mode
+        # extractors, not because it holds content here) and
+        # extracted_output (the actual parsed tool result, useful for
+        # debugging a non-"included" outcome) - so an interrupted run keeps
+        # every already-paid-for result.
+        record = {
+            "story_id": path.stem,
+            "outcome": outcome,
+            "llm_call_made": True,
+            "word_count": word_count,
+            "segment_count": len(segments),
+            "raw_output": result.get("raw_output"),
+            "extracted_output": result.get("extracted_output"),
+            "api_error": api_error,
+            "extraction_error": result.get("extraction_error"),
+            "usage": result.get("usage"),
+        }
+        result_path.write_text(
+            json.dumps(record, indent=2, default=str), encoding="utf-8"
         )
         print(f"[{i}/{len(files)}] {path.stem}: {outcome} ({len(segments)} segments)")
 
-    total = sum(counts.values())
-    excluded = total - counts["included"]
-    print(f"\nLLM calls made: {total} (1 per story)")
-    print(f"Exclusion rate: {excluded}/{total} ({excluded / total:.0%})")
-    print("  baseline was: 11/17 (65%) with claude-haiku-4-5-20251001")
-    print("Breakdown by cause:")
+        if api_error and api_error.get("should_abort_batch"):
+            print(
+                f"\nfatal: {path.name}: {api_error.get('message', api_error)}",
+                file=sys.stderr,
+            )
+            print(
+                "Aborting - this looks like a bad/expired API key or an "
+                "exhausted account balance/quota, not a per-story problem. "
+                "Every remaining story would fail identically, and "
+                "reporting them as 'excluded' would misrepresent an "
+                "account problem as a segmentation reliability finding. "
+                "Results gathered so far are still persisted under "
+                f"{output_dir}/.",
+                file=sys.stderr,
+            )
+            break
+
+    print(f"\nStories sampled: {len(files)}")
+    print(f"LLM calls made: {llm_calls_made}")
+    if llm_calls_made:
+        # Exclusion rate's denominator is stories that actually reached an
+        # extraction attempt - story_json_error/empty_story_body are
+        # file-level problems, not segmentation-reliability signal, and
+        # would otherwise silently understate the rate (or divide by zero
+        # if every sampled file were unreadable).
+        denom = llm_calls_made
+        excluded_of_attempted = denom - counts["included"]
+        print(
+            f"Exclusion rate (of {denom} stories that reached extraction): "
+            f"{excluded_of_attempted}/{denom} ({excluded_of_attempted / denom:.0%})"
+        )
+        print("  baseline was: 11/17 (65%) with claude-haiku-4-5-20251001")
+    else:
+        print("Exclusion rate: n/a (no story reached an extraction attempt)")
+    if word_counts:
+        print(
+            f"Cohort word counts: median={statistics.median(word_counts):,.0f} "
+            f"min={min(word_counts):,} max={max(word_counts):,} "
+            f"(n={len(word_counts)}) - see ABOUT THE COHORT before trusting "
+            "a rate change alone"
+        )
+    print("Breakdown by outcome (all sampled stories, including non-LLM skips):")
     for cause, n in counts.most_common():
         print(f"  {n:>3}  {cause}")
-    print(f"\nPer-story output (incl. raw LLM output): {output_dir}/")
+    print(f"\nPer-story output (incl. raw/extracted LLM output): {output_dir}/")
     return 0
 
 

--- a/experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py
+++ b/experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py
@@ -1,0 +1,158 @@
+"""Measure Stage-1 segmentation reliability only (WI-EVENT-0033 verification).
+
+WHY THIS EXISTS, AND WHY IT ISN'T run_pilot.py
+----------------------------------------------
+WI-EVENT-0033's acceptance criterion asks whether schema-hardening
+`scene_analysis.make_segment_extractor` reduced the segmentation exclusion
+rate observed live during WI-EVENT-0030 dogfooding (11 of 17 sampled
+stories, 65%, with `--model claude-haiku-4-5-20251001`).
+
+That is a *Stage-1* metric, and `run_pilot.run_story()` early-returns on a
+segmentation failure before ever entering the Event-Role-World pipeline
+(`run_pilot.py`'s `return row, []` in its `if seg_error or not segments:`
+branch). So the measurement needs exactly ONE LLM call per story - roughly
+20 calls total - whereas a `run_pilot.py --sample-size 5` run costs several
+hundred (1 genre-detect call per candidate scanned, plus 1 segmentation +
+4-per-segment + 1 story-level call per sampled story).
+
+`run_pilot.py` is also currently frozen pending the pipelining work: it
+accumulates all results in memory and writes only after its whole per-story
+loop finishes, so a crash (or Ctrl-C, which is not an `Exception` subclass
+and so escapes its catch-all) discards every already-paid-for result. This
+script deliberately avoids all of that: it writes each story's outcome,
+including the raw LLM output, to its own file immediately, so an
+interrupted run keeps everything it already paid for and can be re-run
+over the remainder.
+
+READING THE RESULT
+------------------
+Do NOT compare `parsing_error` counts. On the `tool_schema` path
+`llm_extractor.extract()` sets `parsing_error = None` unconditionally
+("there is no JSON-text parse step"), so a post-fix `parsing_error` rate is
+0% by construction - a tautology, not evidence. This script instead reports
+the *segmentation exclusion rate for any cause*, broken down by cause,
+which is the honest comparison against the 65% baseline.
+
+USAGE
+-----
+Needs a real API key (see `lcats/docs/secrets-setup.md`); costs ~1 LLM call
+per story. Run from the repo root with the conda environment active:
+
+    python experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py \
+        --data-dir corpora --sample-size 20 --model claude-haiku-4-5-20251001 \
+        --output /tmp/segmentation_reliability
+
+`--model` defaults to the baseline's `claude-haiku-4-5-20251001` so the
+comparison is like-for-like; the cheaper model is what exposed the failure.
+`--seed` reuses `run_pilot._iter_candidate_files`'s shuffle convention, so a
+given seed selects a reproducible story set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import random
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2] / "lcats" / "src"))
+
+from lcats.analysis import scene_analysis
+from lcats.analysis import story_analysis
+from lcats.utils.secrets import load_secrets
+
+
+def classify(result: dict, segments: list) -> str:
+    """Return "included", or a short label naming why the story was excluded.
+
+    Prefers the api_error's `category` (which distinguishes rate_limit /
+    server / context_length / truncated_output - the transient-vs-fatal
+    distinction that matters most when reading the result), but falls back
+    to `code` when category is "unknown", since that is what an
+    empty_tool_result reports and "unknown" alone would hide it.
+    """
+    api_error = result.get("api_error")
+    if api_error:
+        category = api_error.get("category") or "unknown"
+        label = api_error.get("code") if category == "unknown" else category
+        return f"api_error:{label or 'unknown'}"
+    if result.get("extraction_error"):
+        return f"extraction_error:{result['extraction_error']}"
+    if not segments:
+        return "no_segments"
+    return "included"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--data-dir", default="corpora")
+    parser.add_argument("--sample-size", type=int, default=20)
+    parser.add_argument("--model", default="claude-haiku-4-5-20251001")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output", default="/tmp/segmentation_reliability")
+    args = parser.parse_args()
+
+    load_secrets()
+    from lcats.llm import anthropic_backend
+
+    output_dir = pathlib.Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = sorted(pathlib.Path(args.data_dir).rglob("*.json"))
+    random.Random(args.seed).shuffle(files)
+    files = files[: args.sample_size]
+    if not files:
+        print(f"error: no stories found under {args.data_dir}", file=sys.stderr)
+        return 1
+
+    extractor = scene_analysis.make_segment_extractor(
+        anthropic_backend.AnthropicBackend()
+    )
+    counts: collections.Counter = collections.Counter()
+
+    for i, path in enumerate(files, 1):
+        body = story_analysis.coerce_text(
+            json.loads(path.read_text("utf-8")).get("body", "")
+        )
+        result = extractor.extract(body, model_name=args.model)
+        segments = result.get("extracted_output") or []
+        outcome = classify(result, segments)
+        counts[outcome] += 1
+        # Persist immediately, including the raw LLM output, so an
+        # interrupted run keeps every already-paid-for result.
+        (output_dir / f"{path.stem}.json").write_text(
+            json.dumps(
+                {
+                    "story_id": path.stem,
+                    "outcome": outcome,
+                    "segment_count": len(segments),
+                    "llm_output": result.get("extracted_output"),
+                    "api_error": result.get("api_error"),
+                    "extraction_error": result.get("extraction_error"),
+                    "usage": result.get("usage"),
+                },
+                indent=2,
+                default=str,
+            ),
+            encoding="utf-8",
+        )
+        print(f"[{i}/{len(files)}] {path.stem}: {outcome} ({len(segments)} segments)")
+
+    total = sum(counts.values())
+    excluded = total - counts["included"]
+    print(f"\nLLM calls made: {total} (1 per story)")
+    print(f"Exclusion rate: {excluded}/{total} ({excluded / total:.0%})")
+    print("  baseline was: 11/17 (65%) with claude-haiku-4-5-20251001")
+    print("Breakdown by cause:")
+    for cause, n in counts.most_common():
+        print(f"  {n:>3}  {cause}")
+    print(f"\nPer-story output (incl. raw LLM output): {output_dir}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lcats/project/executions/AD_HOC/2026_07_29_20_12_36_SEGMENTATION_RELIABILITY_CHECK_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_29_20_12_36_SEGMENTATION_RELIABILITY_CHECK_REVIEW.md
@@ -1,0 +1,90 @@
+---
+execution_id: 2026_07_29_20_12_36_SEGMENTATION_RELIABILITY_CHECK_REVIEW
+prompt_id: PROMPT(AD_HOC:SEGMENTATION_RELIABILITY_CHECK_REVIEW)[2026-07-29T20:01:53-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/189
+commit: f38e0372
+created_at: 2026-07-29T20:12:36-04:00
+---
+
+# Summary
+
+Address 6 review comments on PR #189 (`check_segmentation_reliability.py`,
+the Stage-1-only segmentation verification script for WI-EVENT-0033).
+Applying fixes directly rather than through `/lrh-review-response`, per
+its own "specific, minimal changes" recommendation for a small, focused
+script.
+
+# Result
+
+Six review comments (`chatgpt-codex-connector`), all confirmed valid
+against the actual code before fixing:
+
+1. **P1 - cohort mismatch**: the baseline (11/17, 65%) came from
+   `run_pilot.py`'s genre-detected, stratified `build_stratified_sample()`,
+   not a shuffle over all of `corpora/`, and the baseline's exact story
+   list was never persisted anywhere in this repo (confirmed: no
+   `pilot_stories.jsonl` survives from any real run). Fixed with a
+   `--story-list FILE` flag accepting an explicit cohort (one path per
+   line, `#`-comments/blank lines ignored), plus always reporting the
+   sampled cohort's word-count distribution (median/min/max) so a rate
+   change can be sanity-checked against cohort skew. The docstring now
+   documents this limitation honestly under a new "ABOUT THE COHORT"
+   section rather than implying a strictly controlled comparison.
+2. **P2 - no actual resume**: re-running overwrote every file. Fixed:
+   each story's output file is checked first; if present, its cached
+   outcome is reused and no `extract()` call is made.
+3. **P2 - no abort on batch-fatal errors**: a bad API key would have been
+   classified per-story and the run would continue, reporting a
+   misleading 100% exclusion rate. Fixed: checks
+   `api_error.get("should_abort_batch")` after each call and stops
+   immediately, matching `run_pilot.py`'s `FatalPilotError` pattern.
+4. **Unguarded file I/O**: malformed JSON would raise and kill the run;
+   an empty body would still make a paid call. Fixed: both cases are
+   caught before `extract()` is called and recorded as distinct outcomes
+   (`story_json_error`, `empty_story_body`).
+5. **Wrong exclusion-rate denominator**: `sum(counts)` included the new
+   non-LLM outcomes from fix #4, understating the rate (or dividing by
+   zero if every file were unreadable). Fixed: a separate
+   `llm_calls_made` counter is the denominator; the full outcome
+   breakdown (including non-LLM skips) is still reported for
+   transparency.
+6. **Misdescribed persisted output**: the file claimed to hold "raw LLM
+   output" under an `llm_output` key, but that value was actually
+   `extracted_output`; `raw_output` is a distinct field that is an empty
+   string for every call this script makes (confirmed:
+   `AnthropicBackend.complete()` sets `text=""` on the tool-use path -
+   `llm_extractor.py:349`, `anthropic_backend.py:105`). Fixed: persists
+   both `raw_output` and `extracted_output` under their real names, with
+   a code comment explaining why `raw_output` is empty here.
+
+# Validation
+
+- Manual `file:line` verification of all 6 claims against
+  `llm_extractor.py`/`anthropic_backend.py`/`run_pilot.py` before
+  applying any fix (see Result above).
+- A fresh zero-cost fake-backend harness (not reusing the earlier vet
+  harness, which wipes its output dir and would defeat a resume test)
+  exercising: fresh run persists `raw_output`/`extracted_output`/
+  `llm_call_made`/`word_count`; a second run against the same `--output`
+  makes zero new calls (resume); an auth-shaped exception on the 3rd of
+  6 stories (via a real raised exception through `extract()`'s own
+  `_normalize_api_error`/`_classify_api_error` path, not a mocked
+  `should_abort_batch` value) stops the run after exactly 3 calls/files;
+  a malformed-JSON file and an empty-body file both produce a distinct
+  outcome with zero `extract()` calls, alongside one real call for a
+  valid file - all assertions passed.
+- Verified `--story-list` parses an explicit file list, skipping
+  comment/blank lines.
+- `black --check --diff` / `ruff check` on the file - clean.
+- `scripts/test` (from `lcats/`) - full suite, 1505 passed (unaffected,
+  confirms no regression elsewhere).
+- `lrh validate` (from `lcats/`) - 0 errors.
+
+# Follow-up
+
+None beyond PR #189's own original follow-up (this script needs a real
+API key to actually run; the WI-EVENT-0033 acceptance criterion is still
+pending that live run).


### PR DESCRIPTION
## Summary

Adds `experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py` — a Stage-1-only measurement script that verifies WI-EVENT-0033's remaining acceptance criterion **without running the frozen `run_pilot.py`**.

## Why this and not `run_pilot.py`

The 65% figure is a **segmentation-stage** metric (`audit:240-245`: *"11 of 17 sampled stories (65%) were excluded with `extraction_error="parsing_error"`"*, attributed to `make_segment_extractor`). And `run_story()` **early-returns on segmentation failure before entering the ERW pipeline** (`run_pilot.py`'s `return row, []` in its `if seg_error or not segments:` branch).

So the measurement needs **1 LLM call per story (~20 total)**, versus several hundred for `run_pilot.py --sample-size 5` (1 genre-detect call per candidate scanned, plus 1 segmentation + 4-per-segment + 1 story-level per sampled story).

`run_pilot.py` is separately frozen pending the pipelining work: it accumulates results in memory and writes only after its whole per-story loop finishes, so a crash — or Ctrl-C, which is not an `Exception` subclass and escapes its catch-all — discards every already-paid-for result. This script writes each story's outcome, **including the raw LLM output and token usage**, to its own file immediately.

## Two design points worth reviewer attention

1. **The reported metric is deliberately *not* the one the WI names.** On the `tool_schema` path `llm_extractor.extract()` sets `parsing_error = None` unconditionally (*"there is no JSON-text parse step"*), so a post-fix `parsing_error` rate is **0% by construction** — a tautology, not evidence. The script reports the segmentation exclusion rate for **any** cause, broken down by cause. **WI-EVENT-0033's criterion wording should be corrected to match** (not done in this PR).
2. **`classify()` prefers `category` but falls back to `code`.** `category` distinguishes `rate_limit`/`server`/`context_length`/`truncated_output`, but reports `"unknown"` for an `empty_tool_result` — which `code` names precisely. Without the fallback, the most likely failure mode would be labelled uninformatively.

## Verification (zero API cost)

Vetted end-to-end with a fake-backend harness driving the script's real `main()` against the real `corpora/` tree — three scenarios:

| Scenario | Result |
|---|---|
| Mixed success/failure, 6 stories | ✅ exit 0; 6 per-story files; raw `llm_output` persisted; correct rate + breakdown |
| Generic backend exception mid-run | ✅ absorbed by `extract()` into `api_error`, run continues, all 6 files written |
| **Ctrl-C after 3 stories** | ✅ **3 files survive** — every already-paid-for call preserved. `run_pilot.py` would have written **0**. |

Also: `scripts/test` 1505 passed, `scripts/lint` clean, `black`/`ruff` clean on the new file, `lrh validate` 0 errors.

## Notes for the reviewer

- **It came out at 109 lines of code (158 with docstrings), not the ~40 I estimated.** The logic is compact; `black`'s expansion of the persisted-JSON literal plus two explanatory docstrings account for most of the difference. I judged both docstrings worth keeping — they record the two subtleties above — but happy to trim if you disagree.
- **No test file added.** This is explicitly an interim tool to be removed once the pipelining work lands, so I didn't want to expand scope; the harness above covers `classify()`'s branches. Say the word if you'd rather it were committed as a real test.
- **Requires a real API key to run** — I can't execute it here, so the actual number will need to come from you.

Run command (also in the module docstring):

```bash
python experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py --data-dir corpora --sample-size 20 --model claude-haiku-4-5-20251001 --output /tmp/segmentation_reliability
```
