### PR TITLE
Add work item WI-STORY-0042: Make LCATS story discovery and identity dual-layout-compatible

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_30_16_37_28_WI_STORY_0042.md
+++ b/lcats/project/executions/AD_HOC/2026_07_30_16_37_28_WI_STORY_0042.md
@@ -1,0 +1,47 @@
+---
+execution_id: 2026_07_30_16_37_28_WI_STORY_0042
+prompt_id: PROMPT(AD_HOC:WI_STORY_0042)[2026-07-30T16:26:21-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/198
+commit: 7ec2da50
+created_at: 2026-07-30T16:37:28-04:00
+agent: claude_app
+instruction_source: lcats/project/work_items/proposed/WI-STORY-0042.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Created `WI-STORY-0042`, the Stage 1 (read-path compatibility) work item
+for `WS-STORY-BUCKET-LAYOUT`, per the workstream's own Work Items section.
+
+# Result
+
+- Wrote `lcats/project/work_items/proposed/WI-STORY-0042.md` with
+  frontmatter and full body (Summary, Problem/Context with prior-art
+  verdicts, Scope, Required Changes, Non-Goals, Acceptance Criteria,
+  Validation, Risk Notes, Dependencies/Order, Related Workstream and
+  Designs), mirroring sibling `WI-PIPELINE-0040`'s structure and depth.
+- ID `WI-STORY-0042` chosen per the shared cross-prefix numbering
+  convention (global max across all WI prefixes was `0041`,
+  `WI-PIPELINE-0041`).
+- No dependencies; scoped as the item that should land first, since Stage
+  2 (writer migration) assumes dual-layout-tolerant discovery already
+  exists.
+- `related_workstreams: [WS-STORY-BUCKET-LAYOUT]` — not yet added to the
+  workstream's own `work_items:` list; offered as a follow-on per the
+  skill's Step 11.
+
+# Validation
+
+- `lrh validate` -> 0 errors, 53 warnings (2 new, both the standard
+  `OWNER_ROLE_INSUFFICIENT`/`OWNER_NOT_IN_CONTRIBUTORS` pattern already
+  present on every other `owner: unassigned` work item in this repo).
+
+# Follow-up
+
+- Offer to update `WS-STORY-BUCKET-LAYOUT`'s `work_items:` list to include
+  `WI-STORY-0042` (Step 11).
+- Stage 2 and Stage 3 work items still to be created.

--- a/lcats/project/executions/AD_HOC/2026_07_31_03_31_43_WI_STORY_0042_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_03_31_43_WI_STORY_0042_REVIEW.md
@@ -1,0 +1,60 @@
+---
+execution_id: 2026_07_31_03_31_43_WI_STORY_0042_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_STORY_0042_REVIEW)[2026-07-31T03:28:46+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_30_16_37_28_WI_STORY_0042
+pr: https://github.com/xenotaur/LCATS/pull/198
+commit: ff4e9eb1
+created_at: 2026-07-31T03:31:43+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/198
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Addressed 3 open review comments (all `chatgpt-codex-connector`) on
+`WI-STORY-0042`'s work-item PR, each verified against actual repo state
+before applying.
+
+# Result
+
+- **(P1) Preserve flat files in the discovery criterion** — confirmed the
+  WI's acceptance criterion wording ("canonical-filename predicate (story.json
+  only)") was ambiguous enough that a literal implementation would exclude
+  every current flat `<story>.json` file during Stage 1, since writers
+  remain unchanged and flat files must stay discoverable. Reworded the
+  acceptance criterion, Required Changes item, and Scope to state
+  explicitly: `story.json` is required only for files nested inside a
+  bucket directory; flat files at the collection root remain eligible
+  as-is.
+- **(P2) Include JsonDataset in the selector rollout** — confirmed via code
+  read: `lcats/src/lcats/datasets/torchdata.py:20-23`'s `JsonDataset` does
+  `os.walk` + `endswith(".json")`, recursively accepting every JSON file —
+  named in the original impact report (item #3) but missing from both the
+  proposal's key-sites list and this WI's scope. Added it as a 4th site
+  alongside `Corpora.get_corpora`, `find_json_files`, and
+  `infer_story_title` in Scope, Required Changes, acceptance, and
+  `artifacts_expected`.
+- **(P2) Register the new item in its workstream and index** — **partial**:
+  confirmed the workstream `work_items:` half was already resolved by a
+  later commit on this same PR (stale by the time of review); the
+  `project/work_items/README.md` "Proposed Items" registration half was
+  real and still missing. Added `WI-STORY-0042` to that list, in the
+  file's existing ascending-numeric-ID order.
+
+# Validation
+
+- `lrh validate` -> 0 errors, 53 warnings (unchanged from before this
+  fix).
+- `scripts/format --check --diff` / `scripts/lint` -> both report a
+  pre-existing tool-version mismatch (Black `25.11.0` pinned vs `26.3.1`
+  installed; Ruff `0.15.0` pinned vs `0.15.12` installed) unrelated to this
+  change, which touches zero Python files. Per `AGENTS.md`'s own guidance,
+  reported as an environment/cache issue, not a code regression.
+
+# Follow-up
+
+- None — all three findings addressed; part of comment 3 was already moot
+  before this run.

--- a/lcats/project/executions/AD_HOC/2026_07_31_03_42_08_WI_STORY_0042_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_03_42_08_WI_STORY_0042_CONFIRM.md
@@ -1,0 +1,43 @@
+---
+execution_id: 2026_07_31_03_42_08_WI_STORY_0042_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_STORY_0042_CONFIRM)[2026-07-31T03:36:32+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_30_16_37_28_WI_STORY_0042
+pr: https://github.com/xenotaur/LCATS/pull/198
+commit: f86ff175
+created_at: 2026-07-31T03:42:08+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/198
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge fresh-eyes verification of `WI-STORY-0042`'s work-item PR
+against the current `HEAD` diff, independent of the review-response run's
+own claims.
+
+# Result
+
+- Fetched `gh pr diff` directly and confirmed all 3 fixes independently:
+  discovery criterion clarified (flat files stay eligible), `JsonDataset`
+  added as a 4th site, `WI-STORY-0042` registered in
+  `project/work_items/README.md`. All 3 threads classified
+  **Clear-satisfied**.
+- All 3 authors are `chatgpt-codex-connector` (known bot), pre-selected;
+  user declined `--subagent`, proceeded with inline classification.
+- Resolved all 3 threads via `resolveReviewThread`:
+  `PRRT_kwDOKlhIbM6VPOgd`, `PRRT_kwDOKlhIbM6VPOgk`,
+  `PRRT_kwDOKlhIbM6VPOgn` — all confirmed `isResolved: true`.
+- **Thread-resolution verdict: green** (3/3 resolved, 0 exceptions).
+
+# Validation
+
+- CI: all green (`lint`, `coverage`, `test` x2) on the provisional read.
+  Final CI re-check against the post-push `HEAD` happens in this run's
+  readiness report, after this record is pushed.
+
+# Follow-up
+
+- None — all 3 findings addressed and independently verified.

--- a/lcats/project/work_items/README.md
+++ b/lcats/project/work_items/README.md
@@ -21,6 +21,7 @@ YAML frontmatter is authoritative for metadata, and directory buckets are kept a
 - `proposed/WI-EVENT-0033.md` — Add schema-hardened structured output to scene/story analysis extractors
 - `proposed/WI-RELEASE-0037.md` — Resolve gutenbergpy VCS-pin PyPI-publish blocker
 - `proposed/WI-RELEASE-0039.md` — Pre-launch verification of the gutenbergpy dependency resolution before real PyPI publish
+- `proposed/WI-STORY-0042.md` — Make LCATS story discovery and identity dual-layout-compatible
 
 ## Abandoned Items
 - `abandoned/WI-META-0006.md` — superseded by native LRH functionality (`lrh meta register`); reversed by WI-META-0023

--- a/lcats/project/work_items/proposed/WI-STORY-0042.md
+++ b/lcats/project/work_items/proposed/WI-STORY-0042.md
@@ -1,0 +1,160 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-STORY-0042
+title: Make LCATS story discovery and identity dual-layout-compatible
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-STORY-BUCKET-LAYOUT
+related_design:
+  - lcats/project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md
+  - lcats/project/design/flat_story_layout_migration_impact_report.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - edit_file
+  - create_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - modify_datagatherer_writer
+  - implement_stage_2
+acceptance:
+  - A canonical story-file selector utility exists, recognizing both a flat <story>.json file and a nested <story>/story.json file as valid story sources
+  - Corpora.get_corpora (lcats/src/lcats/stories.py:51-52) uses the selector instead of raw os.listdir + endswith(".json")
+  - find_json_files/find_corpus_stories (lcats/src/lcats/analysis/corpus/discovery.py:65) applies a canonical-filename predicate (story.json only) while remaining dual-layout tolerant, per Decision 3
+  - infer_story_title (lcats/src/lcats/analysis/corpus/cli.py:53) derives identity from directory slug when present, not raw file_path.stem, per Decision 2
+  - New dual-layout tests cover both flat-file and nested-bucket fixtures for all of the above
+  - No changes to DataGatherer's writer output or any other writer behavior
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/src/lcats/analysis/corpus/discovery.py
+  - lcats/src/lcats/stories.py
+  - lcats/src/lcats/analysis/corpus/cli.py
+  - lcats/tests/stories_test.py
+  - lcats/tests/analysis_tests/corpus_surveyor_test.py
+---
+
+## Summary
+
+Make LCATS's story discovery and identity logic dual-layout-compatible —
+tolerating both the current flat `data/<collection>/<story>.json` layout
+and the future `data/<collection>/<story>/story.json` bucket layout —
+without changing any writer output. Stage 1 of 3 in
+`WS-STORY-BUCKET-LAYOUT`'s staged expand-contract migration.
+
+## Problem / Context
+
+`flat_story_layout_migration_impact_report.md`'s audit and
+`PROP-LCATS-STORY-BUCKET-LAYOUT` found discovery/identity logic hard-coded
+to the flat layout in multiple places, producing collapsed or broken
+identifiers once a bucket layout exists. This item implements Decision 2
+(canonical identity = directory slug, not `file_path.stem`, which collapses
+to the literal string `"story"` once files move to `<story>/story.json`)
+and Decision 3 (discovery predicate = canonical filename `story.json` only,
+not broad `*.json` schema-sniffing).
+
+### Duplication search
+- In-repo: No existing implementation. `WI-OVERRIDES-0018` mentions the
+  bucket layout only as a forward-compatibility note and explicitly
+  excludes implementing the migration itself.
+- Sibling repos: None identified.
+- External libraries: None applicable.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found requesting this specifically —
+  `PROP-LCATS-STORY-BUCKET-LAYOUT` and `WS-STORY-BUCKET-LAYOUT` are the
+  request.
+- Proposals: `PROP-LCATS-STORY-BUCKET-LAYOUT`'s own Implementation Plan
+  names Stage 1 as this item's scope.
+- Backlog: No matching entries.
+- Recommendation: Proceed.
+
+## Scope
+
+- Add a single canonical story-file selector utility, recognizing both
+  flat and nested-bucket story sources.
+- Update `Corpora.get_corpora`, `find_json_files`/`find_corpus_stories`,
+  and `infer_story_title` to use it.
+- Add dual-layout tests for all of the above.
+- Do not touch any writer (`DataGatherer`, `parser.gather_story()`) —
+  that's Stage 2.
+
+## Required Changes
+
+1. Create the canonical story-file selector utility (location TBD during
+   implementation — likely alongside
+   `lcats/src/lcats/analysis/corpus/discovery.py`).
+2. Update `lcats/src/lcats/stories.py:51-52` (`Corpora.get_corpora`) to use
+   the selector instead of raw `os.listdir` + `endswith(".json")`.
+3. Update `lcats/src/lcats/analysis/corpus/discovery.py:65`
+   (`find_json_files`) to apply the canonical-filename predicate while
+   remaining dual-layout tolerant.
+4. Update `lcats/src/lcats/analysis/corpus/cli.py:53`
+   (`infer_story_title`) to derive identity from directory slug when
+   present, not raw `file_path.stem`.
+5. Add dual-layout tests (flat + nested-bucket fixtures) to
+   `lcats/tests/stories_test.py` and
+   `lcats/tests/analysis_tests/corpus_surveyor_test.py`.
+
+## Non-Goals
+
+- Does not change `DataGatherer.ensure` or `parser.gather_story()` writer
+  behavior — Stage 2 (next work item).
+- Does not fix the gather-overrides `story_id` derivation bug — Stage 2,
+  Decision 7.
+- Does not add the `story_dir`/`story_slug` output column — Stage 2,
+  Decision 5.
+- Does not add standing zero-story-count rejection to `lcats promote` —
+  Stage 2, Decision 6.
+- Does not touch tests/fixtures/docs convergence or dual-layout
+  retraction — Stage 3.
+- Does not touch `lcats gather` incrementality, `notebooks/`, or
+  `experiments/` — deferred in the governing proposal's own Non-Goals.
+
+## Acceptance Criteria
+
+(see frontmatter `acceptance:` above)
+
+## Validation
+
+- `scripts/version tools`
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+
+## Risk Notes
+
+- The canonical-filename predicate (Decision 3) must not accidentally
+  exclude legitimate flat-layout stories during the dual-layout window —
+  worth an explicit fixture mixing both layouts in one collection.
+- `infer_story_title`'s directory-slug derivation needs a defined fallback
+  for genuinely flat files (no enclosing story directory) — must not
+  regress current flat-layout title behavior.
+
+## Dependencies / Order
+
+No dependencies — this item should land first; Stage 2 depends on it (the
+writer migration assumes dual-layout-tolerant discovery already exists).
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md`
+- Design: `project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md`

--- a/lcats/project/work_items/proposed/WI-STORY-0042.md
+++ b/lcats/project/work_items/proposed/WI-STORY-0042.md
@@ -33,7 +33,8 @@ forbidden_actions:
 acceptance:
   - A canonical story-file selector utility exists, recognizing both a flat <story>.json file and a nested <story>/story.json file as valid story sources
   - Corpora.get_corpora (lcats/src/lcats/stories.py:51-52) uses the selector instead of raw os.listdir + endswith(".json")
-  - find_json_files/find_corpus_stories (lcats/src/lcats/analysis/corpus/discovery.py:65) applies a canonical-filename predicate (story.json only) while remaining dual-layout tolerant, per Decision 3
+  - find_json_files/find_corpus_stories (lcats/src/lcats/analysis/corpus/discovery.py:65) requires the literal name story.json only for files nested inside a story-bucket directory, while flat <story>.json files at the collection root remain eligible as-is (Stage 1 does not change writers, so flat files must stay discoverable), per Decision 3
+  - JsonDataset (lcats/src/lcats/datasets/torchdata.py) applies the same selector/predicate as discovery.py, so it neither loads non-story JSON sidecars from bucket directories nor regresses flat-file discovery
   - infer_story_title (lcats/src/lcats/analysis/corpus/cli.py:53) derives identity from directory slug when present, not raw file_path.stem, per Decision 2
   - New dual-layout tests cover both flat-file and nested-bucket fixtures for all of the above
   - No changes to DataGatherer's writer output or any other writer behavior
@@ -46,6 +47,7 @@ artifacts_expected:
   - lcats/src/lcats/analysis/corpus/discovery.py
   - lcats/src/lcats/stories.py
   - lcats/src/lcats/analysis/corpus/cli.py
+  - lcats/src/lcats/datasets/torchdata.py
   - lcats/tests/stories_test.py
   - lcats/tests/analysis_tests/corpus_surveyor_test.py
 ---
@@ -91,7 +93,7 @@ not broad `*.json` schema-sniffing).
 - Add a single canonical story-file selector utility, recognizing both
   flat and nested-bucket story sources.
 - Update `Corpora.get_corpora`, `find_json_files`/`find_corpus_stories`,
-  and `infer_story_title` to use it.
+  `infer_story_title`, and `JsonDataset` to use it.
 - Add dual-layout tests for all of the above.
 - Do not touch any writer (`DataGatherer`, `parser.gather_story()`) —
   that's Stage 2.
@@ -104,12 +106,20 @@ not broad `*.json` schema-sniffing).
 2. Update `lcats/src/lcats/stories.py:51-52` (`Corpora.get_corpora`) to use
    the selector instead of raw `os.listdir` + `endswith(".json")`.
 3. Update `lcats/src/lcats/analysis/corpus/discovery.py:65`
-   (`find_json_files`) to apply the canonical-filename predicate while
-   remaining dual-layout tolerant.
-4. Update `lcats/src/lcats/analysis/corpus/cli.py:53`
+   (`find_json_files`) to require the literal name `story.json` only for
+   files nested inside a story-bucket directory, while continuing to
+   accept flat `<story>.json` files at the collection root as-is — Stage 1
+   does not change writers, so flat files must stay discoverable.
+4. Update `lcats/src/lcats/datasets/torchdata.py` (`JsonDataset`, which
+   currently does `os.walk` + `endswith(".json")`, accepting every JSON
+   file under its root) to apply the same selector/predicate as
+   `discovery.py`, so it neither loads non-story JSON sidecars from bucket
+   directories once nested layouts exist, nor regresses flat-file
+   discovery.
+5. Update `lcats/src/lcats/analysis/corpus/cli.py:53`
    (`infer_story_title`) to derive identity from directory slug when
    present, not raw `file_path.stem`.
-5. Add dual-layout tests (flat + nested-bucket fixtures) to
+6. Add dual-layout tests (flat + nested-bucket fixtures) to
    `lcats/tests/stories_test.py` and
    `lcats/tests/analysis_tests/corpus_surveyor_test.py`.
 

--- a/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
+++ b/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
@@ -13,7 +13,8 @@ related_design:
   - lcats/project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md
   - lcats/project/design/flat_story_layout_migration_impact_report.md
   - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
-work_items: []
+work_items:
+  - WI-STORY-0042
 exit_criteria:
   - "Stage 1 (read-path compatibility) lands: discovery/identity logic is dual-layout-tolerant (Decisions 2-3), with a canonical story-file selector and dual-layout tests, writer output unchanged"
   - "Stage 2 (write-path migration) lands: DataGatherer.ensure and parser.gather_story() both write <collection>/<story>/story.json (Decision 8); overrides story_id derivation fixed (Decision 7); output identifier semantics updated with new story_dir/story_slug column (Decision 5); lcats promote itself rejects zero-story-count collections (Decision 6)"
@@ -78,9 +79,9 @@ to closeout.
 
 ## Work Items
 
-- **Stage 1 work item** (not yet created) — Make story discovery/identity
-  dual-layout-compatible: canonical story-file selector, dual-layout
-  tests, no writer changes yet (Decisions 2-3).
+- **WI-STORY-0042** — Make story discovery/identity dual-layout-compatible:
+  canonical story-file selector, dual-layout tests, no writer changes yet
+  (Decisions 2-3).
 - **Stage 2 work item** (not yet created) — Migrate write paths to the
   bucket layout: `DataGatherer.ensure` and `parser.gather_story()`
   (Decision 8, the mass-quantities collection's writer, found during


### PR DESCRIPTION
## Summary

Adds `WI-STORY-0042`, Stage 1 of `WS-STORY-BUCKET-LAYOUT`'s 3-stage
implementation of `PROP-LCATS-STORY-BUCKET-LAYOUT`.

- Makes story discovery and identity dual-layout-compatible (Decisions 2-3):
  a canonical story-file selector, `Corpora.get_corpora` and
  `find_json_files`/`find_corpus_stories` updated to tolerate both layouts,
  `infer_story_title` deriving identity from directory slug instead of
  `file_path.stem`.
- No writer changes — that's Stage 2 (`WI-STORY-0042`'s own Non-Goals list
  it explicitly).

## Status

`status: proposed`, `type: deliverable`, `priority: high`.
`related_workstreams: [WS-STORY-BUCKET-LAYOUT]`. No dependencies — this
item is designed to land first; Stage 2 depends on it.

## Traceability

Prompt ID: `PROMPT(AD_HOC:WI_STORY_0042)[2026-07-30T16:26:21-04:00]`

## Test plan

- [x] `lrh validate` — 0 errors, 53 warnings (2 new, matching the standard `owner: unassigned` pattern on every other work item in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
