### PR TITLE
Add work item WI-STORY-0043: Migrate LCATS story write paths to the bucket layout

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_30_21_34_40_WI_STORY_0043.md
+++ b/lcats/project/executions/AD_HOC/2026_07_30_21_34_40_WI_STORY_0043.md
@@ -1,0 +1,50 @@
+---
+execution_id: 2026_07_30_21_34_40_WI_STORY_0043
+prompt_id: PROMPT(AD_HOC:WI_STORY_0043)[2026-07-30T20:48:46+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/199
+commit: b60b4602
+created_at: 2026-07-30T21:34:40+00:00
+agent: claude_app
+instruction_source: lcats/project/work_items/proposed/WI-STORY-0043.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Created `WI-STORY-0043`, the Stage 2 (write-path migration) work item for
+`WS-STORY-BUCKET-LAYOUT`, per the workstream's own Work Items section.
+
+# Result
+
+- Wrote `lcats/project/work_items/proposed/WI-STORY-0043.md` covering four
+  design decisions: two writer sites (Decision 8, including the
+  mass-quantities `parser.gather_story()` site found during PR #196's
+  review), the overrides `story_id` fix (Decision 7), the output
+  identifier column (Decision 5), and standing zero-story-count rejection
+  in `lcats promote` (Decision 6).
+- `depends_on: [WI-STORY-0042]` — `lrh validate` initially reported
+  `UNKNOWN_DEPENDENCY` because `WI-STORY-0042` only exists on PR #198's
+  branch, not yet on `main`. Resolved by stacking this branch on
+  `xenotaur/feat/wi-story-0042` (this PR's base is #198's branch, not
+  `main`) rather than waiting for #198 to merge first.
+- One transient `lrh validate` failure (`ImportError` from the editable
+  LRH install) on the first run after rebasing — resolved on immediate
+  retry, consistent with another session's concurrent edits to that
+  checkout elsewhere this session; not a code issue in this PR.
+- ID `WI-STORY-0043` follows the shared cross-prefix numbering pool
+  (`WI-STORY-0042` was the prior max).
+
+# Validation
+
+- `lrh validate` -> 0 errors, 55 warnings (2 new, standard
+  `owner: unassigned` pattern already present on every other work item in
+  this repo).
+
+# Follow-up
+
+- This PR's base will need no action once #198 merges — GitHub retargets
+  stacked PRs to the parent's merge target automatically.
+- Stage 3 work item still to be created.

--- a/lcats/project/executions/AD_HOC/2026_07_30_21_34_40_WI_STORY_0043.md
+++ b/lcats/project/executions/AD_HOC/2026_07_30_21_34_40_WI_STORY_0043.md
@@ -4,8 +4,8 @@ prompt_id: PROMPT(AD_HOC:WI_STORY_0043)[2026-07-30T20:48:46+00:00]
 work_item: AD_HOC
 status: in_progress
 rerun_of: 
-pr: https://github.com/xenotaur/LCATS/pull/199
-commit: b60b4602
+pr: https://github.com/xenotaur/LCATS/pull/200
+commit: 50e51e8a
 created_at: 2026-07-30T21:34:40+00:00
 agent: claude_app
 instruction_source: lcats/project/work_items/proposed/WI-STORY-0043.md
@@ -45,6 +45,13 @@ Created `WI-STORY-0043`, the Stage 2 (write-path migration) work item for
 
 # Follow-up
 
-- This PR's base will need no action once #198 merges — GitHub retargets
-  stacked PRs to the parent's merge target automatically.
+- **Correction (2026-07-31):** the claim above ("GitHub retargets stacked
+  PRs to the parent's merge target automatically") was wrong. Deleting the
+  merged base branch `xenotaur/feat/wi-story-0042` closed PR #199 outright
+  (dangling base, not reopenable) rather than retargeting it. No content
+  was lost — the same head branch (`xenotaur/feat/wi-story-0043`) was
+  re-opened as **PR #200** against `main` directly; `pr:`/`commit:` above
+  updated accordingly. See
+  `feedback_stacked_pr_base_branch_deletion_closes_not_retargets.md` in
+  session memory.
 - Stage 3 work item still to be created.

--- a/lcats/project/executions/AD_HOC/2026_07_31_04_26_37_WI_STORY_0043_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_04_26_37_WI_STORY_0043_REVIEW.md
@@ -1,0 +1,54 @@
+---
+execution_id: 2026_07_31_04_26_37_WI_STORY_0043_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_STORY_0043_REVIEW)[2026-07-31T04:23:20+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_30_21_34_40_WI_STORY_0043
+pr: https://github.com/xenotaur/LCATS/pull/200
+commit: 36d91ee1
+created_at: 2026-07-31T04:26:37+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/200
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Addressed 3 open review comments (2 Copilot, 1 Codex P2) on
+`WI-STORY-0043`'s work-item PR, each verified against actual repo state
+before applying. Caught and corrected a local process slip mid-run: was
+still on the Stage 3 branch from the prior turn when first checking file
+state, which would have produced findings against the wrong branch —
+switched branches before verifying, not after.
+
+# Result
+
+- **(Copilot) Vague `artifacts_expected`** — replaced the bare `lcats/tests`
+  directory entry with 4 concrete files: 3 confirmed existing
+  (`downloaders_test.py`, `parser_test.py`, `promote_test.py`) plus a new
+  `output_test.py` (no dedicated test file currently exists for
+  `output.py`, and this WI adds new functionality to it).
+- **(Copilot) Self-contradicting workstream sentence** — `WS-STORY-BUCKET-LAYOUT.md`
+  said "None yet have `WI-*` IDs" directly below two bullets that already
+  had IDs. Fixed the same way already done on PR #201's (Stage 3's)
+  branch: changed the Stage 3 bullet to `**WI-STORY-0044**` and removed
+  the trailing sentence — this makes the file converge to match what #201
+  already has, once #200 lands.
+- **(Codex, P2) Unresolved output schema decision** — verified against
+  `lcats/src/lcats/analysis/corpus/output.py:12-31`: `TSV_COLUMNS` is an
+  explicit ordered list (currently ending in `story_identifier`, with
+  `story_file`/`path` already commented out of it). Committed to a real
+  decision instead of the prior alternation: column name **`story_dir`**,
+  appended to the *end* of `TSV_COLUMNS` (preserves existing column
+  positions for positional consumers), and **no formal schema-version
+  field** — an explicit decision, not a deferral, since this is a bounded
+  append-only addition to an ad hoc TSV.
+
+# Validation
+
+- `lrh validate` -> 0 errors, 55 warnings (unchanged from before this
+  fix).
+
+# Follow-up
+
+- None — all 3 findings addressed and grounded in actual code/file state.

--- a/lcats/project/executions/AD_HOC/2026_07_31_04_39_44_WI_STORY_0043_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_04_39_44_WI_STORY_0043_CONFIRM.md
@@ -1,0 +1,42 @@
+---
+execution_id: 2026_07_31_04_39_44_WI_STORY_0043_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_STORY_0043_CONFIRM)[2026-07-31T04:31:32+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_30_21_34_40_WI_STORY_0043
+pr: https://github.com/xenotaur/LCATS/pull/200
+commit: 3eed933a
+created_at: 2026-07-31T04:39:44+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/200
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge fresh-eyes verification of `WI-STORY-0043`'s work-item PR
+against the current `HEAD` diff, independent of the review-response run's
+own claims.
+
+# Result
+
+- Fetched `gh pr diff` directly and confirmed all 3 fixes independently:
+  concrete test file paths, workstream self-contradiction fixed, `story_dir`
+  committed to consistently with an explicit no-schema-version decision.
+  All 3 threads classified **Clear-satisfied**.
+- Authors `copilot-pull-request-reviewer` and `chatgpt-codex-connector`
+  are known bots, pre-selected; user proceeded with inline classification.
+- Resolved all 3 threads via `resolveReviewThread`:
+  `PRRT_kwDOKlhIbM6VUCMd`, `PRRT_kwDOKlhIbM6VUCM9`,
+  `PRRT_kwDOKlhIbM6VUCUm` — all confirmed `isResolved: true`.
+- **Thread-resolution verdict: green** (3/3 resolved, 0 exceptions).
+
+# Validation
+
+- CI: all green (`coverage`, `lint`, `test` x2) on the provisional read.
+  Final CI re-check against the post-push `HEAD` happens in this run's
+  readiness report, after this record is pushed.
+
+# Follow-up
+
+- None — all 3 findings addressed and independently verified.

--- a/lcats/project/work_items/proposed/WI-STORY-0043.md
+++ b/lcats/project/work_items/proposed/WI-STORY-0043.md
@@ -1,0 +1,181 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-STORY-0043
+title: Migrate LCATS story write paths to the bucket layout
+type: deliverable
+status: proposed
+priority: high
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-STORY-BUCKET-LAYOUT
+related_design:
+  - lcats/project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md
+  - lcats/docs/reference/gather-overrides.md
+  - lcats/docs/reference/corpus-promotion.md
+depends_on:
+  - WI-STORY-0042
+blocked_by: []
+expected_actions:
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - implement_stage_3
+  - run_real_gather_or_promote
+acceptance:
+  - DataGatherer.ensure (lcats/src/lcats/gatherers/downloaders.py:216) writes <collection>/<story>/story.json
+  - parser.gather_story() (lcats/src/lcats/gatherers/parser.py:1468-1476) writes the same bucket layout for the mass-quantities collection, with its own tests updated
+  - The overrides story_id derivation (downloaders.py:249) uses the canonical story name (directory slug), not a re-derivation from the new leaf filename, so per-story overrides no longer collapse onto one key
+  - output.py gains a new story_dir/story_slug column with a concrete, documented name; story_file/story_identifier semantics are not silently repurposed
+  - promote.py's survey_collection/promote_collections reject a story_count==0 collection as a standing, always-on check (not a one-time step)
+  - New/updated tests cover all of the above
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/src/lcats/gatherers/downloaders.py
+  - lcats/src/lcats/gatherers/parser.py
+  - lcats/src/lcats/analysis/corpus/output.py
+  - lcats/src/lcats/analysis/corpus/promote.py
+  - lcats/tests
+---
+
+## Summary
+
+Migrate LCATS's story write paths to the per-story bucket layout
+(`<collection>/<story>/story.json`), fix the gather-overrides
+identity-collapse bug, update output identifier semantics, and add
+standing zero-story-count rejection to `lcats promote`. Stage 2 of 3 in
+`WS-STORY-BUCKET-LAYOUT`.
+
+## Problem / Context
+
+This implements four of `PROP-LCATS-STORY-BUCKET-LAYOUT`'s design
+decisions. **Decision 8** (two writer sites, not one): `DataGatherer.ensure`
+(`downloaders.py:216`) is the primary writer, but `parser.gather_story()`
+(`parser.py:1468-1476`) independently constructs and writes to a flat path
+for the mass-quantities/single-stories collection (via
+`mass_quantities/gatherer.py:40-54`) — found during proposal PR review
+(PR #196) by `chatgpt-codex-connector`. **Decision 7**: the gather-time
+overrides mechanism keys per-story fixes by filename stem
+(`gather-overrides.md`), derived at `downloaders.py:249` as
+`story_id=os.path.splitext(filename)[0]` — must thread the canonical story
+name through instead of re-deriving it post-migration. **Decision 5**:
+`output.py:105-106`/`180-184` use `file_path.name`/`story_file` for
+identity, non-unique post-migration — needs a new column. **Decision 6**:
+`promote.py:56-59`'s `CollectionSurveyResult.clean` treats a zero-story
+collection as clean, letting `_copy_collection` copy it wholesale — needs a
+standing rejection, not a one-time check.
+
+### Duplication search
+- In-repo: No existing implementation of any of these four fixes.
+- Sibling repos: None identified.
+- External libraries: None applicable.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found — `PROP-LCATS-STORY-BUCKET-LAYOUT` and
+  `WS-STORY-BUCKET-LAYOUT` are the request; Decision 8 specifically
+  originates from PR #196's review.
+- Proposals: `PROP-LCATS-STORY-BUCKET-LAYOUT`'s Implementation Plan names
+  Stage 2 as this item's scope.
+- Backlog: No matching entries.
+- Recommendation: Proceed.
+
+## Scope
+
+- Migrate both writer sites (`DataGatherer.ensure`, `parser.gather_story()`)
+  to the bucket layout.
+- Fix the overrides `story_id` derivation.
+- Add the `story_dir`/`story_slug` output column.
+- Add standing zero-story-count rejection to `lcats promote`.
+- Update/add tests for all of the above.
+- Assumes Stage 1's dual-layout-tolerant discovery (`WI-STORY-0042`)
+  already exists.
+
+## Required Changes
+
+1. Migrate `DataGatherer.ensure` (`downloaders.py:216`) to write
+   `<collection>/<story>/story.json`.
+2. Migrate `parser.gather_story()` (`parser.py:1468-1476`) to the same
+   bucket layout; update its own tests (mass-quantities collection).
+3. Fix the `story_id` derivation at `downloaders.py:249` to use the
+   canonical story name (directory slug), not a re-derivation from the new
+   leaf filename.
+4. Add a `story_dir`/`story_slug` column to `output.py`'s TSV/human output
+   schema; keep `story_file` for the literal leaf filename (now low-value
+   but non-breaking).
+5. Add zero-story-count rejection to `promote.py`'s
+   `survey_collection`/`promote_collections` as a standing, always-on
+   check.
+6. Add/update tests for all of the above.
+
+## Non-Goals
+
+- Does not touch Stage 1's read-path/discovery work (already done,
+  `WI-STORY-0042`).
+- Does not touch tests/fixtures/docs convergence or dual-layout
+  retraction — Stage 3.
+- Does not perform the actual production `lcats gather` + `lcats promote`
+  run migrating real corpus content — a separate, release-time human
+  action.
+- Does not touch `lcats gather` incrementality/checkpointing,
+  `notebooks/`, or `experiments/` — deferred in the governing proposal's
+  own Non-Goals.
+- Does not finalize the `story_dir`/`story_slug` column name or TSV schema
+  version-bump policy beyond what's needed to ship Decision 5 — the
+  proposal's Open Questions defer full bikeshedding, but this item must
+  pick and document a concrete name.
+- Does not change the overrides *file format* itself (directory-slug
+  keying vs. filename-stem keying) — a call-site fix per Decision 7, not a
+  schema change to `lcats/gatherers/overrides/<collection>.json`.
+
+## Acceptance Criteria
+
+(see frontmatter `acceptance:` above)
+
+## Validation
+
+- `scripts/version tools`
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
+
+## Risk Notes
+
+- Two writer sites (not one) means a partial fix — migrating only
+  `DataGatherer.ensure` — would leave the mass-quantities collection
+  silently producing flat files that Stage 3's canonical-only discovery
+  then omits, exactly as PR #196's review found.
+- The `story_id` fix must thread the canonical name through, not re-derive
+  it — a re-derivation bug here is easy to reintroduce accidentally in a
+  refactor, since it's the same shape as the already-fixed Decision 2 bug
+  from Stage 1.
+- `promote.py`'s standing zero-story check must not itself become the
+  layout-drift point — verify it triggers on a collection with genuinely
+  zero canonical stories, not one merely mid-migration.
+
+## Dependencies / Order
+
+Depends on `WI-STORY-0042` (Stage 1) — writer migration assumes
+dual-layout-tolerant discovery already exists, so this item should not
+start implementation before Stage 1 lands.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md`
+- Design: `project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md`
+- Reference: `lcats/docs/reference/gather-overrides.md`,
+  `lcats/docs/reference/corpus-promotion.md`

--- a/lcats/project/work_items/proposed/WI-STORY-0043.md
+++ b/lcats/project/work_items/proposed/WI-STORY-0043.md
@@ -35,7 +35,7 @@ acceptance:
   - DataGatherer.ensure (lcats/src/lcats/gatherers/downloaders.py:216) writes <collection>/<story>/story.json
   - parser.gather_story() (lcats/src/lcats/gatherers/parser.py:1468-1476) writes the same bucket layout for the mass-quantities collection, with its own tests updated
   - The overrides story_id derivation (downloaders.py:249) uses the canonical story name (directory slug), not a re-derivation from the new leaf filename, so per-story overrides no longer collapse onto one key
-  - output.py gains a new story_dir/story_slug column with a concrete, documented name; story_file/story_identifier semantics are not silently repurposed
+  - output.py gains a new story_dir column, appended to the end of TSV_COLUMNS (preserving existing column positions for positional consumers); story_file/story_identifier semantics are not silently repurposed; no formal schema-version field is introduced (explicit decision, not deferred)
   - promote.py's survey_collection/promote_collections reject a story_count==0 collection as a standing, always-on check (not a one-time step)
   - New/updated tests cover all of the above
   - lrh validate reports 0 errors
@@ -48,7 +48,10 @@ artifacts_expected:
   - lcats/src/lcats/gatherers/parser.py
   - lcats/src/lcats/analysis/corpus/output.py
   - lcats/src/lcats/analysis/corpus/promote.py
-  - lcats/tests
+  - lcats/tests/gatherers_tests/downloaders_test.py
+  - lcats/tests/gatherers_tests/parser_test.py
+  - lcats/tests/analysis_tests/promote_test.py
+  - lcats/tests/analysis_tests/output_test.py
 ---
 
 ## Summary
@@ -98,7 +101,7 @@ standing rejection, not a one-time check.
 - Migrate both writer sites (`DataGatherer.ensure`, `parser.gather_story()`)
   to the bucket layout.
 - Fix the overrides `story_id` derivation.
-- Add the `story_dir`/`story_slug` output column.
+- Add the `story_dir` output column.
 - Add standing zero-story-count rejection to `lcats promote`.
 - Update/add tests for all of the above.
 - Assumes Stage 1's dual-layout-tolerant discovery (`WI-STORY-0042`)
@@ -113,9 +116,13 @@ standing rejection, not a one-time check.
 3. Fix the `story_id` derivation at `downloaders.py:249` to use the
    canonical story name (directory slug), not a re-derivation from the new
    leaf filename.
-4. Add a `story_dir`/`story_slug` column to `output.py`'s TSV/human output
-   schema; keep `story_file` for the literal leaf filename (now low-value
-   but non-breaking).
+4. Add a `story_dir` column, appended to the end of `output.py`'s
+   `TSV_COLUMNS` list — appending (not inserting) preserves existing
+   column positions for any positional TSV consumer; only a consumer
+   requiring an exact total column count needs updating. Keep
+   `story_file` for the literal leaf filename (now low-value but
+   non-breaking). No formal schema-version field is introduced — this is
+   a bounded addition to an existing ad hoc TSV, not a versioned schema.
 5. Add zero-story-count rejection to `promote.py`'s
    `survey_collection`/`promote_collections` as a standing, always-on
    check.
@@ -133,10 +140,12 @@ standing rejection, not a one-time check.
 - Does not touch `lcats gather` incrementality/checkpointing,
   `notebooks/`, or `experiments/` — deferred in the governing proposal's
   own Non-Goals.
-- Does not finalize the `story_dir`/`story_slug` column name or TSV schema
-  version-bump policy beyond what's needed to ship Decision 5 — the
-  proposal's Open Questions defer full bikeshedding, but this item must
-  pick and document a concrete name.
+- Does not introduce a formal TSV schema-version field or a general
+  schema-versioning mechanism — decided, not deferred: this item's column
+  addition is bounded (append `story_dir` to the end of `TSV_COLUMNS`),
+  and a real version-negotiation mechanism is a separate, larger design
+  question only worth solving if a future change can't stay
+  append-only.
 - Does not change the overrides *file format* itself (directory-slug
   keying vs. filename-stem keying) — a call-site fix per Decision 7, not a
   schema change to `lcats/gatherers/overrides/<collection>.json`.

--- a/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
+++ b/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
@@ -15,6 +15,7 @@ related_design:
   - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
 work_items:
   - WI-STORY-0042
+  - WI-STORY-0043
 exit_criteria:
   - "Stage 1 (read-path compatibility) lands: discovery/identity logic is dual-layout-tolerant (Decisions 2-3), with a canonical story-file selector and dual-layout tests, writer output unchanged"
   - "Stage 2 (write-path migration) lands: DataGatherer.ensure and parser.gather_story() both write <collection>/<story>/story.json (Decision 8); overrides story_id derivation fixed (Decision 7); output identifier semantics updated with new story_dir/story_slug column (Decision 5); lcats promote itself rejects zero-story-count collections (Decision 6)"
@@ -82,12 +83,12 @@ to closeout.
 - **WI-STORY-0042** — Make story discovery/identity dual-layout-compatible:
   canonical story-file selector, dual-layout tests, no writer changes yet
   (Decisions 2-3).
-- **Stage 2 work item** (not yet created) — Migrate write paths to the
-  bucket layout: `DataGatherer.ensure` and `parser.gather_story()`
-  (Decision 8, the mass-quantities collection's writer, found during
-  proposal review); fix the overrides `story_id` derivation (Decision 7);
-  update output identifier semantics (Decision 5); add standing
-  zero-story-count rejection to `lcats promote` (Decision 6).
+- **WI-STORY-0043** — Migrate write paths to the bucket layout:
+  `DataGatherer.ensure` and `parser.gather_story()` (Decision 8, the
+  mass-quantities collection's writer, found during proposal review); fix
+  the overrides `story_id` derivation (Decision 7); update output
+  identifier semantics (Decision 5); add standing zero-story-count
+  rejection to `lcats promote` (Decision 6).
 - **Stage 3 work item** (not yet created) — Convergence: normalize
   tests/fixtures/docs to the new layout, run an explicit end-to-end
   gather-then-promote validation pass, and land dual-layout retraction

--- a/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
+++ b/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
@@ -89,14 +89,10 @@ to closeout.
   the overrides `story_id` derivation (Decision 7); update output
   identifier semantics (Decision 5); add standing zero-story-count
   rejection to `lcats promote` (Decision 6).
-- **Stage 3 work item** (not yet created) — Convergence: normalize
-  tests/fixtures/docs to the new layout, run an explicit end-to-end
-  gather-then-promote validation pass, and land dual-layout retraction
-  (Decision 4) as its own follow-up once the tracked `corpora/` snapshot
-  is confirmed migrated.
-
-None yet have `WI-*` IDs — offered as a follow-on after this workstream is
-created.
+- **WI-STORY-0044** — Convergence: normalize tests/fixtures/docs to the
+  new layout, run an explicit end-to-end gather-then-promote validation
+  pass, and land dual-layout retraction (Decision 4) as its own follow-up
+  once the tracked `corpora/` snapshot is confirmed migrated.
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary

Adds `WI-STORY-0043`, Stage 2 of `WS-STORY-BUCKET-LAYOUT`'s 3-stage
implementation of `PROP-LCATS-STORY-BUCKET-LAYOUT`.

- Migrates both writer sites (`DataGatherer.ensure` and
  `parser.gather_story()`, the latter found during PR #196's review) to
  the bucket layout.
- Fixes the gather-overrides `story_id` identity-collapse bug (Decision 7).
- Adds the `story_dir`/`story_slug` output column (Decision 5).
- Adds standing zero-story-count rejection to `lcats promote` itself
  (Decision 6), not a one-time check.
- Also carries the workstream update adding `WI-STORY-0042` and
  `WI-STORY-0043` to `WS-STORY-BUCKET-LAYOUT`'s `work_items:` list, and
  the two review fixes from PR #198 (already merged via that PR's own
  history, now included here since this branch was stacked on it).

## Note on this PR's history

This replaces the original stacked PR #199, which GitHub auto-closed (not
mergeable/reopenable) when the upstream branch `xenotaur/feat/wi-story-0042`
was deleted after PR #198 merged. No content was lost — this is the same
branch (`xenotaur/feat/wi-story-0043`), now targeting `main` directly.

## Status

`status: proposed`, `type: deliverable`, `priority: high`.
`related_workstreams: [WS-STORY-BUCKET-LAYOUT]`, `depends_on:
[WI-STORY-0042]` (already merged via PR #198).

## Traceability

Prompt ID: `PROMPT(AD_HOC:WI_STORY_0043)[2026-07-30T20:48:46+00:00]`

## Test plan

- [x] `lrh validate` — 0 errors (see original PR #199 for full history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
