### PR TITLE
Implement dual-layout story discovery (WI-STORY-0042, Stage 1)

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_07_31_19_41_59_WI_STORY_0042_IMPL_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_19_41_59_WI_STORY_0042_IMPL_REVIEW.md
@@ -1,0 +1,77 @@
+---
+execution_id: 2026_07_31_19_41_59_WI_STORY_0042_IMPL_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_STORY_0042_IMPL_REVIEW)[2026-07-31T19:41:36+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_31_19_06_38_WI_STORY_0042
+pr: https://github.com/xenotaur/LCATS/pull/202
+commit: e435197f8264220f3ebf392fb05c812b5aaecf45
+created_at: 2026-07-31T19:41:59+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/202
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Addressed automated review feedback (Codex + Copilot) on PR #202
+(WI-STORY-0042 implementation): two real, reproduced bugs in the recursive
+story-file walker, one deliberate scope-boundary explanation, and one
+straightforward defensive fix.
+
+# Result
+
+- **Codex P1 "Do not mistake a collection's flat story.json for a bucket"**
+  and the related **Copilot "sidecar in bucket dir" findings** — both
+  confirmed by direct reproduction before any fix was written. Root cause:
+  `_walk_canonical_story_files` reused the same "does this directory
+  contain story.json" signal to mean two different things at different
+  recursion depths (bucket-detection vs collection-role-inference), which
+  is structurally irreducible when a collection happens to hold a flat
+  file literally named `story.json`. Presented the tradeoff to the user
+  (redesign with explicit level context vs. a narrower patch vs. defer)
+  rather than silently picking an approach, given this touches the core
+  selector's contract. User chose the redesign.
+  - Fix: `_walk_canonical_story_files` now checks whether the directory it
+    is handed IS ITSELF a bucket before applying collection-level flat-file
+    scanning to it — fixes the direct-pointing-at-a-bucket-dir case
+    (sidecar no longer included).
+  - Fix: `story.json` is now a **reserved** filename — a flat file directly
+    in a collection literally named `story.json` is skipped with a warning
+    (`iter_collection_story_files`) rather than being structurally
+    indistinguishable from a bucket directory of the same name one level
+    up. This removes the ambiguity by convention instead of trying to infer
+    role from structure alone, which was proven not to work for every case.
+  - Both fixes verified via direct reproduction scripts (not just new unit
+    tests) before and after.
+- **Codex P1 "Apply the canonical selector to find_corpus_stories"** — left
+  out of scope per user decision: `find_corpus_stories` has its own
+  dedicated test (`test_nested_dirs_are_searched`) requiring arbitrary
+  nested filenames, and no real bucket-layout data exists yet (Stage 1 is
+  read-path only). Noted explicitly as a Stage 2/3 follow-up rather than
+  silently dropped.
+- **Codex P2 "Avoid following directory symlinks"** — fixed directly:
+  `iter_collection_story_files` and `_walk_canonical_story_files` now skip
+  symlinked entries, matching `find_corpus_stories`'s existing
+  `follow_symlinks=False` default.
+- New/updated tests in `tests/analysis_tests/discovery_test.py`: reserved
+  filename warning + skip behavior, symlink skipping, direct-bucket-pointing
+  with sidecar (regression), and ordinary flat filenames surviving a
+  root-level scan (regression, using non-colliding names).
+
+# Validation
+
+- `python3 -m pytest tests/` — 1538 passed, no regressions.
+- `scripts/format --check --diff` — clean (LCATS conda env, black 25.11.0
+  matching repo pins).
+- `scripts/lint` — clean.
+- `lrh validate` — 0 errors, 57 pre-existing unrelated warnings.
+- Both original bugs re-verified fixed via direct reproduction scripts
+  (not just the new unit tests) before pushing.
+
+# Follow-up
+
+- `find_corpus_stories` not using the canonical selector is a known,
+  documented gap to close before Stage 2/3 write real bucket-layout data.
+- Reply on the 5 review threads explaining the fixes / scope decision, then
+  resolve them.

--- a/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
@@ -48,6 +48,27 @@ claims):
 Thread-resolution verdict: **4/4 resolvable threads resolved; 1 surfaced
 exception left open by user decision, not an unaddressed defect.**
 
+**Second round (Step 8 retrigger surfaced a genuine new finding):** the
+`@codex review` retrigger on commit `43590c1e` (this record's own confirm
+commit) returned a clean top-level review but opened one new inline
+thread:
+
+- **Codex P1 "Prefer bucket slugs over metadata names"** — `infer_story_title`
+  checked `data["name"]`/`metadata.name` before the canonical-filename
+  check, so a `story.json` file with a `name` field never reached the
+  directory-slug branch, inverting Decision 2 of
+  `PROP-LCATS-STORY-BUCKET-LAYOUT` (slug is the primary identifier because
+  metadata titles are mutable/non-unique). Verified against the actual
+  merged proposal text before agreeing, not just the review comment.
+  Clear-satisfied after a direct fix (reordered the checks so the
+  canonical-filename branch runs first) landed on commit `b991fc8f`.
+  Thread resolved. Two new regression tests added
+  (`test_bucket_layout_prefers_directory_slug_over_name_field`,
+  `test_bucket_layout_prefers_directory_slug_over_metadata_name`).
+
+Reviewers retriggered again on `b991fc8f`; REVIEW-LANDED for this new HEAD
+is being checked separately before the final merge verdict.
+
 # Validation
 
 - CI on `10252545`: lint SUCCESS, both `test` jobs SUCCESS, `coverage` was

--- a/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
@@ -69,6 +69,40 @@ thread:
 Reviewers retriggered again on `b991fc8f`; REVIEW-LANDED for this new HEAD
 is being checked separately before the final merge verdict.
 
+**Third round:** the retrigger on `b991fc8f` surfaced two more real,
+reproduced findings:
+
+- **Codex P1 "Honor the reserved filename before stopping traversal"** —
+  confirmed by reproduction: `_walk_canonical_story_files`'s Case-A
+  short-circuit runs before `iter_collection_story_files`'s reserved-name
+  warning ever gets a chance, so pointing `find_json_files` directly at a
+  collection containing a flat file literally named `story.json` silently
+  dropped every sibling. Brought this to the user directly rather than
+  guessing a fourth code-level trick, since it's the same structurally
+  irreducible ambiguity already surfaced once this session (a directory
+  containing exactly `{story.json, other.json}` looks identical whether
+  `other.json` is a bucket sidecar or an independent flat story). The
+  user's answer changed the analysis: LCATS's bucket layout is expected to
+  hold parallel sidecar files (`audit.json`, `scenes.json`, `events.json`,
+  etc.) once the write path migrates, so "story.json plus other JSON in
+  the same directory" is *not* an edge case needing a tiebreak -- it's the
+  normal, expected bucket shape. Case-A's existing bucket-wins,
+  silently-exclude-the-rest behavior is therefore correct as originally
+  written, not a compromise. No code change; documented the rationale in
+  `_walk_canonical_story_files`'s docstring (commit `191fa079`) so a
+  future reader doesn't reopen the same question without this context.
+  Thread resolved on that basis.
+- **Codex P2 "Preserve flat story symlinks when skipping directory
+  links"** — confirmed by reproduction: the symlink guard added in the
+  first round (`entry.is_symlink(): continue`) was too broad and dropped
+  legitimate symlinked flat story files, not just the directory-symlink
+  cycle risk it was meant to guard against. Fixed by narrowing the check
+  to `entry.is_symlink() and entry.is_dir()`. Verified both halves by
+  reproduction: a symlinked flat file is now found; a symlinked directory
+  is still skipped. Thread resolved on commit `191fa079`.
+
+Reviewers retriggered a third time on `191fa079`.
+
 # Validation
 
 - CI on `10252545`: lint SUCCESS, both `test` jobs SUCCESS, `coverage` was

--- a/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
@@ -103,6 +103,26 @@ reproduced findings:
 
 Reviewers retriggered a third time on `191fa079`.
 
+**Fourth round:** Codex confirmed clean directly on `9ad5c690` ("Didn't
+find any major issues"). Copilot's formal review did not land for a long
+delay across two retriggers (~40+ minutes) -- surfaced to the user rather
+than guessing "not configured" or declaring Green without it; user
+reported it had been out of review credits and re-ran it manually.
+Copilot's review then landed on the exact `9ad5c690` HEAD with "no new
+comments" but two **suppressed** (body-only, non-thread) findings, both
+triaged rather than waved through on the "no new comments" headline:
+
+- `Corpora.get_corpora` traversed symlinked directories under
+  `corpora_root`, inconsistent with the discovery helpers'
+  `follow_symlinks=False` convention established earlier in this PR.
+  Confirmed by reproduction, fixed, regression test added.
+- `find_json_files`'s docstring was stale after the bucket-short-circuit
+  and reserved-filename fixes from earlier rounds. Updated to describe
+  the actual rule.
+
+Both landed on commit `5a019715`. No new formal inline threads opened.
+Reviewers retriggered a fourth time on `5a019715`.
+
 # Validation
 
 - CI on `10252545`: lint SUCCESS, both `test` jobs SUCCESS, `coverage` was

--- a/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
@@ -123,6 +123,24 @@ triaged rather than waved through on the "no new comments" headline:
 Both landed on commit `5a019715`. No new formal inline threads opened.
 Reviewers retriggered a fourth time on `5a019715`.
 
+**Final check:** on `HEAD` `1f712858` (a no-code-change commit adding this
+record's own round-4 update), Codex confirmed clean, citing the exact SHA
+("Reviewed commit: 1f7128586e... Didn't find any major issues"). The
+formal `copilot-pull-request-reviewer` review had not yet caught up to
+this exact SHA at check time, but the mention-responder
+(`copilot-swe-agent`) replied with a clean, substantive pass shortly after
+the retrigger, explicitly covering the fixed functions and confirming the
+full test suite green. CI: lint/coverage/both test jobs all SUCCESS.
+Unresolved threads: exactly 1 (`find_corpus_stories` scope, left open by
+user decision).
+
+# Final verdict
+
+**Green** — all resolvable threads resolved, CI green, both retriggered
+reviewers confirmed clean on the final HEAD.
+
+`gh pr merge 202 --merge --match-head-commit 1f7128586eafb82e5098ad053e6ae0d30dcb9cf2`
+
 # Validation
 
 - CI on `10252545`: lint SUCCESS, both `test` jobs SUCCESS, `coverage` was

--- a/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM.md
@@ -1,0 +1,69 @@
+---
+execution_id: 2026_07_31_19_55_55_WI_STORY_0042_IMPL_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_STORY_0042_IMPL_CONFIRM)[2026-07-31T19:44:35+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_07_31_19_06_38_WI_STORY_0042
+pr: https://github.com/xenotaur/LCATS/pull/202
+commit: 1025254554e774ca64c0ca462f5439ae818344dc
+created_at: 2026-07-31T19:55:55+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/202
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge verification and thread-resolution pass for PR #202
+(WI-STORY-0042 implementation), following the `/lrh-review-response`
+round that fixed the collection-vs-bucket ambiguity and symlink handling.
+
+# Result
+
+Verified all 5 unresolved threads against the live `HEAD` diff at commit
+`10252545` (never against the review-response execution record's own
+claims):
+
+- **Codex "Do not mistake a collection's flat story.json for a bucket"** —
+  Clear-satisfied. `_walk_canonical_story_files` now checks bucket-ness of
+  the directory it's handed before applying collection semantics, and
+  `story.json` is reserved for the bucket marker. Resolved.
+- **Codex "Avoid following directory symlinks"** — Clear-satisfied. Both
+  `iter_collection_story_files` and `_walk_canonical_story_files` skip
+  symlinked entries. Resolved.
+- **Copilot "sidecar returned for direct bucket-dir pointing"** —
+  Clear-satisfied, same fix as the first item. Resolved.
+- **Copilot "missing regression test for bucket dir + sidecar"** —
+  Clear-satisfied. `test_pointed_directly_at_bucket_dir_excludes_sidecar`
+  added. Resolved.
+- **Codex "Apply the canonical selector to find_corpus_stories"** —
+  surfaced as a deliberate scope decision, not resolved. Presented to the
+  user at the confirm gate with rationale (own dedicated test requires
+  arbitrary nested filenames; no real bucket-layout data exists yet since
+  Stage 1 is read-path only); user chose to leave this thread open rather
+  than resolve it, since resolving it here would need either a new PR
+  reply (outside this skill's autonomous-comment boundary) or silently
+  closing a thread without a public explanation.
+
+Thread-resolution verdict: **4/4 resolvable threads resolved; 1 surfaced
+exception left open by user decision, not an unaddressed defect.**
+
+# Validation
+
+- CI on `10252545`: lint SUCCESS, both `test` jobs SUCCESS, `coverage` was
+  IN_PROGRESS at time of check (not yet complete).
+- Threads re-fetched via `lrh github --mode raw --state all threads
+  xenotaur/LCATS 202`, filtered to `isResolved == false` — all 4
+  Clear-satisfied threads confirmed `isResolved: true` after resolution.
+- REVIEW-LANDED not yet re-checked against this `_CONFIRM` commit (no
+  additional code change was pushed in this step — only thread
+  resolution — so no new commit was produced by this record; the readiness
+  verdict still requires fresh reviewer confirmation on `10252545`,
+  reported separately).
+
+# Follow-up
+
+- Not yet Green: need CI to finish, and an explicit clean pass from
+  Codex/Copilot on `10252545` (or a retrigger) before the merge gate.
+- `find_corpus_stories` selector gap remains an open, surfaced thread and
+  a documented Stage 2/3 follow-up.

--- a/lcats/project/executions/WI-STORY-0042/2026_07_31_19_06_38_WI_STORY_0042.md
+++ b/lcats/project/executions/WI-STORY-0042/2026_07_31_19_06_38_WI_STORY_0042.md
@@ -1,0 +1,76 @@
+---
+execution_id: 2026_07_31_19_06_38_WI_STORY_0042
+prompt_id: PROMPT(WI-STORY-0042:WI_STORY_0042)[2026-07-31T09:12:24+00:00]
+work_item: WI-STORY-0042
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/202
+commit: 1708df475171fea22a82541fbad3fa64957bd584
+created_at: 2026-07-31T19:06:38+00:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-STORY-0042.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Implemented `WI-STORY-0042` (Stage 1 of `WS-STORY-BUCKET-LAYOUT`: read-path compatibility),
+per Decision 3 of `PROP-LCATS-STORY-BUCKET-LAYOUT`.
+
+# Result
+
+- Added `discovery.iter_collection_story_files` (`lcats/src/lcats/analysis/corpus/discovery.py`),
+  the canonical story-file selector: recognizes either a flat `<story>.json` file or a nested
+  `<story>/story.json` bucket directory as a valid story source, one level deep relative to the
+  directory scanned, no recursion.
+- `Corpora.get_corpora` (`lcats/src/lcats/stories.py:45-66`) now uses the selector instead of raw
+  `os.listdir` + `.endswith(".json")`. This also fixes a latent bug in the prior `os.walk`-based
+  traversal, which would treat a nested story-bucket directory's own name as a brand-new
+  top-level collection key instead of grouping it under its real collection — traced manually and
+  reproduced via smoke test before the fix, not a regression introduced by this change.
+- `discovery.find_json_files` is rewritten to apply the same flat-vs-canonical-name predicate
+  recursively at every directory level, via a new `_walk_canonical_story_files` helper, so it
+  behaves correctly whether pointed at a corpus root, a single collection directory, or a single
+  story's own directory. `discovery.find_corpus_stories` is deliberately left untouched — its own
+  test suite (`corpus_surveyor_test.py::TestFindCorpusStories::test_nested_dirs_are_searched`)
+  requires arbitrarily-named nested files to remain discoverable, and `corpus_surveyor.py`
+  aliases it directly.
+- `JsonDataset` (`lcats/src/lcats/datasets/torchdata.py`) now uses `discovery.find_json_files`
+  instead of a manual `os.walk`, so it neither loads sidecar JSON from bucket directories nor
+  regresses flat-file discovery.
+- `infer_story_title` (`lcats/src/lcats/analysis/corpus/cli.py:47-63`) now falls back to the
+  enclosing directory's slug for canonical `story.json` files (whose stem is otherwise always the
+  useless literal `"story"`), while flat-layout files keep the existing `.stem` fallback.
+- No changes to `DataGatherer`'s writer output or any other writer behavior — this stage is
+  read-path only, per the WI's acceptance criteria.
+- Scope note: the WI's acceptance-criteria text loosely named both `find_json_files` and
+  `find_corpus_stories` for Decision 3's tightening, but the WI's own Required Changes section
+  (and the actual code/tests, per above) only supports changing `find_json_files`. Implemented
+  precisely what Required Changes specifies.
+
+# Validation
+
+- New dual-layout tests added: `tests/stories_test.py` (`TestCorpora`, extended with
+  nested-bucket, mixed-layout, sidecar-exclusion, and collection-misgrouping-regression cases),
+  `tests/analysis_tests/discovery_test.py` (new file — `iter_collection_story_files` and
+  `find_json_files` had zero prior real test coverage; every existing call site mocked them),
+  `tests/analysis_tests/corpus_cli_test.py` (new file — `infer_story_title`),
+  `tests/datasets_tests/torchdata_test.py` (new file — `JsonDataset`, no prior test file existed).
+- `python3 -m pytest tests/` — 1534 passed, no regressions.
+- `scripts/version tools` — ran in the `LCATS` conda env (base env's `black`/`ruff` were
+  version-skewed against the repo's pins; `LCATS` env matches: black 25.11.0, ruff 0.15.0).
+- `scripts/format --check --diff` — clean after formatting the 2 new test files that needed it.
+- `scripts/lint` — clean.
+- `scripts/test` — 1530 passed.
+- `lrh validate` — 0 errors, 57 pre-existing warnings unrelated to this change (`owner
+  'unassigned'` across many pre-existing work items).
+
+# Follow-up
+
+- `status` is `in_progress`; update to `landed` (via `/lrh-closeout`) after PR #202 merges, with
+  the real merge commit and confirmed `pr:`/`commit:` fields.
+- Stale editable pip install recurred again during this implementation (this environment's
+  `lcats` package pointed at a different worktree until `pip install -e . --force-reinstall
+  --no-deps` was re-run from this worktree) — worth a standing memory given how often this has
+  now happened across sessions.
+- Next natural step: implement `WI-STORY-0043` (Stage 2, write-path migration).

--- a/lcats/src/lcats/analysis/corpus/cli.py
+++ b/lcats/src/lcats/analysis/corpus/cli.py
@@ -47,19 +47,21 @@ def read_story_text(file_path: pathlib.Path) -> str:
 def infer_story_title(data: dict, file_path: pathlib.Path) -> str:
     """Infer stable title from story data, falling back to filename stem.
 
-    A canonical per-story-bucket file (``story.json``) always has the same
-    leaf stem ("story"), which is useless as an identifier -- fall back to
-    the enclosing directory's name (the story's slug) for that case instead,
-    per Decision 2 of PROP-LCATS-STORY-BUCKET-LAYOUT. Flat-layout files keep
-    the existing stem fallback unchanged.
+    Per Decision 2 of PROP-LCATS-STORY-BUCKET-LAYOUT, the directory slug is
+    the *primary* identifier for a canonical per-story-bucket file
+    (``story.json``) -- checked first, ahead of metadata -- because metadata
+    titles are mutable and not guaranteed unique, while the slug is stable.
+    This also sidesteps the leaf stem always being the literal ``"story"``
+    for every bucket file. Flat-layout files are unaffected: they keep the
+    existing content-title-then-stem fallback chain.
     """
+    if file_path.name == discovery.CANONICAL_STORY_FILENAME:
+        return file_path.parent.name
     story_title = (
         data.get("name") or data.get("metadata", {}).get("name") or ""
     ).strip()
     if story_title:
         return story_title
-    if file_path.name == discovery.CANONICAL_STORY_FILENAME:
-        return file_path.parent.name
     return file_path.stem
 
 

--- a/lcats/src/lcats/analysis/corpus/cli.py
+++ b/lcats/src/lcats/analysis/corpus/cli.py
@@ -45,13 +45,22 @@ def read_story_text(file_path: pathlib.Path) -> str:
 
 
 def infer_story_title(data: dict, file_path: pathlib.Path) -> str:
-    """Infer stable title from story data, falling back to filename stem."""
+    """Infer stable title from story data, falling back to filename stem.
+
+    A canonical per-story-bucket file (``story.json``) always has the same
+    leaf stem ("story"), which is useless as an identifier -- fall back to
+    the enclosing directory's name (the story's slug) for that case instead,
+    per Decision 2 of PROP-LCATS-STORY-BUCKET-LAYOUT. Flat-layout files keep
+    the existing stem fallback unchanged.
+    """
     story_title = (
         data.get("name") or data.get("metadata", {}).get("name") or ""
     ).strip()
-    if not story_title:
-        return file_path.stem
-    return story_title
+    if story_title:
+        return story_title
+    if file_path.name == discovery.CANONICAL_STORY_FILENAME:
+        return file_path.parent.name
+    return file_path.stem
 
 
 def coerce_story_text(value) -> str:

--- a/lcats/src/lcats/analysis/corpus/discovery.py
+++ b/lcats/src/lcats/analysis/corpus/discovery.py
@@ -59,7 +59,8 @@ def iter_collection_story_files(
     The canonical story-file selector, per Decision 3 of
     PROP-LCATS-STORY-BUCKET-LAYOUT. Tolerates both layouts:
 
-    - Flat: any ``<story>.json`` file directly in ``collection_dir``.
+    - Flat: any ``<story>.json`` file directly in ``collection_dir``, other
+      than the literal name ``story.json`` (reserved, see below).
     - Bucket: ``<story>/story.json`` -- a subdirectory of ``collection_dir``
       containing a file literally named ``story.json``.
 
@@ -69,13 +70,35 @@ def iter_collection_story_files(
     collection's own directory. Sibling JSON artifacts inside a story's own
     bucket directory (analysis output, override sidecars) are intentionally
     excluded once nested, since only the canonical leaf name is accepted.
+
+    ``story.json`` is reserved exclusively for the nested bucket marker: a
+    flat file directly in ``collection_dir`` literally named ``story.json``
+    is skipped (with a warning) rather than treated as an ordinary flat
+    story. Without this reservation, a directory one level up could never
+    structurally distinguish "a collection whose own flat file happens to be
+    named story.json" from "a story's own bucket directory" -- the two look
+    identical from outside. Reserving the name removes that ambiguity
+    entirely instead of trying to guess it away.
+
+    Directory entries reached via a symlink are skipped, matching
+    :func:`find_corpus_stories`'s default ``follow_symlinks=False``.
     """
     path = pathlib.Path(collection_dir)
     if not path.is_dir():
         return
     for entry in sorted(path.iterdir()):
+        if entry.is_symlink():
+            continue
         if entry.is_file():
             if entry.suffix == ".json":
+                if entry.name == CANONICAL_STORY_FILENAME:
+                    print(
+                        f"warning: skipping {entry} -- {CANONICAL_STORY_FILENAME!r} "
+                        "is reserved for per-story bucket directories and cannot "
+                        "be used as a flat story filename",
+                        file=sys.stderr,
+                    )
+                    continue
                 yield entry
         elif entry.is_dir():
             nested = entry / CANONICAL_STORY_FILENAME
@@ -86,14 +109,30 @@ def iter_collection_story_files(
 def _walk_canonical_story_files(directory: pathlib.Path) -> Iterator[pathlib.Path]:
     """Recursively yield canonical story files under directory.
 
-    Applies :func:`iter_collection_story_files`'s flat-vs-bucket predicate at
-    every directory level, then recurses into subdirectories that are not
-    themselves story buckets -- so this behaves correctly whether ``directory``
-    is a corpus root (immediate children are collection directories), a single
-    collection directory, or a single story's own directory.
+    First checks whether ``directory`` is itself a story bucket (contains
+    its own ``story.json``) -- if so, yields only that canonical file and
+    stops, regardless of what other JSON sidecars sit alongside it. This
+    only matters when ``directory`` is handed to this function directly, as
+    a top-level scan target (e.g. a caller pointing straight at one story's
+    bucket) -- reaching a bucket directory via recursion from a collection
+    is already handled by :func:`iter_collection_story_files`, which stops
+    at the bucket boundary and never recurses into it.
+
+    Otherwise applies :func:`iter_collection_story_files`'s flat-vs-bucket
+    predicate to ``directory``, then recurses into subdirectories that are
+    not themselves story buckets -- so this behaves correctly whether
+    ``directory`` is a corpus root (immediate children are collection
+    directories), a single collection directory, or a single story's own
+    directory.
     """
+    canonical = directory / CANONICAL_STORY_FILENAME
+    if canonical.is_file():
+        yield canonical
+        return
     yield from iter_collection_story_files(directory)
     for entry in sorted(directory.iterdir()):
+        if entry.is_symlink():
+            continue
         if entry.is_dir() and not (entry / CANONICAL_STORY_FILENAME).is_file():
             yield from _walk_canonical_story_files(entry)
 

--- a/lcats/src/lcats/analysis/corpus/discovery.py
+++ b/lcats/src/lcats/analysis/corpus/discovery.py
@@ -7,6 +7,8 @@ import typing
 
 from typing import Iterable, Iterator, Union
 
+CANONICAL_STORY_FILENAME = "story.json"
+
 
 def find_corpus_stories(
     root: Union[str, pathlib.Path],
@@ -49,10 +51,64 @@ def find_corpus_stories(
     return results
 
 
+def iter_collection_story_files(
+    collection_dir: Union[str, pathlib.Path],
+) -> Iterator[pathlib.Path]:
+    """Yield canonical story files that are immediate entries of collection_dir.
+
+    The canonical story-file selector, per Decision 3 of
+    PROP-LCATS-STORY-BUCKET-LAYOUT. Tolerates both layouts:
+
+    - Flat: any ``<story>.json`` file directly in ``collection_dir``.
+    - Bucket: ``<story>/story.json`` -- a subdirectory of ``collection_dir``
+      containing a file literally named ``story.json``.
+
+    Applies only one level of nesting relative to ``collection_dir``. A
+    subdirectory without a canonical ``story.json`` is skipped, not searched
+    further -- ``collection_dir`` is assumed to already be a single
+    collection's own directory. Sibling JSON artifacts inside a story's own
+    bucket directory (analysis output, override sidecars) are intentionally
+    excluded once nested, since only the canonical leaf name is accepted.
+    """
+    path = pathlib.Path(collection_dir)
+    if not path.is_dir():
+        return
+    for entry in sorted(path.iterdir()):
+        if entry.is_file():
+            if entry.suffix == ".json":
+                yield entry
+        elif entry.is_dir():
+            nested = entry / CANONICAL_STORY_FILENAME
+            if nested.is_file():
+                yield nested
+
+
+def _walk_canonical_story_files(directory: pathlib.Path) -> Iterator[pathlib.Path]:
+    """Recursively yield canonical story files under directory.
+
+    Applies :func:`iter_collection_story_files`'s flat-vs-bucket predicate at
+    every directory level, then recurses into subdirectories that are not
+    themselves story buckets -- so this behaves correctly whether ``directory``
+    is a corpus root (immediate children are collection directories), a single
+    collection directory, or a single story's own directory.
+    """
+    yield from iter_collection_story_files(directory)
+    for entry in sorted(directory.iterdir()):
+        if entry.is_dir() and not (entry / CANONICAL_STORY_FILENAME).is_file():
+            yield from _walk_canonical_story_files(entry)
+
+
 def find_json_files(
     directories: Iterable[Union[str, pathlib.Path]],
 ) -> Iterator[pathlib.Path]:
-    """Yield JSON files from provided paths in deterministic order."""
+    """Yield canonical story files from provided paths in deterministic order.
+
+    Tolerates both the flat and per-story-bucket layouts (Decision 3 of
+    PROP-LCATS-STORY-BUCKET-LAYOUT) via :func:`_walk_canonical_story_files`:
+    a JSON file directly inside whatever directory is being scanned is always
+    eligible regardless of name; a JSON file reached by descending into a
+    subdirectory is eligible only if it is literally named ``story.json``.
+    """
     for directory in directories:
         path = pathlib.Path(directory)
         if not path.exists():
@@ -62,6 +118,4 @@ def find_json_files(
             if path.suffix == ".json":
                 yield path
             continue
-        for file_path in sorted(path.rglob("*.json")):
-            if file_path.is_file():
-                yield file_path
+        yield from _walk_canonical_story_files(path)

--- a/lcats/src/lcats/analysis/corpus/discovery.py
+++ b/lcats/src/lcats/analysis/corpus/discovery.py
@@ -87,7 +87,7 @@ def iter_collection_story_files(
     if not path.is_dir():
         return
     for entry in sorted(path.iterdir()):
-        if entry.is_symlink():
+        if entry.is_symlink() and entry.is_dir():
             continue
         if entry.is_file():
             if entry.suffix == ".json":
@@ -111,12 +111,21 @@ def _walk_canonical_story_files(directory: pathlib.Path) -> Iterator[pathlib.Pat
 
     First checks whether ``directory`` is itself a story bucket (contains
     its own ``story.json``) -- if so, yields only that canonical file and
-    stops, regardless of what other JSON sidecars sit alongside it. This
-    only matters when ``directory`` is handed to this function directly, as
-    a top-level scan target (e.g. a caller pointing straight at one story's
-    bucket) -- reaching a bucket directory via recursion from a collection
-    is already handled by :func:`iter_collection_story_files`, which stops
-    at the bucket boundary and never recurses into it.
+    stops, regardless of what other JSON sidecars (``audit.json``,
+    ``scenes.json``, ``events.json``, and similar per-story analysis
+    artifacts) sit alongside it. This is a deliberate, unconditional rule,
+    not a best-effort heuristic: once a directory contains ``story.json``,
+    every other JSON file in it is treated as that story's own sidecar
+    content, never as an independent second story -- this is how bucket
+    directories are actually populated once the write path migrates (see
+    Decision 3 of PROP-LCATS-STORY-BUCKET-LAYOUT), so there is no
+    real-world case where "story.json plus another flat story" both belong
+    directly in the same directory. This only matters when ``directory``
+    is handed to this function directly, as a top-level scan target (e.g.
+    a caller pointing straight at one story's bucket) -- reaching a bucket
+    directory via recursion from a collection is already handled by
+    :func:`iter_collection_story_files`, which stops at the bucket
+    boundary and never recurses into it.
 
     Otherwise applies :func:`iter_collection_story_files`'s flat-vs-bucket
     predicate to ``directory``, then recurses into subdirectories that are

--- a/lcats/src/lcats/analysis/corpus/discovery.py
+++ b/lcats/src/lcats/analysis/corpus/discovery.py
@@ -152,10 +152,19 @@ def find_json_files(
     """Yield canonical story files from provided paths in deterministic order.
 
     Tolerates both the flat and per-story-bucket layouts (Decision 3 of
-    PROP-LCATS-STORY-BUCKET-LAYOUT) via :func:`_walk_canonical_story_files`:
-    a JSON file directly inside whatever directory is being scanned is always
-    eligible regardless of name; a JSON file reached by descending into a
-    subdirectory is eligible only if it is literally named ``story.json``.
+    PROP-LCATS-STORY-BUCKET-LAYOUT) via :func:`_walk_canonical_story_files`,
+    with three exceptions to "any JSON file directly in a scanned directory
+    is eligible regardless of name":
+
+    - If the directory being scanned is itself a story bucket (contains its
+      own ``story.json``), only that canonical file is yielded -- every
+      other JSON sidecar alongside it is excluded, not just files reached
+      by descending further.
+    - A flat file literally named ``story.json`` directly in a directory
+      being scanned as a collection is reserved for the bucket marker and
+      is skipped (with a warning), not treated as an ordinary flat story.
+    - A JSON file reached by descending into a subdirectory is eligible
+      only if it is literally named ``story.json``.
     """
     for directory in directories:
         path = pathlib.Path(directory)

--- a/lcats/src/lcats/datasets/torchdata.py
+++ b/lcats/src/lcats/datasets/torchdata.py
@@ -4,6 +4,8 @@ import os
 import json
 from torch.utils.data import Dataset
 
+from lcats.analysis.corpus import discovery
+
 # TODO(centaur): Do this in a more principled way.
 DEFAULT_ROOT_DIR = "data"
 
@@ -16,13 +18,14 @@ class JsonDataset(Dataset):
         else:
             self.data_dir = root_dir
 
-        # Gather all json files in the specified directory and its subdirectories
-        self.file_paths = []
-        for root, _, files in os.walk(self.data_dir):
-            for file in files:
-                if file.endswith(".json"):
-                    file_path = os.path.join(root, file)
-                    self.file_paths.append(file_path)
+        # Gather canonical story files (flat or per-story-bucket layout, per
+        # Decision 3 of PROP-LCATS-STORY-BUCKET-LAYOUT) in the specified
+        # directory and its subdirectories, via the same selector discovery.py
+        # uses -- so this dataset stays in sync with the rest of the corpus
+        # tooling instead of re-implementing its own traversal.
+        self.file_paths = [
+            str(path) for path in discovery.find_json_files([self.data_dir])
+        ]
 
     def __len__(self):
         return len(self.file_paths)

--- a/lcats/src/lcats/stories.py
+++ b/lcats/src/lcats/stories.py
@@ -1,8 +1,10 @@
 """Classes for working with stories and corpora of stories."""
 
 import json
-import os
+import pathlib
 import yaml
+
+from lcats.analysis.corpus import discovery
 
 
 class Corpora:
@@ -41,18 +43,26 @@ class Corpora:
         return stories
 
     def get_corpora(self):
-        """Utility function to load all corpora from the corpora root."""
+        """Utility function to load all corpora from the corpora root.
+
+        Tolerates both the flat (``<collection>/<story>.json``) and
+        per-story-bucket (``<collection>/<story>/story.json``) layouts, per
+        Decision 3 of PROP-LCATS-STORY-BUCKET-LAYOUT. Each immediate
+        subdirectory of the corpora root is treated as one collection;
+        story files within it are found via
+        ``discovery.iter_collection_story_files``, which does not recurse
+        past one level -- so a story's own bucket directory is never
+        mistaken for a second collection.
+        """
         corpora = {}
-        for root, dirs, files in os.walk(self.corpora_root):
-            del files  # Unused
-            for dir_name in dirs:
-                corpora[dir_name] = []
-                dir_path = os.path.join(root, dir_name)
-                for file_name in os.listdir(dir_path):
-                    if file_name.endswith(".json"):
-                        file_path = os.path.join(dir_path, file_name)
-                        story = Story.from_json_file(file_path)
-                        corpora[dir_name].append(story)
+        root_path = pathlib.Path(self.corpora_root)
+        if not root_path.is_dir():
+            return corpora
+        for collection_dir in sorted(p for p in root_path.iterdir() if p.is_dir()):
+            collection_stories = []
+            for story_path in discovery.iter_collection_story_files(collection_dir):
+                collection_stories.append(Story.from_json_file(str(story_path)))
+            corpora[collection_dir.name] = collection_stories
         return corpora
 
 

--- a/lcats/src/lcats/stories.py
+++ b/lcats/src/lcats/stories.py
@@ -52,13 +52,17 @@ class Corpora:
         story files within it are found via
         ``discovery.iter_collection_story_files``, which does not recurse
         past one level -- so a story's own bucket directory is never
-        mistaken for a second collection.
+        mistaken for a second collection. Symlinked directories directly
+        under the corpora root are skipped, matching the discovery
+        helpers' own ``follow_symlinks=False`` convention.
         """
         corpora = {}
         root_path = pathlib.Path(self.corpora_root)
         if not root_path.is_dir():
             return corpora
-        for collection_dir in sorted(p for p in root_path.iterdir() if p.is_dir()):
+        for collection_dir in sorted(
+            p for p in root_path.iterdir() if p.is_dir() and not p.is_symlink()
+        ):
             collection_stories = []
             for story_path in discovery.iter_collection_story_files(collection_dir):
                 collection_stories.append(Story.from_json_file(str(story_path)))

--- a/lcats/tests/analysis_tests/corpus_cli_test.py
+++ b/lcats/tests/analysis_tests/corpus_cli_test.py
@@ -1,0 +1,39 @@
+"""Unit tests for lcats.analysis.corpus.cli.infer_story_title."""
+
+import pathlib
+import unittest
+
+from lcats.analysis.corpus import cli
+
+
+class TestInferStoryTitle(unittest.TestCase):
+    """Tests for cli.infer_story_title."""
+
+    def test_uses_name_field_when_present(self):
+        data = {"name": "Explicit Title"}
+        path = pathlib.Path("collection/story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "Explicit Title")
+
+    def test_uses_metadata_name_when_top_level_name_absent(self):
+        data = {"metadata": {"name": "Metadata Title"}}
+        path = pathlib.Path("collection/story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "Metadata Title")
+
+    def test_flat_layout_falls_back_to_file_stem(self):
+        data = {}
+        path = pathlib.Path("collection/my_story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "my_story")
+
+    def test_bucket_layout_falls_back_to_directory_slug(self):
+        data = {}
+        path = pathlib.Path("collection/my_story/story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "my_story")
+
+    def test_blank_name_field_falls_back(self):
+        data = {"name": "   "}
+        path = pathlib.Path("collection/my_story/story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "my_story")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/analysis_tests/corpus_cli_test.py
+++ b/lcats/tests/analysis_tests/corpus_cli_test.py
@@ -9,18 +9,23 @@ from lcats.analysis.corpus import cli
 class TestInferStoryTitle(unittest.TestCase):
     """Tests for cli.infer_story_title."""
 
-    def test_uses_name_field_when_present(self):
+    def test_flat_layout_uses_name_field_when_present(self):
         data = {"name": "Explicit Title"}
-        path = pathlib.Path("collection/story.json")
+        path = pathlib.Path("collection/my_story.json")
         self.assertEqual(cli.infer_story_title(data, path), "Explicit Title")
 
-    def test_uses_metadata_name_when_top_level_name_absent(self):
+    def test_flat_layout_uses_metadata_name_when_top_level_name_absent(self):
         data = {"metadata": {"name": "Metadata Title"}}
-        path = pathlib.Path("collection/story.json")
+        path = pathlib.Path("collection/my_story.json")
         self.assertEqual(cli.infer_story_title(data, path), "Metadata Title")
 
     def test_flat_layout_falls_back_to_file_stem(self):
         data = {}
+        path = pathlib.Path("collection/my_story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "my_story")
+
+    def test_flat_layout_blank_name_field_falls_back_to_stem(self):
+        data = {"name": "   "}
         path = pathlib.Path("collection/my_story.json")
         self.assertEqual(cli.infer_story_title(data, path), "my_story")
 
@@ -29,8 +34,17 @@ class TestInferStoryTitle(unittest.TestCase):
         path = pathlib.Path("collection/my_story/story.json")
         self.assertEqual(cli.infer_story_title(data, path), "my_story")
 
-    def test_blank_name_field_falls_back(self):
-        data = {"name": "   "}
+    def test_bucket_layout_prefers_directory_slug_over_name_field(self):
+        """Regression test for Decision 2 of PROP-LCATS-STORY-BUCKET-LAYOUT:
+        the directory slug is the primary identifier for a canonical
+        story.json file, even when a (mutable, non-unique) name field is
+        also present -- metadata must not override it."""
+        data = {"name": "Mutable Metadata Title"}
+        path = pathlib.Path("collection/my_story/story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "my_story")
+
+    def test_bucket_layout_prefers_directory_slug_over_metadata_name(self):
+        data = {"metadata": {"name": "Mutable Metadata Title"}}
         path = pathlib.Path("collection/my_story/story.json")
         self.assertEqual(cli.infer_story_title(data, path), "my_story")
 

--- a/lcats/tests/analysis_tests/discovery_test.py
+++ b/lcats/tests/analysis_tests/discovery_test.py
@@ -77,7 +77,7 @@ class TestIterCollectionStoryFiles(test_utils.TestCaseWithData):
         self.assertEqual(found, [other])
         self.assertIn("reserved", captured.stderr.getvalue())
 
-    def test_skips_symlinked_entries(self):
+    def test_skips_symlinked_directories(self):
         real_target = self.root.parent / "outside_target"
         real_target.mkdir()
         (real_target / "story.json").write_text("{}", encoding="utf-8")
@@ -88,6 +88,17 @@ class TestIterCollectionStoryFiles(test_utils.TestCaseWithData):
             self.skipTest("symlinks not supported in this environment")
         found = list(discovery.iter_collection_story_files(self.root))
         self.assertEqual(found, [])
+
+    def test_preserves_symlinked_flat_files(self):
+        real_target = self.root.parent / "real_story.json"
+        real_target.write_text("{}", encoding="utf-8")
+        link = self.root / "linked_story.json"
+        try:
+            link.symlink_to(real_target)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks not supported in this environment")
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [link])
 
 
 class TestFindJsonFiles(test_utils.TestCaseWithData):

--- a/lcats/tests/analysis_tests/discovery_test.py
+++ b/lcats/tests/analysis_tests/discovery_test.py
@@ -1,0 +1,124 @@
+"""Unit tests for lcats.analysis.corpus.discovery."""
+
+import pathlib
+import unittest
+
+from lcats.utils import test_utils
+from lcats.analysis.corpus import discovery
+
+
+class TestIterCollectionStoryFiles(test_utils.TestCaseWithData):
+    """Unit tests for discovery.iter_collection_story_files."""
+
+    def setUp(self):
+        super().setUp()
+        self.root = pathlib.Path(self.test_temp_dir) / "collection"
+        self.root.mkdir()
+
+    def _write(self, relpath):
+        p = self.root / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}", encoding="utf-8")
+        return p
+
+    def test_finds_flat_story_any_name(self):
+        p = self._write("story1.json")
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [p])
+
+    def test_finds_nested_bucket_story(self):
+        p = self._write("story1/story.json")
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [p])
+
+    def test_mixed_flat_and_bucket(self):
+        flat = self._write("flat_story.json")
+        bucket = self._write("bucket_story/story.json")
+        found = set(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, {flat, bucket})
+
+    def test_ignores_sidecar_json_in_bucket_dir(self):
+        self._write("story1/story.json")
+        self._write("story1/analysis.json")
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].name, "story.json")
+
+    def test_skips_subdir_without_canonical_file(self):
+        self._write("empty_dir/notes.txt")
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [])
+
+    def test_ignores_non_json_flat_files(self):
+        self._write("readme.txt")
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [])
+
+    def test_does_not_recurse_past_one_level(self):
+        self._write("a/b/story.json")
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [])
+
+    def test_nonexistent_dir_yields_nothing(self):
+        found = list(discovery.iter_collection_story_files(self.root / "nonexistent"))
+        self.assertEqual(found, [])
+
+
+class TestFindJsonFiles(test_utils.TestCaseWithData):
+    """Unit tests for discovery.find_json_files."""
+
+    def setUp(self):
+        super().setUp()
+        self.root = pathlib.Path(self.test_temp_dir) / "corpus"
+        self.root.mkdir()
+
+    def _write(self, relpath):
+        p = self.root / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("{}", encoding="utf-8")
+        return p
+
+    def test_finds_flat_story_at_collection_root(self):
+        p = self._write("fantasy/story1.json")
+        found = list(discovery.find_json_files([self.root]))
+        self.assertIn(p, found)
+
+    def test_finds_nested_bucket_story(self):
+        p = self._write("fantasy/story1/story.json")
+        found = list(discovery.find_json_files([self.root]))
+        self.assertIn(p, found)
+
+    def test_ignores_sidecar_json_in_bucket_dir(self):
+        self._write("fantasy/story1/story.json")
+        sidecar = self._write("fantasy/story1/analysis.json")
+        found = list(discovery.find_json_files([self.root]))
+        self.assertNotIn(sidecar, found)
+
+    def test_mixed_layout_across_collections(self):
+        flat = self._write("fantasy/story1.json")
+        bucket = self._write("horror/story2/story.json")
+        found = set(discovery.find_json_files([self.root]))
+        self.assertEqual(found, {flat, bucket})
+
+    def test_single_json_file_path_is_yielded(self):
+        p = self._write("standalone.json")
+        found = list(discovery.find_json_files([p]))
+        self.assertEqual(found, [p])
+
+    def test_nonexistent_directory_is_skipped_with_warning(self):
+        found = list(discovery.find_json_files([self.root / "nonexistent"]))
+        self.assertEqual(found, [])
+
+    def test_works_when_pointed_directly_at_collection_dir(self):
+        p = self._write("fantasy/story1.json")
+        found = list(discovery.find_json_files([self.root / "fantasy"]))
+        self.assertEqual(found, [p])
+
+    def test_works_when_pointed_directly_at_story_bucket_dir(self):
+        p = self._write("fantasy/story1/story.json")
+        found = list(discovery.find_json_files([self.root / "fantasy" / "story1"]))
+        self.assertEqual(found, [p])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/analysis_tests/discovery_test.py
+++ b/lcats/tests/analysis_tests/discovery_test.py
@@ -3,6 +3,7 @@
 import pathlib
 import unittest
 
+from lcats.utils import capture
 from lcats.utils import test_utils
 from lcats.analysis.corpus import discovery
 
@@ -63,6 +64,31 @@ class TestIterCollectionStoryFiles(test_utils.TestCaseWithData):
         found = list(discovery.iter_collection_story_files(self.root / "nonexistent"))
         self.assertEqual(found, [])
 
+    def test_flat_file_literally_named_story_json_is_reserved(self):
+        """story.json is reserved for the bucket marker; a flat file with
+        that literal name is skipped (with a warning), not treated as an
+        ordinary flat story -- otherwise a directory one level up could
+        never tell "collection with an oddly-named flat file" apart from
+        "story's own bucket directory"."""
+        self._write("story.json")
+        other = self._write("other_story.json")
+        with capture.capture_output() as captured:
+            found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [other])
+        self.assertIn("reserved", captured.stderr.getvalue())
+
+    def test_skips_symlinked_entries(self):
+        real_target = self.root.parent / "outside_target"
+        real_target.mkdir()
+        (real_target / "story.json").write_text("{}", encoding="utf-8")
+        link = self.root / "linked_story"
+        try:
+            link.symlink_to(real_target)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks not supported in this environment")
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [])
+
 
 class TestFindJsonFiles(test_utils.TestCaseWithData):
     """Unit tests for discovery.find_json_files."""
@@ -118,6 +144,25 @@ class TestFindJsonFiles(test_utils.TestCaseWithData):
         p = self._write("fantasy/story1/story.json")
         found = list(discovery.find_json_files([self.root / "fantasy" / "story1"]))
         self.assertEqual(found, [p])
+
+    def test_pointed_directly_at_bucket_dir_excludes_sidecar(self):
+        """Regression test: pointing find_json_files directly at a bucket
+        directory that also holds a sidecar JSON file must yield only the
+        canonical story file, not the sidecar."""
+        p = self._write("fantasy/story1/story.json")
+        self._write("fantasy/story1/analysis.json")
+        found = list(discovery.find_json_files([self.root / "fantasy" / "story1"]))
+        self.assertEqual(found, [p])
+
+    def test_ordinary_flat_filenames_survive_root_level_scan(self):
+        """Regression test: a collection with plainly-named flat stories
+        (no collision with the reserved story.json name) is fully found
+        when scanning starts at the corpus root, not just at the
+        collection itself."""
+        s1 = self._write("sherlock/story1.json")
+        s2 = self._write("sherlock/story2.json")
+        found = set(discovery.find_json_files([self.root]))
+        self.assertEqual(found, {s1, s2})
 
 
 if __name__ == "__main__":

--- a/lcats/tests/datasets_tests/torchdata_test.py
+++ b/lcats/tests/datasets_tests/torchdata_test.py
@@ -1,0 +1,56 @@
+"""Unit tests for lcats.datasets.torchdata.JsonDataset."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from lcats.datasets import torchdata
+
+
+class TestJsonDataset(unittest.TestCase):
+    """Tests for JsonDataset's dual-layout file discovery."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp)
+
+    def _write(self, relpath, data):
+        path = os.path.join(self.tmp, relpath)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        return path
+
+    def test_finds_flat_story(self):
+        self._write("collection/story1.json", {"name": "Flat1"})
+        dataset = torchdata.JsonDataset(root_dir=self.tmp)
+        self.assertEqual(len(dataset), 1)
+        self.assertEqual(dataset[0]["name"], "Flat1")
+
+    def test_finds_nested_bucket_story(self):
+        self._write("collection/story1/story.json", {"name": "Bucket1"})
+        dataset = torchdata.JsonDataset(root_dir=self.tmp)
+        self.assertEqual(len(dataset), 1)
+        self.assertEqual(dataset[0]["name"], "Bucket1")
+
+    def test_ignores_sidecar_json_in_bucket_dir(self):
+        self._write("collection/story1/story.json", {"name": "Bucket1"})
+        self._write("collection/story1/analysis.json", {"unrelated": "data"})
+        dataset = torchdata.JsonDataset(root_dir=self.tmp)
+        self.assertEqual(len(dataset), 1)
+
+    def test_subdirectory_argument_scopes_search(self):
+        self._write("collectionA/story1.json", {"name": "A1"})
+        self._write("collectionB/story2.json", {"name": "B1"})
+        dataset = torchdata.JsonDataset(root_dir=self.tmp, subdirectory="collectionA")
+        self.assertEqual(len(dataset), 1)
+        self.assertEqual(dataset[0]["name"], "A1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/stories_test.py
+++ b/lcats/tests/stories_test.py
@@ -408,6 +408,28 @@ class TestCorpora(unittest.TestCase):
         self.assertEqual(len(result["fantasy"]), 1)
         self.assertEqual(result["fantasy"][0].name, "S1")
 
+    def test_get_corpora_skips_symlinked_collection_dirs(self):
+        """A symlinked directory directly under the corpora root is not
+        traversed as a collection, matching the discovery helpers'
+        follow_symlinks=False convention."""
+        outside = os.path.join(self.tmp, "..", "outside_collection")
+        outside = os.path.abspath(outside)
+        os.makedirs(outside, exist_ok=True)
+        with open(os.path.join(outside, "story1.json"), "w", encoding="utf-8") as f:
+            json.dump({"name": "Outside"}, f)
+        try:
+            os.symlink(outside, os.path.join(self.tmp, "linked_collection"))
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks not supported in this environment")
+        try:
+            corpora = stories.Corpora(self.tmp)
+            result = corpora.get_corpora()
+            self.assertEqual(result, {})
+        finally:
+            import shutil
+
+            shutil.rmtree(outside)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lcats/tests/stories_test.py
+++ b/lcats/tests/stories_test.py
@@ -341,6 +341,73 @@ class TestCorpora(unittest.TestCase):
         names = {s.name for s in result}
         self.assertEqual(names, {"A1", "A2", "B1"})
 
+    def _make_bucket_story(self, corpus_dir, story_slug, data):
+        """Helper: create a per-story-bucket <story_slug>/story.json file."""
+        bucket_dir = os.path.join(corpus_dir, story_slug)
+        os.makedirs(bucket_dir)
+        path = os.path.join(bucket_dir, "story.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def test_get_corpora_loads_nested_bucket_story(self):
+        """get_corpora finds stories in <collection>/<story>/story.json."""
+        corpus_dir = os.path.join(self.tmp, "fantasy")
+        os.makedirs(corpus_dir)
+        self._make_bucket_story(
+            corpus_dir, "story1", {"name": "Bucket1", "body": "B1", "metadata": {}}
+        )
+        corpora = stories.Corpora(self.tmp)
+        result = corpora.get_corpora()
+        self.assertIn("fantasy", result)
+        self.assertEqual(len(result["fantasy"]), 1)
+        self.assertEqual(result["fantasy"][0].name, "Bucket1")
+
+    def test_get_corpora_mixed_flat_and_bucket_layout(self):
+        """get_corpora combines flat and bucket stories within one collection."""
+        corpus_dir = self._make_corpus_dir(
+            "mixed", [{"name": "Flat1", "body": "F1", "metadata": {}}]
+        )
+        self._make_bucket_story(
+            corpus_dir,
+            "bucket_story",
+            {"name": "Bucket1", "body": "B1", "metadata": {}},
+        )
+        corpora = stories.Corpora(self.tmp)
+        result = corpora.get_corpora()
+        self.assertEqual(len(result["mixed"]), 2)
+        names = {s.name for s in result["mixed"]}
+        self.assertEqual(names, {"Flat1", "Bucket1"})
+
+    def test_get_corpora_bucket_story_not_treated_as_new_collection(self):
+        """A nested story bucket is grouped under its real collection, not
+        spuriously surfaced as a new top-level collection key (regression
+        test for the original os.walk-based traversal bug)."""
+        corpus_dir = os.path.join(self.tmp, "sherlock")
+        os.makedirs(corpus_dir)
+        self._make_bucket_story(
+            corpus_dir, "story1", {"name": "S1", "body": "B1", "metadata": {}}
+        )
+        corpora = stories.Corpora(self.tmp)
+        result = corpora.get_corpora()
+        self.assertEqual(set(result.keys()), {"sherlock"})
+        self.assertNotIn("story1", result)
+
+    def test_get_corpora_ignores_sidecar_json_in_bucket_dir(self):
+        """A non-canonical JSON file inside a story's bucket directory (e.g.
+        analysis output) is not picked up as a second story."""
+        corpus_dir = os.path.join(self.tmp, "fantasy")
+        os.makedirs(corpus_dir)
+        self._make_bucket_story(
+            corpus_dir, "story1", {"name": "S1", "body": "B1", "metadata": {}}
+        )
+        sidecar_path = os.path.join(corpus_dir, "story1", "analysis.json")
+        with open(sidecar_path, "w", encoding="utf-8") as f:
+            json.dump({"unrelated": "data"}, f)
+        corpora = stories.Corpora(self.tmp)
+        result = corpora.get_corpora()
+        self.assertEqual(len(result["fantasy"]), 1)
+        self.assertEqual(result["fantasy"][0].name, "S1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Implements WI-STORY-0042 (Stage 1: read-path compatibility) of WS-STORY-BUCKET-LAYOUT, per Decision 3 of PROP-LCATS-STORY-BUCKET-LAYOUT.

- Adds `discovery.iter_collection_story_files`, the canonical story-file selector: recognizes either a flat `<story>.json` file or a nested `<story>/story.json` bucket directory as a valid story source, one level deep, no recursion.
- `Corpora.get_corpora` (`lcats/src/lcats/stories.py`) now uses the selector instead of raw `os.listdir` + `.endswith(".json")`. This also fixes a latent bug in the prior `os.walk`-based traversal, which misgrouped nested story-bucket directories as spurious new top-level collections instead of stories within their real collection.
- `discovery.find_json_files` is rewritten to apply the same flat-vs-canonical-name predicate recursively at every directory level (via a new `_walk_canonical_story_files` helper), so it behaves correctly whether pointed at a corpus root, a single collection dir, or a single story's own dir. `discovery.find_corpus_stories` is deliberately left untouched — its own test suite requires arbitrarily-named nested files to remain discoverable.
- `JsonDataset` (`lcats/src/lcats/datasets/torchdata.py`) now uses `discovery.find_json_files` instead of a manual `os.walk`, so it stays in sync with the rest of the corpus tooling and neither loads sidecar JSON from bucket directories nor regresses flat-file discovery.
- `infer_story_title` (`lcats/src/lcats/analysis/corpus/cli.py`) now falls back to the enclosing directory's slug for canonical `story.json` files (whose stem is otherwise always the useless literal `"story"`), while flat-layout files keep the existing stem fallback.
- No changes to `DataGatherer`'s writer output or any other writer behavior — this stage is read-path only.

## Test plan

- [x] New dual-layout tests: `tests/stories_test.py` (`TestCorpora`, extended with nested/mixed/sidecar/regression cases), `tests/analysis_tests/discovery_test.py` (new file, covers `iter_collection_story_files` and `find_json_files` directly), `tests/analysis_tests/corpus_cli_test.py` (new file, `infer_story_title`), `tests/datasets_tests/torchdata_test.py` (new file, `JsonDataset`)
- [x] `python3 -m pytest tests/` — 1534 passed (repo-wide, no regressions)
- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — clean
- [x] `scripts/test` — 1530 passed
- [x] `lrh validate` — 0 errors (57 pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
