### PR TITLE
Adopt PROP-LCATS-PIPELINE-CHECKPOINTING

### DIFF
--- a/lcats/project/design/proposals/README.md
+++ b/lcats/project/design/proposals/README.md
@@ -6,11 +6,11 @@ short index plus the proposal document.
 
 ## Current proposal sets
 
-- [`PROP-LCATS-EVENT-ROLE-WORLD-EXTRACTOR`](proposed/lcats-event-role-world-extractor/README.md)
-  — proposed; implementation not started.
+- [`PROP-LCATS-EVENT-ROLE-WORLD-EXTRACTOR`](adopted/lcats-event-role-world-extractor/README.md)
+  — adopted; implemented (`WI-EVENT-0024`/`0025`/`0026`/`0027`).
 - [`PROP-LCATS-PYPI-RELEASE-READINESS`](proposed/lcats-pypi-release-readiness/README.md)
   — proposed; implementation partial (`WI-RELEASE-0038` delivered,
   `WI-RELEASE-0037`/`WI-RELEASE-0039` open).
-- [`PROP-LCATS-PIPELINE-CHECKPOINTING`](proposed/lcats-pipeline-checkpointing/README.md)
-  — proposed; implementation not started.
+- [`PROP-LCATS-PIPELINE-CHECKPOINTING`](adopted/lcats-pipeline-checkpointing/README.md)
+  — adopted; implementation not started (governed by `WS-PIPELINE-CHECKPOINTING`).
 

--- a/lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
+++ b/lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
@@ -2,7 +2,7 @@
 id: PROP-LCATS-PIPELINE-CHECKPOINTING
 type: design_proposal
 title: Staged, Checkpointed Pipeline Execution for LCATS Batch Scripts
-status: proposed
+status: adopted
 created_on: 2026-07-30
 updated_on: 2026-07-30
 implementation_status: not_started

--- a/lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/README.md
+++ b/lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/README.md
@@ -1,7 +1,7 @@
 ---
 id: PROP-LCATS-PIPELINE-CHECKPOINTING
 type: design_proposal_set
-status: proposed
+status: adopted
 implementation_status: not_started
 ---
 
@@ -20,5 +20,4 @@ meaning a crash or interruption discards every already-paid-for LLM call.
   decisions (checkpoint publication, staleness/identity, granularity,
   adoption path), non-goals, and implementation plan.
 
-No governing workstream exists yet; the Implementation Plan recommends
-`/lrh-workstream` once this proposal is adopted.
+Governed by [`WS-PIPELINE-CHECKPOINTING`](../../../workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md).

--- a/lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/README.md
+++ b/lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/README.md
@@ -20,4 +20,4 @@ meaning a crash or interruption discards every already-paid-for LLM call.
   decisions (checkpoint publication, staleness/identity, granularity,
   adoption path), non-goals, and implementation plan.
 
-Governed by [`WS-PIPELINE-CHECKPOINTING`](../../../workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md).
+Governed by [`WS-PIPELINE-CHECKPOINTING`](../../../../workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md).

--- a/lcats/project/executions/AD_HOC/2026_07_30_02_00_11_ADOPT_PIPELINE_CHECKPOINTING_PROPOSAL_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_30_02_00_11_ADOPT_PIPELINE_CHECKPOINTING_PROPOSAL_REVIEW.md
@@ -1,0 +1,66 @@
+---
+execution_id: 2026_07_30_02_00_11_ADOPT_PIPELINE_CHECKPOINTING_PROPOSAL_REVIEW
+prompt_id: PROMPT(AD_HOC:ADOPT_PIPELINE_CHECKPOINTING_PROPOSAL_REVIEW)[2026-07-30T02:00:01-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of:
+pr: https://github.com/xenotaur/LCATS/pull/192
+commit:
+agent: claude_app
+instruction_source: user request in-session ("Save the memory and move the proposal status to adopted.", followed by "Let's land PR 192 via ## Land an Open PR to Closeout")
+session_transcript: pending
+created_at: 2026-07-30T02:00:11-04:00
+---
+
+# Summary
+
+**POST-HOC BACKFILL, reconstructed at review-response time — not a
+fabricated instruction-phase record.** PR #192 (moving
+`PROP-LCATS-PIPELINE-CHECKPOINTING` from `proposed/` to `adopted/`) was
+authored directly in-session in response to an explicit user instruction,
+without first minting a prompt ID — the same recurring gap already
+documented in `feedback_planning_skills_no_execution_record.md` for
+authored-in-conversation control-plane edits. This record covers both
+the original adoption edit and this round's review-comment fix.
+
+# Result
+
+- `PROP-LCATS-PIPELINE-CHECKPOINTING` moved `proposed/` → `adopted/`,
+  `status: adopted` set in both `00_proposal.md` and its `README.md`
+  index; the README's closing note updated to point at its now-existing
+  governing workstream (`WS-PIPELINE-CHECKPOINTING`, PR #191) instead of
+  recommending `/lrh-workstream`.
+- Fixed the resulting stale `related_design` path and "not yet formally
+  adopted" wording in `WS-PIPELINE-CHECKPOINTING.md`.
+- Also fixed two pre-existing staleness bugs noticed in
+  `project/design/proposals/README.md` while touching this file: the
+  event-role-world-extractor entry still linked `proposed/` though that
+  proposal moved to `adopted/` earlier, and the pipeline-checkpointing
+  entry needed the same path fix.
+- Review landed with 1 comment (`chatgpt-codex-connector`, P2): the new
+  governing-workstream link in `lcats-pipeline-checkpointing/README.md`
+  used `../../../workstreams/...`, which resolves to the nonexistent
+  `project/design/workstreams/...` — confirmed directly with `ls` from
+  the file's own directory (3 levels fails, 4 levels resolves). Fixed to
+  `../../../../workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md`.
+- While verifying this, confirmed the sibling
+  `lcats-pypi-release-readiness/README.md` has the exact same off-by-one
+  bug in its own `WS-RELEASE` link (same directory depth, same missing
+  `../` level) — out of scope for this PR's diff, flagged as a separate
+  follow-up task rather than fixed here.
+
+CHAIN-NOTE: cycles=1; stops=0; gates=[merge]; friction=no primary record was minted for the original adoption edit, requiring this backfill (planning-skills-no-execution-record gap extends to direct in-conversation control-plane edits, not just skill invocations); note="verifying the reviewer's relative-path finding with a real ls, rather than counting `../` by eye, is what caught the identical pre-existing bug in a sibling file"
+
+# Validation
+
+- `lrh validate` (from `lcats/`) — 0 errors, 47 warnings (unchanged
+  baseline; planning-only markdown, no source code changed).
+- Relative-path fix verified directly with `ls` from the file's own
+  directory, not just by counting `../` segments.
+
+# Follow-up
+
+- Separate follow-up task flagged: fix the identical relative-path bug
+  in `lcats-pypi-release-readiness/README.md`'s `WS-RELEASE` link.
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after the session ends.

--- a/lcats/project/workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md
+++ b/lcats/project/workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md
@@ -10,7 +10,7 @@ related_focus:
   - FOCUS-WORLDCON-2026
 related_roadmap: []
 related_design:
-  - lcats/project/design/proposals/proposed/lcats-pipeline-checkpointing/00_proposal.md
+  - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
   - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
   - lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
 work_items: []
@@ -25,19 +25,15 @@ exit_criteria:
 
 ## Purpose
 
-This workstream will deliver `PROP-LCATS-PIPELINE-CHECKPOINTING`
-(`lcats/project/design/proposals/proposed/lcats-pipeline-checkpointing/00_proposal.md`),
-drafted and confirmed this session in response to `run_pilot.py`'s
-measured failure against 8 operational criteria (3 real runs, ~$50, zero
-surviving artifacts; no bounded small-scale trial). The proposal's own
-`status` is still `proposed`, not yet formally `adopted` — this
-workstream exists as the recommended follow-on the proposal's own
-Implementation Plan calls for, and its scoping is contingent on that
-proposal's adoption completing before implementation work items are
-picked up. It coordinates building a shared, reusable checkpoint
-pattern — not a `run_pilot.py`-only patch — and migrating `run_pilot.py`
-onto it, then re-vetting the migrated script before any further real,
-paid run is attempted.
+This workstream delivers `PROP-LCATS-PIPELINE-CHECKPOINTING`
+(`lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md`),
+drafted, confirmed, and adopted this session in response to
+`run_pilot.py`'s measured failure against 8 operational criteria (3 real
+runs, ~$50, zero surviving artifacts; no bounded small-scale trial). It
+coordinates building a shared, reusable checkpoint pattern — not a
+`run_pilot.py`-only patch — and migrating `run_pilot.py` onto it, then
+re-vetting the migrated script before any further real, paid run is
+attempted.
 
 ## Scope
 
@@ -79,9 +75,8 @@ paid run is attempted.
 - Work items: `WI-EVENT-0032` and `WI-EVENT-0033` both explicitly defer
   Category E (checkpointing/logging) as "independent and schedulable
   separately" — this workstream is exactly that follow-on.
-- Proposals: `PROP-LCATS-PIPELINE-CHECKPOINTING` (drafted and confirmed
-  this session; still `status: proposed`) requests this workstream
-  directly in its own Implementation Plan.
+- Proposals: `PROP-LCATS-PIPELINE-CHECKPOINTING` (adopted this session)
+  requests this workstream directly in its own Implementation Plan.
 - Backlog: No matching entries (no `project/design/backlog.md` exists).
 - Recommendation: Proceed.
 


### PR DESCRIPTION
## Summary
- Adopts `PROP-LCATS-PIPELINE-CHECKPOINTING`: moves it from `proposed/` to `adopted/`, sets `status: adopted` in both the proposal and its README index.
- Updates the README to point at its now-existing governing workstream (`WS-PIPELINE-CHECKPOINTING`, PR #191) instead of recommending `/lrh-workstream`.
- Fixes the resulting stale `related_design` path in `WS-PIPELINE-CHECKPOINTING.md` and its "not yet formally adopted" wording.
- Also fixes two pre-existing staleness bugs in `project/design/proposals/README.md` noticed while touching this file: the event-role-world-extractor entry still linked `proposed/` though that proposal moved to `adopted/` earlier, and it was missing a governing-workstream note for pipeline-checkpointing.
- Planning-only — no source code changed.

## Test plan
- [x] `lrh validate` (from `lcats/`) — 0 errors, 47 warnings (unchanged baseline).
- [x] Repo-wide grep confirms no remaining references to the old `proposed/lcats-pipeline-checkpointing` or `proposed/lcats-event-role-world-extractor` paths.
