### PR TITLE
Add work item WI-PIPELINE-0040: Implement shared checkpoint helper for LCATS batch scripts

### DIFF
--- a/lcats/project/executions/WI-PIPELINE-0040/2026_07_30_02_25_08_WI_PIPELINE_0040_REVIEW.md
+++ b/lcats/project/executions/WI-PIPELINE-0040/2026_07_30_02_25_08_WI_PIPELINE_0040_REVIEW.md
@@ -1,0 +1,76 @@
+---
+execution_id: 2026_07_30_02_25_08_WI_PIPELINE_0040_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_PIPELINE_0040_REVIEW)[2026-07-30T02:25:01-04:00]
+work_item: WI-PIPELINE-0040
+status: in_progress
+rerun_of:
+pr: https://github.com/xenotaur/LCATS/pull/193
+commit:
+agent: claude_app
+instruction_source: user request in-session ("Let's create the work items via /lrh-work-item", confirmed both drafts, "Let's land PR 193 via ## Land an Open PR to Closeout")
+session_transcript: pending
+created_at: 2026-07-30T02:25:08-04:00
+---
+
+# Summary
+
+**POST-HOC BACKFILL, reconstructed at review-response time — not a
+fabricated instruction-phase record.** `WI-PIPELINE-0040` (shared
+checkpoint helper for LCATS batch scripts) was authored and PR #193
+opened directly through the `/lrh-work-item` skill, which mints no
+execution record of its own — the same recurring gap already documented
+for `/lrh-workstream` and `/lrh-proposal`. This record covers both the
+original work-item authorship and this round's review-comment fixes.
+
+The work item delivers the first of `PROP-LCATS-PIPELINE-CHECKPOINTING`'s
+two Implementation Plan items: a shared, reusable checkpoint helper
+generalizing `DataGatherer.download`'s bucket-directory pattern, with
+atomic publication (Decision 1) and a success/failure-plus-configuration-
+identity predicate (Decision 2).
+
+# Result
+
+- `WI-PIPELINE-0040.md` drafted and confirmed by the user, covering:
+  prior-art check, scope, required changes, non-goals, acceptance
+  criteria, validation, risk notes, and dependency ordering relative to
+  the planned `WI-PIPELINE-0041`.
+- Registered in `WS-PIPELINE-CHECKPOINTING`'s `work_items:` list and
+  Work Items section.
+- Review landed with 2 comments (`copilot-pull-request-reviewer` and
+  `chatgpt-codex-connector`, both P2/unlabeled), both valid and fixed:
+  - copilot: the workstream's Work Items prose named `WI-PIPELINE-0041`
+    even though that file doesn't exist in this PR's own diff (it's
+    being created in a separate, stacked PR, #195) — inconsistent with
+    how other workstreams here only reference created WI IDs. Fixed by
+    removing the specific ID from this PR's copy of the workstream,
+    describing the second item generically instead ("a second work item
+    is expected next... not yet assigned an ID").
+  - codex (P2): the acceptance criteria required every checkpoint to
+    always record a fingerprint with "at minimum model name and a
+    version/hash," while the Non-Goals said the API must let a caller
+    omit a fingerprint field as a deliberate choice — a genuine internal
+    contradiction (an implementor couldn't tell whether fingerprint-free
+    checkpoints are valid). Fixed by clarifying the actual intended
+    design: the API requires an explicit fingerprint *argument* on every
+    call (never a silent default), but its contents are caller-defined,
+    and a caller may pass an empty/no-op fingerprint as an explicit,
+    visible opt-out — with defined resume semantics for that case (the
+    mismatch check never invalidates that caller's checkpoints, since
+    there's nothing to compare).
+
+CHAIN-NOTE: cycles=1; stops=0; gates=[merge]; friction=no primary record was minted for the original /lrh-work-item authorship, requiring this backfill (planning-skills-no-execution-record gap, now confirmed for all three planning skills across 6+ instances); note="the fingerprint self-contradiction was a genuine design gap I introduced by writing the acceptance criteria and non-goals from two different mental models (mandatory field vs. deliberate omission) without cross-checking them against each other — same underlying failure class as feedback_own_planning_docs_need_code_verification, just applied to internal document consistency rather than external code claims"
+
+# Validation
+
+- `lrh validate` (from `lcats/`) — 0 errors, 49 warnings (unchanged
+  baseline + 2 expected `owner: unassigned` warnings for the new WI;
+  planning-only markdown, no source code changed).
+
+# Follow-up
+
+- `WI-PIPELINE-0041` (stacked PR #195) still needs to add itself to
+  `WS-PIPELINE-CHECKPOINTING`'s `work_items:` list and Work Items
+  section once it lands, per the review finding fixed here — that
+  registration already exists in #195's own commits.
+- `session_transcript: pending` should be updated to `claude-app:<session-id>`
+  after the session ends.

--- a/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
+++ b/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
@@ -1,0 +1,158 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-PIPELINE-0040
+title: Implement shared checkpoint helper for LCATS batch scripts
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-PIPELINE-CHECKPOINTING
+related_design:
+  - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - create_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - implement_new_architecture
+  - modify_run_pilot_script
+acceptance:
+  - A shared checkpoint helper module exists (lcats/src/lcats/utils/checkpoint.py) providing a per-item/per-stage checkpoint API generalizing DataGatherer.download's bucket-directory + file-existence pattern
+  - Checkpoint publication is atomic: writes go to a temp path in the same directory and are moved into place via os.replace/Path.replace only after the write completes, per Decision 1
+  - Any checkpoint file that fails to parse (I/O error, JSON error) is treated as incomplete, never as done and never as a hard failure that aborts the caller, per Decision 1
+  - The checkpoint predicate distinguishes success from recorded failure (not bare file presence), per Decision 2
+  - Each checkpoint records a configuration-identity fingerprint (at minimum model name and a version/hash of the relevant prompt template or tool schema) alongside its outcome, and a fingerprint mismatch on resume is treated as if the checkpoint did not exist, per Decision 2
+  - The helper's API supports per-stage granularity (independent checkpoints for distinct pipeline stages within a single run), per Decision 3
+  - New unit tests cover atomic publication under simulated interruption, the success/failure predicate, and fingerprint mismatch invalidation
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/src/lcats/utils/checkpoint.py
+  - lcats/tests/utils_tests/checkpoint_test.py
+---
+
+## Summary
+
+Implement a shared, reusable checkpoint helper for LCATS's LLM-driven
+batch scripts, generalizing `DataGatherer.download`'s existing
+bucket-directory + file-existence pattern with atomic publication,
+a success/failure-plus-configuration-identity predicate, and per-stage
+granularity — the shared building block `PROP-LCATS-PIPELINE-CHECKPOINTING`
+calls for before any script (starting with `run_pilot.py`, in
+WI-PIPELINE-0041) can be migrated onto it.
+
+## Problem / Context
+
+`run_pilot.py`'s current in-memory-only, write-at-the-end architecture
+discards every already-paid-for LLM call on any crash or interruption —
+measured directly this session (3 real runs, ~$50, zero surviving
+artifacts). `PROP-LCATS-PIPELINE-CHECKPOINTING` (adopted; see
+`related_design`) chose a bucket-directory + file-existence checkpoint
+pattern as the fix, explicitly as a shared helper rather than a
+`run_pilot.py`-only patch, since LCATS has multiple other pipeline-like
+processes that would otherwise keep the same fragility. This item
+delivers exactly that helper, with the two hardening requirements review
+added to the proposal: atomic publication (Decision 1) and a
+success/failure-plus-configuration-identity checkpoint predicate
+(Decision 2).
+
+### Duplication search
+- In-repo: No existing implementation. `lcats/src/lcats/pipeline.py` is a
+  documented, tested module but has no disk persistence of any kind (see
+  the proposal's own Prior Art Check) — not something to extend as-is.
+  `DataGatherer.download` (`lcats/src/lcats/gatherers/downloaders.py:223-253`)
+  is the closest existing precedent, but is bucket-specific, not a
+  reusable, importable helper.
+- Sibling repos: None identified.
+- External libraries: Prefect/Dagster/Ray considered and deferred in the
+  governing proposal — not adopted now.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found requesting this specifically (the proposal
+  itself is the request).
+- Proposals: `PROP-LCATS-PIPELINE-CHECKPOINTING`'s own Implementation
+  Plan names this as its first item.
+- Backlog: No matching entries.
+- Recommendation: Proceed.
+
+## Scope
+
+- Implement a shared checkpoint helper module usable by `run_pilot.py`,
+  `check_segmentation_reliability.py`, and future batch scripts alike.
+- Implement Decision 1 (atomic publication) and Decision 2
+  (success/failure predicate plus configuration-identity fingerprint).
+- Support Decision 3's per-stage granularity (the helper's API must let a
+  caller checkpoint multiple distinct stages independently, not only one
+  per-item checkpoint).
+- Unit-test the helper in isolation, with no dependency on `run_pilot.py`
+  or any real LLM backend.
+
+## Required Changes
+
+1. Create `lcats/src/lcats/utils/checkpoint.py` implementing the
+   checkpoint API described above.
+2. Create `lcats/tests/utils_tests/checkpoint_test.py` covering atomic
+   publication (including simulated interruption of the write), the
+   success/failure predicate, and configuration-fingerprint mismatch
+   invalidation.
+
+## Non-Goals
+
+- Does not migrate `run_pilot.py` itself onto the helper — that is
+  WI-PIPELINE-0041.
+- Does not adopt Ray, Dagster, or Prefect — per the proposal's Non-Goals.
+- Does not implement Category E1 (model-invocation logging/budget
+  enforcement) — per the proposal's Non-Goals.
+- Does not decide the exact configuration-fingerprint contents for any
+  specific caller (e.g. `run_pilot.py`'s own model/schema versioning) —
+  the helper's API must make omitting a fingerprint field a deliberate
+  caller choice, not prescribe the contents itself; per-caller fingerprint
+  design is WI-PIPELINE-0041's concern.
+
+## Acceptance Criteria
+
+(see frontmatter `acceptance:` above)
+
+## Validation
+
+- `scripts/version tools`
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+
+## Risk Notes
+
+- Getting the atomic-publication mechanism wrong (e.g. `os.replace`
+  across filesystems, which is not atomic) would silently reintroduce
+  the exact torn-write failure mode this item exists to eliminate —
+  worth an explicit same-filesystem-temp-path test.
+- An overly narrow configuration-fingerprint API (e.g. hardcoding "model
+  name" as the only field) would force WI-PIPELINE-0041 to work around
+  it rather than use it as designed.
+
+## Dependencies / Order
+
+No dependencies — this item should land first, since WI-PIPELINE-0041
+depends on it.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md`
+- Design: `project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md`

--- a/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
+++ b/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
@@ -33,7 +33,8 @@ acceptance:
   - Checkpoint publication is atomic: writes go to a temp path in the same directory and are moved into place via os.replace/Path.replace only after the write completes, per Decision 1
   - Any checkpoint file that fails to parse (I/O error, JSON error) is treated as incomplete, never as done and never as a hard failure that aborts the caller, per Decision 1
   - The checkpoint predicate distinguishes success from recorded failure (not bare file presence), per Decision 2
-  - Each checkpoint records a configuration-identity fingerprint (at minimum model name and a version/hash of the relevant prompt template or tool schema) alongside its outcome, and a fingerprint mismatch on resume is treated as if the checkpoint did not exist, per Decision 2
+  - The helper's checkpoint API requires every caller to explicitly pass a fingerprint argument (no silent default) alongside a checkpoint's outcome, per Decision 2; the exact fingerprint contents are caller-defined (e.g. model name plus a prompt/schema version/hash), and a fingerprint mismatch on resume is treated as if the checkpoint did not exist
+  - A caller that explicitly opts out by passing an empty/no-op fingerprint gets defined, documented resume behavior (the mismatch check never invalidates that caller's checkpoints, since there is nothing to compare) rather than an undefined or silently-broken state
   - The helper's API supports per-stage granularity (independent checkpoints for distinct pipeline stages within a single run), per Decision 3
   - New unit tests cover atomic publication under simulated interruption, the success/failure predicate, and fingerprint mismatch invalidation
   - lrh validate reports 0 errors
@@ -119,11 +120,13 @@ success/failure-plus-configuration-identity checkpoint predicate
 - Does not adopt Ray, Dagster, or Prefect — per the proposal's Non-Goals.
 - Does not implement Category E1 (model-invocation logging/budget
   enforcement) — per the proposal's Non-Goals.
-- Does not decide the exact configuration-fingerprint contents for any
-  specific caller (e.g. `run_pilot.py`'s own model/schema versioning) —
-  the helper's API must make omitting a fingerprint field a deliberate
-  caller choice, not prescribe the contents itself; per-caller fingerprint
-  design is WI-PIPELINE-0041's concern.
+- Does not decide the exact *contents* of any specific caller's
+  fingerprint (e.g. `run_pilot.py`'s own model/schema versioning fields)
+  — the helper's API requires a fingerprint argument on every call (never
+  silently defaulted) but leaves what goes inside it to each caller;
+  per-caller fingerprint design is WI-PIPELINE-0041's concern. A caller
+  may still choose an empty/no-op fingerprint, but that is an explicit,
+  visible argument at the call site, not an omitted parameter.
 
 ## Acceptance Criteria
 

--- a/lcats/project/workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md
+++ b/lcats/project/workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md
@@ -85,9 +85,10 @@ attempted.
 
 - **WI-PIPELINE-0040** — Shared checkpoint helper: implement and
   unit-test the helper described above (Decisions 1, 2, 4).
-- **WI-PIPELINE-0041** — `run_pilot.py` migration + re-vetting (not yet
-  created): migrate the script to use the helper (Decision 3) and
-  re-run this session's 8-criteria vetting against the migrated version.
+- A second work item is expected next: migrate `run_pilot.py` to use the
+  helper (Decision 3) and re-run this session's 8-criteria vetting against
+  the migrated version. Not yet assigned an ID — will be added to this
+  list once its file exists, per convention.
 
 ## Exit Criteria
 

--- a/lcats/project/workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md
+++ b/lcats/project/workstreams/proposed/WS-PIPELINE-CHECKPOINTING.md
@@ -13,7 +13,8 @@ related_design:
   - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
   - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
   - lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
-work_items: []
+work_items:
+  - WI-PIPELINE-0040
 exit_criteria:
   - A shared checkpoint helper exists (location settled during work-item scoping) implementing Decision 1's atomic temp-file + rename publication and Decision 2's success/failure predicate plus configuration-identity fingerprint, with unit tests
   - run_pilot.py is migrated to staged, checkpointed execution per Decision 3's per-stage granularity, with separate checkpointed artifacts for genre-detection, segmentation, ERW-extraction, and cross-segment-relation (not the whole per-story pipeline collapsed into one unit)
@@ -82,14 +83,11 @@ attempted.
 
 ## Work Items
 
-Not yet created. Per the proposal's Implementation Plan, this workstream
-expects two work items once scoped via `/lrh-work-item`:
-
-- **Shared checkpoint helper** — implement and unit-test the helper
-  described above (Decisions 1, 2, 4).
-- **`run_pilot.py` migration + re-vetting** — migrate the script to use
-  the helper (Decision 3) and re-run this session's 8-criteria vetting
-  against the migrated version.
+- **WI-PIPELINE-0040** — Shared checkpoint helper: implement and
+  unit-test the helper described above (Decisions 1, 2, 4).
+- **WI-PIPELINE-0041** — `run_pilot.py` migration + re-vetting (not yet
+  created): migrate the script to use the helper (Decision 3) and
+  re-run this session's 8-criteria vetting against the migrated version.
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary
- Adds `WI-PIPELINE-0040`: implement a shared checkpoint helper for LCATS's LLM-driven batch scripts, generalizing `DataGatherer.download`'s bucket-directory + file-existence pattern with atomic publication and a success/failure-plus-configuration-identity predicate.
- First of two work items delivering `PROP-LCATS-PIPELINE-CHECKPOINTING` (adopted, PR #192), scoped under `WS-PIPELINE-CHECKPOINTING` (PR #191).
- Registers `WI-PIPELINE-0040` in the workstream's `work_items:` list and Work Items section.
- Planning-only — no source code changed.

## Test plan
- [x] `lrh validate` (from `lcats/`) — 0 errors, 49 warnings (baseline 47 + 2 expected `owner: unassigned` warnings, consistent with other proposed WIs).
