### PR TITLE
Add workstream WS-STORY-BUCKET-LAYOUT: Per-Story Bucket Directory Layout Migration for LCATS Corpus Storage

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_30_14_28_49_WS_STORY_BUCKET_LAYOUT.md
+++ b/lcats/project/executions/AD_HOC/2026_07_30_14_28_49_WS_STORY_BUCKET_LAYOUT.md
@@ -1,0 +1,52 @@
+---
+execution_id: 2026_07_30_14_28_49_WS_STORY_BUCKET_LAYOUT
+prompt_id: PROMPT(AD_HOC:WS_STORY_BUCKET_LAYOUT)[2026-07-30T14:06:20-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/197
+commit: b8ba3490
+created_at: 2026-07-30T14:28:49-04:00
+agent: claude_app
+instruction_source: lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Created `WS-STORY-BUCKET-LAYOUT`, the workstream coordinating the 3-stage
+implementation of `PROP-LCATS-STORY-BUCKET-LAYOUT` (merged via PR #196),
+following this session's design and review work on the underlying
+proposal.
+
+# Result
+
+- Wrote `lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md` with
+  frontmatter and full body (Purpose, Scope, Prior Art Check, Work Items,
+  Exit Criteria, Non-Goals, Open Questions), mirroring the sibling
+  `WS-PIPELINE-CHECKPOINTING` workstream's structure and depth.
+- Scope tracks the proposal's 3 stages verbatim: read-path compatibility
+  (Decisions 2-3), write-path migration (Decisions 5-8, including the
+  review-discovered `parser.gather_story()` writer site and the standing
+  `lcats promote` zero-story-count rejection), and convergence-and-validation
+  (Decision 4's two-part retraction gating).
+- `work_items: []` — none created yet; offered as a follow-on per the
+  skill's Step 11.
+- `related_focus: [FOCUS-WORLDCON-2026]` — LCATS's only active focus
+  ("story analysis pipeline foundations"), genuinely thematically connected
+  (corpus storage foundations), not invented for the sake of a non-empty
+  field.
+- Non-Goals explicitly cross-reference the proposal's four excluded
+  follow-ons (gather incrementality, notebook fixes, experiment fixes,
+  librarize-and-test investigation) so none get silently assumed in-scope.
+
+# Validation
+
+- `lrh validate` -> 0 errors, 51 pre-existing warnings (unrelated
+  `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS` items; none
+  reference the new workstream).
+
+# Follow-up
+
+- Offer to create the 3 stage work items via `/lrh-work-item` once this
+  workstream PR is confirmed/merged.

--- a/lcats/project/executions/AD_HOC/2026_07_30_14_55_05_WS_STORY_BUCKET_LAYOUT_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_30_14_55_05_WS_STORY_BUCKET_LAYOUT_REVIEW.md
@@ -1,0 +1,49 @@
+---
+execution_id: 2026_07_30_14_55_05_WS_STORY_BUCKET_LAYOUT_REVIEW
+prompt_id: PROMPT(AD_HOC:WS_STORY_BUCKET_LAYOUT_REVIEW)[2026-07-30T14:52:07-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_30_14_28_49_WS_STORY_BUCKET_LAYOUT
+pr: https://github.com/xenotaur/LCATS/pull/197
+commit: 17d0663d
+created_at: 2026-07-30T14:55:05-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/197
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Addressed 2 open review comments on `WS-STORY-BUCKET-LAYOUT`'s workstream
+PR — both root-caused to the same underlying YAML bug, verified before
+applying.
+
+# Result
+
+- **Copilot:** flagged that unquoted `exit_criteria` entries containing
+  `: ` parse as single-key mappings, not plain strings.
+- **Codex (P1):** flagged that the unquoted `summary` field (containing
+  "stages: read-path") makes the frontmatter fail to parse entirely
+  (`yaml.safe_load` -> `ScannerError: mapping values are not allowed
+  here`), plus the same issue on 3 `exit_criteria` lines.
+- Verified directly with `yaml.safe_load()` before and after: the
+  unpatched file threw a hard `ScannerError`; the patched file parses
+  cleanly with `summary` as `str` and all 5 `exit_criteria` items as
+  plain strings (previously would have silently become dict-typed list
+  items for the 3 affected entries).
+- Fix: quoted `summary` and the 3 affected `exit_criteria` items
+  (`Stage 1 ... lands: ...`, `Stage 2 ... lands: ...`, `Stage 3 ... lands:
+  ...`) in double quotes. The 2 unaffected items (no embedded colon) were
+  left as plain scalars.
+
+# Validation
+
+- `python3 -c "import yaml; yaml.safe_load(...)"` — parse error before,
+  clean parse (correct types) after.
+- `lrh validate` -> 0 errors, 51 pre-existing warnings (unchanged from
+  before this fix; none reference this file).
+
+# Follow-up
+
+- None — both threads were Clear-satisfied by the same fix; no partial or
+  ambiguous findings remained.

--- a/lcats/project/executions/AD_HOC/2026_07_30_15_09_41_WS_STORY_BUCKET_LAYOUT_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_30_15_09_41_WS_STORY_BUCKET_LAYOUT_CONFIRM.md
@@ -1,0 +1,44 @@
+---
+execution_id: 2026_07_30_15_09_41_WS_STORY_BUCKET_LAYOUT_CONFIRM
+prompt_id: PROMPT(AD_HOC:WS_STORY_BUCKET_LAYOUT_CONFIRM)[2026-07-30T15:00:17-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_30_14_28_49_WS_STORY_BUCKET_LAYOUT
+pr: https://github.com/xenotaur/LCATS/pull/197
+commit: 0d6264df
+created_at: 2026-07-30T15:09:41-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/197
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge fresh-eyes verification of `WS-STORY-BUCKET-LAYOUT`'s workstream
+PR against the current `HEAD` diff, independent of the review-response
+run's own claims.
+
+# Result
+
+- Fetched `gh pr diff` directly and confirmed both fixes independently:
+  `summary` field quoted, all 3 affected `exit_criteria` lines quoted.
+  Both threads classified **Clear-satisfied**.
+- Both authors (`copilot-pull-request-reviewer`, `chatgpt-codex-connector`)
+  are known bots, pre-selected; user declined `--subagent`, proceeded with
+  inline classification.
+- Resolved both threads via `resolveReviewThread`: `PRRT_kwDOKlhIbM6VNFzr`,
+  `PRRT_kwDOKlhIbM6VNGHY` — both confirmed `isResolved: true`.
+- **Thread-resolution verdict: green** (2/2 resolved, 0 exceptions).
+
+# Validation
+
+- CI: all checks green (`coverage`, `lint`, `test` x2) on the provisional
+  read; this repo confirmed to have no required-status-check branch
+  protection (established earlier this session). Final CI re-check against
+  the post-push `HEAD` happens in this run's readiness report, after this
+  record is pushed.
+
+# Follow-up
+
+- None — both surfaced findings were addressed and independently verified;
+  no Unaddressed/Partial/Ambiguous/Problematic threads remained.

--- a/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
+++ b/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
@@ -5,7 +5,7 @@ title: Per-Story Bucket Directory Layout Migration for LCATS Corpus Storage
 status: proposed
 stage: designed
 origin: design_review
-summary: Deliver PROP-LCATS-STORY-BUCKET-LAYOUT's staged expand-contract migration from flat per-collection story files to per-story bucket directories, across three stages: read-path compatibility, write-path migration, and convergence-and-validation.
+summary: "Deliver PROP-LCATS-STORY-BUCKET-LAYOUT's staged expand-contract migration from flat per-collection story files to per-story bucket directories, across three stages: read-path compatibility, write-path migration, and convergence-and-validation."
 related_focus:
   - FOCUS-WORLDCON-2026
 related_roadmap: []
@@ -15,9 +15,9 @@ related_design:
   - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
 work_items: []
 exit_criteria:
-  - Stage 1 (read-path compatibility) lands: discovery/identity logic is dual-layout-tolerant (Decisions 2-3), with a canonical story-file selector and dual-layout tests, writer output unchanged
-  - Stage 2 (write-path migration) lands: DataGatherer.ensure and parser.gather_story() both write <collection>/<story>/story.json (Decision 8); overrides story_id derivation fixed (Decision 7); output identifier semantics updated with new story_dir/story_slug column (Decision 5); lcats promote itself rejects zero-story-count collections (Decision 6)
-  - Stage 3 convergence work lands: tests/fixtures/docs normalized to the new layout, with an explicit end-to-end gather-then-promote validation pass confirmed
+  - "Stage 1 (read-path compatibility) lands: discovery/identity logic is dual-layout-tolerant (Decisions 2-3), with a canonical story-file selector and dual-layout tests, writer output unchanged"
+  - "Stage 2 (write-path migration) lands: DataGatherer.ensure and parser.gather_story() both write <collection>/<story>/story.json (Decision 8); overrides story_id derivation fixed (Decision 7); output identifier semantics updated with new story_dir/story_slug column (Decision 5); lcats promote itself rejects zero-story-count collections (Decision 6)"
+  - "Stage 3 convergence work lands: tests/fixtures/docs normalized to the new layout, with an explicit end-to-end gather-then-promote validation pass confirmed"
   - Dual-layout retraction (Decision 4) lands as its own follow-up, only after the tracked corpora/ snapshot is confirmed migrated via a separate gather-then-promote action
   - All work items resolved and lrh validate reports 0 errors
 ---

--- a/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
+++ b/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
@@ -1,0 +1,134 @@
+---
+id: WS-STORY-BUCKET-LAYOUT
+kind: planning_node
+title: Per-Story Bucket Directory Layout Migration for LCATS Corpus Storage
+status: proposed
+stage: designed
+origin: design_review
+summary: Deliver PROP-LCATS-STORY-BUCKET-LAYOUT's staged expand-contract migration from flat per-collection story files to per-story bucket directories, across three stages: read-path compatibility, write-path migration, and convergence-and-validation.
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_design:
+  - lcats/project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md
+  - lcats/project/design/flat_story_layout_migration_impact_report.md
+  - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
+work_items: []
+exit_criteria:
+  - Stage 1 (read-path compatibility) lands: discovery/identity logic is dual-layout-tolerant (Decisions 2-3), with a canonical story-file selector and dual-layout tests, writer output unchanged
+  - Stage 2 (write-path migration) lands: DataGatherer.ensure and parser.gather_story() both write <collection>/<story>/story.json (Decision 8); overrides story_id derivation fixed (Decision 7); output identifier semantics updated with new story_dir/story_slug column (Decision 5); lcats promote itself rejects zero-story-count collections (Decision 6)
+  - Stage 3 convergence work lands: tests/fixtures/docs normalized to the new layout, with an explicit end-to-end gather-then-promote validation pass confirmed
+  - Dual-layout retraction (Decision 4) lands as its own follow-up, only after the tracked corpora/ snapshot is confirmed migrated via a separate gather-then-promote action
+  - All work items resolved and lrh validate reports 0 errors
+---
+
+# Workstream: Per-Story Bucket Directory Layout Migration for LCATS Corpus Storage
+
+## Purpose
+
+This workstream delivers `PROP-LCATS-STORY-BUCKET-LAYOUT`
+(`lcats/project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md`),
+a staged expand-contract migration from LCATS's flat per-collection story
+storage (`data/<collection>/<story>.json`) to per-story bucket directories
+(`data/<collection>/<story>/story.json`). It coordinates the three
+implementation stages the proposal defines, and tracks the
+review-discovered fixes (the mass-quantities writer site, the
+gather-overrides identity site, and standing promotion validation) through
+to closeout.
+
+## Scope
+
+- Stage 1 — Read-path compatibility: dual-layout-tolerant discovery/identity
+  logic, a canonical story-file selector, dual-layout tests
+  (Decisions 2-3).
+- Stage 2 — Write-path migration: `DataGatherer.ensure` and
+  `parser.gather_story()` (Decision 8) both migrate to the bucket layout;
+  overrides `story_id` fix (Decision 7); output identifier semantics
+  (Decision 5); standing zero-story-count rejection in `lcats promote`
+  (Decision 6).
+- Stage 3 — Convergence and validation: tests/fixtures/docs normalized to
+  the new layout; explicit end-to-end gather-then-promote validation pass;
+  dual-layout retraction as a distinct, separately-gated follow-up
+  (Decision 4).
+- Land each work item through the standard LRH execution lifecycle
+  (`/lrh-implement` → `/lrh-review-response` → `/lrh-confirm-fixes` →
+  `/lrh-closeout`).
+
+## Prior Art Check
+
+### Duplication search
+- In-repo: No existing implementation. `PROP-LCATS-STORY-BUCKET-LAYOUT`
+  itself already ran this search in full — no code implements the
+  migration; `flat_story_layout_migration_impact_report.md` is the audit
+  that motivated it.
+- Sibling repos: None identified.
+- External libraries: None applicable — internal storage-layout
+  convention. Approach follows Martin Fowler's Parallel Change
+  (expand-contract) pattern, per the proposal.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found in `project/work_items/proposed/` referencing
+  this migration.
+- Proposals: `PROP-LCATS-STORY-BUCKET-LAYOUT` requests this workstream
+  directly — its own Implementation Plan recommends a workstream given its
+  3-stage, multi-PR scope.
+- Backlog: No `project/design/backlog.md` exists in this repo.
+- Recommendation: Proceed.
+
+## Work Items
+
+- **Stage 1 work item** (not yet created) — Make story discovery/identity
+  dual-layout-compatible: canonical story-file selector, dual-layout
+  tests, no writer changes yet (Decisions 2-3).
+- **Stage 2 work item** (not yet created) — Migrate write paths to the
+  bucket layout: `DataGatherer.ensure` and `parser.gather_story()`
+  (Decision 8, the mass-quantities collection's writer, found during
+  proposal review); fix the overrides `story_id` derivation (Decision 7);
+  update output identifier semantics (Decision 5); add standing
+  zero-story-count rejection to `lcats promote` (Decision 6).
+- **Stage 3 work item** (not yet created) — Convergence: normalize
+  tests/fixtures/docs to the new layout, run an explicit end-to-end
+  gather-then-promote validation pass, and land dual-layout retraction
+  (Decision 4) as its own follow-up once the tracked `corpora/` snapshot
+  is confirmed migrated.
+
+None yet have `WI-*` IDs — offered as a follow-on after this workstream is
+created.
+
+## Exit Criteria
+
+(see frontmatter `exit_criteria:` above)
+
+## Non-Goals
+
+- Does not implement `lcats gather` incremental/restartable checkpointing —
+  `PROP-LCATS-PIPELINE-CHECKPOINTING`'s own deferred, separately-scoped
+  future work.
+- Does not fix hardcoded flat-layout paths in
+  `lcats/notebooks/12_extract_scenes.ipynb` and `13_clean_corpus.ipynb` —
+  a needed, lower-urgency follow-on, scoped separately.
+- Does not fix the non-recursive glob bugs in
+  `experiments/02_llm_backend_comparison/run_comparison.py` and
+  `smoke_test.py`, or the stem-collision output-naming bug in
+  `experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py` —
+  real bugs, more pressing than the notebooks (silent failure mode), but
+  still a separate follow-on so they're fixed once against the final
+  layout.
+- Does not decide whether `notebooks/` and `experiments/` implementation
+  code should be librarized into the installable package with unit test
+  coverage — a separate, larger architecture question.
+- Does not perform the actual production `lcats gather` + `lcats promote`
+  run migrating real corpus content — a release-time human action, not a
+  workstream deliverable.
+
+## Open Questions
+
+- Exact `story_dir`/`story_slug` column name and TSV schema version-bump
+  policy — deferred to Stage 2 work-item scoping.
+- Whether the overrides file format itself should key by directory slug or
+  whether Decision 7's call-site fix is sufficient — deferred to Stage 2
+  work-item scoping.
+- Relative priority and timing between the deferred `experiments/` fix and
+  `notebooks/` fix — deferred to future scoping, after this workstream
+  lands.


### PR DESCRIPTION
## Summary

Adds `WS-STORY-BUCKET-LAYOUT`, the workstream delivering
`PROP-LCATS-STORY-BUCKET-LAYOUT`'s staged expand-contract migration from
flat per-collection story files (`data/<collection>/<story>.json`) to
per-story bucket directories (`data/<collection>/<story>/story.json`).

- Coordinates the proposal's 3 stages: read-path compatibility, write-path
  migration, and convergence-and-validation.
- Carries the two review-discovered fixes from PR #196 forward as explicit
  exit criteria: the `parser.gather_story()` mass-quantities writer site
  (Decision 8) and standing zero-story-count rejection in `lcats promote`
  (Decision 6).
- Non-Goals explicitly exclude and cross-reference the proposal's four
  related-but-separate follow-ons (gather incrementality, notebook fixes,
  experiment fixes, librarize-and-test investigation).

## Status

`status: proposed`, `stage: designed`, `work_items: []` — no work items
created yet; offered as a follow-on once this workstream is confirmed.

## Traceability

Prompt ID: `PROMPT(AD_HOC:WS_STORY_BUCKET_LAYOUT)[2026-07-30T14:06:20-04:00]`

## Test plan

- [x] `lrh validate` — 0 errors, 51 pre-existing warnings unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
