### PR TITLE
Fix off-by-one relative path to WS-RELEASE workstream

### DIFF
--- a/lcats/project/design/proposals/proposed/lcats-pypi-release-readiness/README.md
+++ b/lcats/project/design/proposals/proposed/lcats-pypi-release-readiness/README.md
@@ -18,4 +18,4 @@ verification step.
 - [`00_proposal.md`](00_proposal.md) — background, PyPI upload-validation
   grounding, design decisions, non-goals, and implementation plan.
 
-Governed by [`WS-RELEASE`](../../../workstreams/proposed/WS-RELEASE.md).
+Governed by [`WS-RELEASE`](../../../../workstreams/proposed/WS-RELEASE.md).


### PR DESCRIPTION
## Summary
- Fix an off-by-one relative-path bug in `lcats-pypi-release-readiness/README.md`'s link to `WS-RELEASE.md`
- From `lcats/project/design/proposals/proposed/lcats-pypi-release-readiness/`, the file needs 4 levels of `../` to reach `lcats/project/workstreams/proposed/WS-RELEASE.md`, not 3
- Same class of bug chatgpt-codex-connector caught in PR #192's sibling file (`lcats-pipeline-checkpointing/README.md`)

## Test plan
- [x] Verified with `ls` from the file's directory: 3 `../` fails, 4 `../` resolves
- [x] `lrh validate` from `lcats/`: 0 errors (47 pre-existing warnings unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
