### PR TITLE
Migrate LCATS story write paths to the bucket layout (WI-STORY-0043, Stage 2)

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_08_01_01_34_04_WI_STORY_0043_IMPL_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_08_01_01_34_04_WI_STORY_0043_IMPL_REVIEW.md
@@ -1,0 +1,63 @@
+---
+execution_id: 2026_08_01_01_34_04_WI_STORY_0043_IMPL_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_STORY_0043_IMPL_REVIEW)[2026-08-01T01:33:57+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_01_01_22_37_WI_STORY_0043
+pr: https://github.com/xenotaur/LCATS/pull/203
+commit: c515c88dbf04e9c67ee2c61d5d51f7661c0268e8
+created_at: 2026-08-01T01:34:04+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/203
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Addressed automated review feedback (Codex + Copilot) on PR #203
+(WI-STORY-0043 implementation): a real gap in the zero-story-count
+rejection check, plus two doc-clarity findings.
+
+# Result
+
+- **Codex P1 "Count only canonical stories before approving promotion"**
+  and **Copilot's duplicate finding on the same line** — confirmed by
+  reproduction before fixing: a bucket directory holding only a sidecar
+  (`broken_story/audit.json`, no `story.json`) reported `story_count=1,
+  clean=True` under the original `discovery.find_corpus_stories`-based
+  count, exactly the writer-regression scenario Decision 6's
+  `story_count > 0` check exists to catch. Fixed by switching to
+  `discovery.iter_collection_story_files` (the canonical dual-layout
+  selector), applied here to a single known collection directory — no
+  root-level ambiguity risk, matching `Corpora.get_corpora`'s already-safe
+  usage pattern. Re-verified the fix resolves it (story_count=0,
+  clean=False) without reintroducing the original false-positive concern
+  (a legitimately mid-migration flat collection), since
+  `iter_collection_story_files` already tolerates flat layout per
+  Decision 3. Regression test added
+  (`test_bucket_with_only_sidecar_is_not_clean`). Both threads resolved.
+- **Copilot "ensure() docstring misleading about suffix"** — fixed:
+  docstring now explicitly states `self.suffix` no longer affects the
+  write path at all (retained only for backward-compatible construction).
+  Thread resolved.
+- **Copilot "story_file (below) is misleading"** — fixed: the TSV_COLUMNS
+  comment referenced a "below" placement that was actually above, and
+  didn't clarify `story_file` isn't part of `TSV_COLUMNS` itself. Thread
+  resolved.
+
+All 4 unresolved threads on this PR resolved; none surfaced as
+out-of-scope or requiring further user input.
+
+# Validation
+
+- `python3 -m pytest tests/` — 1556 passed, no regressions.
+- `scripts/format --check --diff` — clean.
+- `scripts/lint` — clean.
+- `lrh validate` — 0 errors, 57 pre-existing unrelated warnings.
+- Fix verified by direct reproduction (bucket-with-only-sidecar scenario)
+  before and after, not just the new unit test.
+
+# Follow-up
+
+- Reviewers retriggered on the fix commit; REVIEW-LANDED being checked
+  separately before the merge verdict.

--- a/lcats/project/executions/AD_HOC/2026_08_01_01_44_07_WI_STORY_0043_IMPL_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_01_01_44_07_WI_STORY_0043_IMPL_CONFIRM.md
@@ -5,7 +5,7 @@ work_item: AD_HOC
 status: in_progress
 rerun_of: 2026_08_01_01_22_37_WI_STORY_0043
 pr: https://github.com/xenotaur/LCATS/pull/203
-commit: 98df773ddab56a1c66cd655ce9436c682fc62142
+commit: 992061fbb0b2e00758fac31906c9b0d5a3e8f5c7
 created_at: 2026-08-01T01:44:07+00:00
 agent: claude_app
 instruction_source: https://github.com/xenotaur/LCATS/pull/203
@@ -60,12 +60,29 @@ rediscover.
 CI on `98df773d`: lint/coverage/both test jobs all SUCCESS. Unresolved
 threads: 0.
 
+**Second round:** pushing this record's own commit (`3bee7b23`) and
+retriggering surfaced one more genuine finding from Codex on the exact
+final HEAD:
+
+- **Codex P2 "Resolve bucket names for bare story.json inputs"** —
+  confirmed by reproduction: `story_dir_value` returned `""` for a bare
+  relative `pathlib.Path("story.json")` (e.g. `lcats survey story.json`
+  run from inside the bucket directory itself), since
+  `Path(".").name == ""`. Fixed by resolving to the absolute path when
+  the lexical parent has no name, recovering the real bucket directory.
+  Regression test added
+  (`test_bare_relative_canonical_file_resolves_parent_name`). Landed on
+  commit `992061fb`. Thread resolved.
+
+Reviewers retriggered a third time on `992061fb`; REVIEW-LANDED confirmed
+separately before the final verdict below.
+
 # Final verdict
 
 **Green** — all threads resolved, CI green, both retriggered reviewers
 confirmed clean on the final HEAD.
 
-`gh pr merge 203 --merge --match-head-commit 98df773ddab56a1c66cd655ce9436c682fc62142`
+`gh pr merge 203 --merge --match-head-commit 992061fbb0b2e00758fac31906c9b0d5a3e8f5c7`
 
 # Validation
 

--- a/lcats/project/executions/AD_HOC/2026_08_01_01_44_07_WI_STORY_0043_IMPL_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_01_01_44_07_WI_STORY_0043_IMPL_CONFIRM.md
@@ -1,0 +1,79 @@
+---
+execution_id: 2026_08_01_01_44_07_WI_STORY_0043_IMPL_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_STORY_0043_IMPL_CONFIRM)[2026-08-01T01:44:00+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_01_01_22_37_WI_STORY_0043
+pr: https://github.com/xenotaur/LCATS/pull/203
+commit: 98df773ddab56a1c66cd655ce9436c682fc62142
+created_at: 2026-08-01T01:44:07+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/203
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge verification and thread-resolution pass for PR #203
+(WI-STORY-0043 implementation), following the single `/lrh-review-response`
+round that fixed the story_count/sidecar gap and two doc-clarity findings.
+
+# Result
+
+Verified all 4 unresolved threads against the live `HEAD` diff before
+resolving (never against the review-response record's own claims):
+
+- **Codex "Count only canonical stories before approving promotion"** and
+  **Copilot's duplicate finding on the same line** — Clear-satisfied.
+  `survey_collection` now uses `discovery.iter_collection_story_files`
+  instead of the broad recursive `find_corpus_stories`, fixing a confirmed
+  (reproduced) gap where a bucket holding only a sidecar file (no
+  `story.json`) was wrongly reported `story_count=1, clean=True`. Both
+  resolved.
+- **Copilot "ensure() docstring misleading about suffix"** — Clear-satisfied,
+  docstring updated. Resolved.
+- **Copilot "story_file (below) is misleading"** — Clear-satisfied, comment
+  wording fixed. Resolved.
+
+Thread-resolution verdict: **4/4 threads resolved, no exceptions.**
+
+**REVIEW-LANDED, single round:** retriggered both reviewers on the fix
+commit (`c515c88d`) plus this record's own commit (`98df773d`). Codex
+confirmed clean directly on `98df773d` ("Reviewed commit: 98df773dda...
+Didn't find any major issues"). Copilot's mention-responder
+(`copilot-swe-agent`) gave a detailed, substantive clean pass explicitly
+covering every changed function and confirming the specific regression
+test reproduces the bug it targets — read in full, not just the
+"no other concerns" headline, per this session's established practice of
+not trusting a clean-looking summary alone.
+
+One item surfaced in Copilot's response, **not from this PR**: a
+pre-existing, confirmed real bug in `DataGatherer.get()` (calls
+`self.download(filename, callback, force)` — 3 positional args against
+`download()`'s 4-parameter signature `(filename, resource, handler,
+force=False)`, so `force` never reaches `download()`'s own `force`
+parameter). Verified by reading both signatures directly. Left unfixed —
+unrelated to WI-STORY-0043's write-path migration scope — and flagged as
+a separate follow-up task rather than silently left for someone to
+rediscover.
+
+CI on `98df773d`: lint/coverage/both test jobs all SUCCESS. Unresolved
+threads: 0.
+
+# Final verdict
+
+**Green** — all threads resolved, CI green, both retriggered reviewers
+confirmed clean on the final HEAD.
+
+`gh pr merge 203 --merge --match-head-commit 98df773ddab56a1c66cd655ce9436c682fc62142`
+
+# Validation
+
+- `python3 -m pytest tests/` — 1556 passed, no regressions.
+- `scripts/format --check --diff`, `scripts/lint` — clean.
+- `lrh validate` — 0 errors, 57 pre-existing unrelated warnings.
+
+# Follow-up
+
+- `DataGatherer.get()`/`download()` positional-argument mismatch (see
+  above) — flagged as a separate follow-up task, not fixed here.

--- a/lcats/project/executions/WI-STORY-0043/2026_08_01_01_22_37_WI_STORY_0043.md
+++ b/lcats/project/executions/WI-STORY-0043/2026_08_01_01_22_37_WI_STORY_0043.md
@@ -1,0 +1,89 @@
+---
+execution_id: 2026_08_01_01_22_37_WI_STORY_0043
+prompt_id: PROMPT(WI-STORY-0043:WI_STORY_0043)[2026-08-01T00:42:08+00:00]
+work_item: WI-STORY-0043
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/203
+commit: a97106ce65dfe3c1561107a4bc7dc7a2fc930e8a
+created_at: 2026-08-01T01:22:37+00:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-STORY-0043.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Implemented `WI-STORY-0043` (Stage 2 of `WS-STORY-BUCKET-LAYOUT`: write-path
+migration), per Decisions 5, 6, 7, and 8 of `PROP-LCATS-STORY-BUCKET-LAYOUT`.
+
+# Result
+
+- `DataGatherer.ensure` (`lcats/src/lcats/gatherers/downloaders.py:200-227`)
+  now creates a per-story bucket directory and writes the reserved canonical
+  filename (`<collection>/<story>/story.json`) instead of the flat
+  `<collection>/<story>.json`. `download()`'s `story_id` is threaded straight
+  through from `filename` instead of a redundant `os.path.splitext`
+  re-derivation — `filename` was already the clean slug (confirmed by tracing
+  its only real caller, `gatherlib.py`'s `names.normalize_basename(...)`),
+  and the old line was exactly the shape of bug the WI's own Risk Notes
+  warned about reintroducing.
+- `parser.gather_story()` (`lcats/src/lcats/gatherers/parser.py`) migrated to
+  the same bucket layout — a second writer site, found during PR #196's
+  review (Decision 8). Also fixed a pre-existing inconsistency where this
+  call site passed an extension-bearing filename into `DataGatherer.ensure`
+  while independently reconstructing its own write path from
+  `constants.DATA_ROOT`, bypassing `ensure()`'s own returned path entirely —
+  a latent divergence risk if `LCATS_DATA_DIR` is ever set differently from
+  the default, closed by using `ensure()`'s return value directly. Left the
+  two other `os.path.splitext(file_name)` occurrences in this file
+  (`test_story_get`/`test_story_get_nc`, lines ~1539/~1599) untouched —
+  confirmed both are debug-only functions with no file-writing at all, out
+  of the WI's explicit scope (only `gather_story()` is named).
+- `output.py` gains a `story_dir` column, appended to the end of
+  `TSV_COLUMNS` (positional consumers keep existing column positions).
+  Populated via a new `story_dir_value()` helper in `parse_special_character_rows`,
+  `finding_to_row`, and `clean_row` — canonical bucket files get their
+  parent directory name, flat files get `""`. `story_file` keeps its
+  existing (now low-value but non-breaking) meaning, per Decision 5.
+- `promote.py`'s `CollectionSurveyResult.clean` now also requires
+  `story_count > 0`, checked on every `survey_collection`/`promote_collections`
+  call rather than as a one-time step (Decision 6), so a writer regression or
+  stale mid-migration collection can no longer be wholesale-copied into
+  `corpora/` undetected. `story_count` stays sourced from the existing,
+  untouched `discovery.find_corpus_stories` (broad recursive finder)
+  specifically to avoid false-positiving on a legitimately mid-migration
+  flat collection, per the WI's own Risk Notes.
+- Blast-radius finding: `output.TSV_COLUMNS` is re-exported by reference as
+  `corpus_survey.TSV_COLUMNS`, and `corpus_survey_test.py` had two
+  assertions hardcoding its prior length/position — fixed to use
+  column-name lookups instead of positional indices, so they don't break on
+  future column additions either. `specials.py`/`specials_cli.py`/`assess_cli.py`
+  each maintain their own independent `TSV_COLUMNS` — confirmed unaffected.
+
+# Validation
+
+- New/updated tests: `downloaders_test.py` (bucket-layout write paths;
+  discovered and fixed one existing test that never actually exercised
+  `ensure()`'s return value — the old code discarded it entirely),
+  `parser_test.py` (mock `gatherer.ensure` now returns a real 2-tuple,
+  matching the new dependency the refactor introduced), `promote_test.py`
+  (zero-story-count rejection at both `survey_collection` and
+  `promote_collections` levels), new `output_test.py` (`story_dir`
+  population across all three row builders), `corpus_survey_test.py` (two
+  positional-index fixes described above).
+- `python3 -m pytest tests/` — 1555 passed, no regressions.
+- `scripts/version tools`, `scripts/format --check --diff`, `scripts/lint`
+  — all clean (`LCATS` conda env: black 25.11.0, ruff 0.15.0, matching repo
+  pins).
+- `scripts/test` — 1551 passed.
+- `lrh validate` — 0 errors, 57 pre-existing warnings unrelated to this
+  change.
+
+# Follow-up
+
+- `status` is `in_progress`; update to `landed` via `/lrh-closeout` after
+  PR #203 merges.
+- Next natural step: implement `WI-STORY-0044` (Stage 3, convergence —
+  fixtures/tests/docs normalization, standing promote validation already
+  landed here, dual-layout retraction as its own gated follow-up).

--- a/lcats/src/lcats/analysis/corpus/output.py
+++ b/lcats/src/lcats/analysis/corpus/output.py
@@ -98,10 +98,19 @@ def story_dir_value(file_path: pathlib.Path) -> str:
     whose own leaf name is always the same reserved string and therefore not
     a usable identifier on its own (Decision 5 of
     PROP-LCATS-STORY-BUCKET-LAYOUT).
+
+    Falls back to the resolved (absolute) path when the lexical parent has
+    no name -- e.g. a bare relative ``story.json`` invoked from inside the
+    bucket directory itself, whose ``pathlib.Path(...).parent`` is ``.``
+    and therefore has an empty ``.name``. Resolving recovers the real
+    directory name in that case instead of leaving the column blank.
     """
-    if file_path.name == discovery.CANONICAL_STORY_FILENAME:
-        return file_path.parent.name
-    return ""
+    if file_path.name != discovery.CANONICAL_STORY_FILENAME:
+        return ""
+    parent_name = file_path.parent.name
+    if parent_name:
+        return parent_name
+    return file_path.resolve().parent.name
 
 
 def parse_special_character_rows(

--- a/lcats/src/lcats/analysis/corpus/output.py
+++ b/lcats/src/lcats/analysis/corpus/output.py
@@ -31,9 +31,11 @@ TSV_COLUMNS = [
     "story_identifier",
     # Appended (not inserted) so positional TSV consumers keep existing
     # column positions -- see Decision 5 of PROP-LCATS-STORY-BUCKET-LAYOUT.
-    # story_file (below) is the leaf filename, always "story.json" for a
-    # canonical bucket file post-migration and therefore non-unique;
-    # story_dir is the actual per-story identity for that case.
+    # story_file (a row-dict field, not part of this schema list -- see
+    # the commented placeholder above) is the leaf filename, always
+    # "story.json" for a canonical bucket file post-migration and
+    # therefore non-unique; story_dir is the actual per-story identity
+    # for that case.
     "story_dir",
 ]
 IDENTIFIER_FIELDS = ("path", "filename", "title")

--- a/lcats/src/lcats/analysis/corpus/output.py
+++ b/lcats/src/lcats/analysis/corpus/output.py
@@ -6,6 +6,7 @@ import pathlib
 
 from typing import Mapping, Sequence
 
+from lcats.analysis.corpus import discovery
 from lcats.analysis.corpus import models
 
 DEFAULT_OUTPUT_FORMAT = "human"
@@ -28,6 +29,12 @@ TSV_COLUMNS = [
     # "story_file",
     # "path",
     "story_identifier",
+    # Appended (not inserted) so positional TSV consumers keep existing
+    # column positions -- see Decision 5 of PROP-LCATS-STORY-BUCKET-LAYOUT.
+    # story_file (below) is the leaf filename, always "story.json" for a
+    # canonical bucket file post-migration and therefore non-unique;
+    # story_dir is the actual per-story identity for that case.
+    "story_dir",
 ]
 IDENTIFIER_FIELDS = ("path", "filename", "title")
 DEFAULT_IDENTIFIER_FIELD = "path"
@@ -82,6 +89,19 @@ def severity_from_classification(classification: str) -> str:
     return "warning"
 
 
+def story_dir_value(file_path: pathlib.Path) -> str:
+    """Return the story's bucket directory name, or "" for a flat file.
+
+    Only meaningful for a canonical per-story-bucket file (``story.json``),
+    whose own leaf name is always the same reserved string and therefore not
+    a usable identifier on its own (Decision 5 of
+    PROP-LCATS-STORY-BUCKET-LAYOUT).
+    """
+    if file_path.name == discovery.CANONICAL_STORY_FILENAME:
+        return file_path.parent.name
+    return ""
+
+
 def parse_special_character_rows(
     tsv_output: str, file_path: pathlib.Path, story_title: str = ""
 ) -> list[dict[str, str]]:
@@ -103,6 +123,7 @@ def parse_special_character_rows(
             {
                 "story_title": story_title,
                 "story_file": file_path.name,
+                "story_dir": story_dir_value(file_path),
                 "path": str(file_path),
                 "check": compact_value("special-characters", CHECK_VALUE_MAP),
                 "kind": compact_value("special-character", KIND_VALUE_MAP),
@@ -140,6 +161,7 @@ def finding_to_row(
         {
             "story_title": story_title,
             "story_file": file_path.name,
+            "story_dir": story_dir_value(file_path),
             "path": str(file_path),
             "check": compact_value(check_name, CHECK_VALUE_MAP),
             "kind": compact_value(finding.kind, KIND_VALUE_MAP),
@@ -161,6 +183,7 @@ def clean_row(file_path: pathlib.Path, story_title: str = "") -> dict[str, str]:
         {
             "story_title": story_title,
             "story_file": file_path.name,
+            "story_dir": story_dir_value(file_path),
             "path": str(file_path),
             "check": "summary",
             "kind": "clean",

--- a/lcats/src/lcats/analysis/corpus/promote.py
+++ b/lcats/src/lcats/analysis/corpus/promote.py
@@ -55,8 +55,16 @@ class CollectionSurveyResult:
 
     @property
     def clean(self) -> bool:
-        """Return True when the collection has no blocking findings."""
-        return not self.findings
+        """Return True when the collection has no blocking findings and at
+        least one story.
+
+        A zero-story collection is never clean, even with no findings -- a
+        writer regression or a stale/mid-migration collection would
+        otherwise report `findings=()` and be promoted (wholesale-copied)
+        undetected. This is a standing check on every survey, not a
+        one-time step (Decision 6 of PROP-LCATS-STORY-BUCKET-LAYOUT).
+        """
+        return not self.findings and self.story_count > 0
 
 
 def survey_collection(

--- a/lcats/src/lcats/analysis/corpus/promote.py
+++ b/lcats/src/lcats/analysis/corpus/promote.py
@@ -89,7 +89,17 @@ def survey_collection(
         if allowlist is not None
         else specials.load_allowlist_config(specials.default_allowlist_config_path())
     )
-    story_paths = discovery.find_corpus_stories(collection_dir)
+    # Use the canonical dual-layout selector, not find_corpus_stories's
+    # broad recursive JSON match -- a bucket directory holding only
+    # sidecars (audit.json etc.) and no story.json is exactly the
+    # writer-regression case Decision 6's story_count > 0 check exists to
+    # catch, and find_corpus_stories would silently count the sidecar as
+    # a story instead. iter_collection_story_files still tolerates a flat
+    # collection mid-migration (Decision 3), so this is not a regression
+    # of that concern -- it's the same selector Corpora.get_corpora uses,
+    # applied here to a single known collection directory (no root-level
+    # ambiguity risk).
+    story_paths = list(discovery.iter_collection_story_files(collection_dir))
     findings: list[BlockingFinding] = []
     for story_path in story_paths:
         data = cli.read_story_data(story_path)

--- a/lcats/src/lcats/gatherers/downloaders.py
+++ b/lcats/src/lcats/gatherers/downloaders.py
@@ -8,6 +8,7 @@ import shutil
 import requests
 
 from lcats import constants
+from lcats.analysis.corpus import discovery
 from lcats.gatherers import normalization
 from lcats.utils import env
 from lcats.utils import names
@@ -197,7 +198,14 @@ class DataGatherer:
         return os.path.join(self.root, self.name)
 
     def ensure(self, filename):
-        """Ensure the directory tree exists and whether the file is there."""
+        """Ensure the story's bucket directory exists and whether its canonical
+        file is there.
+
+        Writes to ``<collection>/<filename>/story.json`` (Decision 8 of
+        PROP-LCATS-STORY-BUCKET-LAYOUT) rather than the old flat
+        ``<collection>/<filename><suffix>`` path -- ``filename`` names the
+        story's own subdirectory now, not a leaf file stem.
+        """
         # Create the root directory if it doesn't exist
         paths.makedirs(self.root)
 
@@ -212,8 +220,12 @@ class DataGatherer:
                     self.license if self.license else "No license provided."
                 )
 
-        # Check if the file exists
-        file_path = os.path.join(self.path, filename + self.suffix)
+        # Create the story's own bucket directory and point at its canonical
+        # file -- the leaf filename is always the reserved canonical name,
+        # not filename + self.suffix.
+        story_dir = os.path.join(self.path, filename)
+        paths.makedirs(story_dir)
+        file_path = os.path.join(story_dir, discovery.CANONICAL_STORY_FILENAME)
         return os.path.exists(file_path), file_path
 
     def resource(self, resource, force=False):
@@ -242,11 +254,16 @@ class DataGatherer:
 
             # Apply replayable gather-time repairs (rules + per-story overrides)
             # before the first write so the fix is reproduced on every
-            # regeneration, not stored as a one-off.
+            # regeneration, not stored as a one-off. story_id is the
+            # canonical story name (filename) itself, threaded straight
+            # through -- never re-derived from the write path's leaf name,
+            # which is always the reserved canonical filename post-migration
+            # and would collapse every story onto one overrides key
+            # (Decision 7 of PROP-LCATS-STORY-BUCKET-LAYOUT).
             normalization.normalize_story_dict(
                 data_to_save,
                 collection=self.name,
-                story_id=os.path.splitext(filename)[0],
+                story_id=filename,
             )
 
             # Write data to JSON file

--- a/lcats/src/lcats/gatherers/downloaders.py
+++ b/lcats/src/lcats/gatherers/downloaders.py
@@ -204,7 +204,11 @@ class DataGatherer:
         Writes to ``<collection>/<filename>/story.json`` (Decision 8 of
         PROP-LCATS-STORY-BUCKET-LAYOUT) rather than the old flat
         ``<collection>/<filename><suffix>`` path -- ``filename`` names the
-        story's own subdirectory now, not a leaf file stem.
+        story's own subdirectory now, not a leaf file stem. ``self.suffix``
+        no longer affects the write path at all: the leaf filename is
+        always the reserved canonical name, never ``filename + self.suffix``
+        -- ``suffix`` is retained only as a constructor parameter/attribute
+        for backward compatibility, not consulted here.
         """
         # Create the root directory if it doesn't exist
         paths.makedirs(self.root)

--- a/lcats/src/lcats/gatherers/parser.py
+++ b/lcats/src/lcats/gatherers/parser.py
@@ -1430,6 +1430,12 @@ def gather_story(gatherer, story):
     file_name = names.title_and_author_to_filename(
         title, author, ext=constants.FILE_SUFFIX, max_len=50
     )
+    # The story's canonical slug (no extension): names the bucket
+    # subdirectory (Decision 8 of PROP-LCATS-STORY-BUCKET-LAYOUT) and is
+    # threaded straight through as the overrides story_id -- never
+    # re-derived from the write path's leaf name, which is always the
+    # reserved canonical filename post-migration (Decision 7).
+    story_slug = os.path.splitext(file_name)[0]
 
     print(f"Gathering story {story}: {title}")
     print(f" - File name: {file_name}")
@@ -1460,16 +1466,15 @@ def gather_story(gatherer, story):
     normalization.normalize_story_dict(
         data_to_save,
         collection=storymap.TARGET_DIRECTORY,
-        story_id=os.path.splitext(file_name)[0],
+        story_id=story_slug,
     )
 
     # Move all of this code up into the API so it is done consistently.
-    # Ensure the data directory exists
-    path = os.path.join(constants.DATA_ROOT, storymap.TARGET_DIRECTORY)
-
-    # Ensure the file path exists.
-    file_path = os.path.join(path, file_name)
-    gatherer.ensure(file_name)
+    # Ensure the story's bucket directory exists and get its canonical file
+    # path -- use gatherer.ensure()'s own returned path (respects
+    # gatherer.root / env.data_root(), rather than reconstructing a
+    # possibly-diverging path from constants.DATA_ROOT independently).
+    _, file_path = gatherer.ensure(story_slug)
 
     # Write data to JSON file
     with open(file_path, "w", encoding="utf-8") as json_file:

--- a/lcats/tests/analysis_tests/corpus_survey_test.py
+++ b/lcats/tests/analysis_tests/corpus_survey_test.py
@@ -369,7 +369,10 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
 
         self.assertEqual(1, len(rows))
         row = rows[0]
-        self.assertEqual(corpus_survey.TSV_COLUMNS, list(row.keys())[:15])
+        self.assertEqual(
+            corpus_survey.TSV_COLUMNS,
+            list(row.keys())[: len(corpus_survey.TSV_COLUMNS)],
+        )
         self.assertEqual("Story Title", row["story_title"])
         self.assertEqual("story.json", row["story_file"])
         self.assertEqual("story.json", row["path"])
@@ -470,7 +473,8 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
         self.assertTrue(all(not line.startswith("#check=") for line in lines[1:]))
         first_data = lines[1].split("\t")
         self.assertEqual("spchar", first_data[0])
-        self.assertEqual("story.json", first_data[-1])
+        first_row = dict(zip(corpus_survey.TSV_COLUMNS, first_data))
+        self.assertEqual("story.json", first_row["story_identifier"])
 
     def test_main_tsv_output_file_writes_and_skips_stdout(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -559,7 +563,8 @@ class CorpusSurveyCliHelpersTest(unittest.TestCase):
 
         output = "".join(call.args[0] for call in fake_stdout.write.call_args_list)
         lines = [line for line in output.splitlines() if line]
-        self.assertEqual("story.json", lines[1].split("\t")[-1])
+        first_row = dict(zip(corpus_survey.TSV_COLUMNS, lines[1].split("\t")))
+        self.assertEqual("story.json", first_row["story_identifier"])
 
     def test_compact_human_tsv_row_truncates_unicode_name(self):
         row = corpus_survey.compact_human_tsv_row(

--- a/lcats/tests/analysis_tests/output_test.py
+++ b/lcats/tests/analysis_tests/output_test.py
@@ -1,6 +1,8 @@
 """Unit tests for lcats.analysis.corpus.output."""
 
+import os
 import pathlib
+import tempfile
 import unittest
 
 from lcats.analysis.corpus import models
@@ -17,6 +19,22 @@ class TestStoryDirValue(unittest.TestCase):
     def test_flat_file_returns_empty_string(self):
         path = pathlib.Path("collection/my_story.json")
         self.assertEqual("", output.story_dir_value(path))
+
+    def test_bare_relative_canonical_file_resolves_parent_name(self):
+        """A bare `story.json` (e.g. `lcats survey story.json` run from
+        inside the bucket directory) has a lexically empty parent name
+        (`Path(".").name == ""`) -- must resolve to recover the real
+        bucket directory name instead of leaving story_dir blank."""
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bucket_dir = os.path.join(tmpdir, "my_story")
+            os.makedirs(bucket_dir)
+            os.chdir(bucket_dir)
+            try:
+                path = pathlib.Path("story.json")
+                self.assertEqual("my_story", output.story_dir_value(path))
+            finally:
+                os.chdir(original_cwd)
 
 
 class TestTsvColumns(unittest.TestCase):

--- a/lcats/tests/analysis_tests/output_test.py
+++ b/lcats/tests/analysis_tests/output_test.py
@@ -1,0 +1,94 @@
+"""Unit tests for lcats.analysis.corpus.output."""
+
+import pathlib
+import unittest
+
+from lcats.analysis.corpus import models
+from lcats.analysis.corpus import output
+
+
+class TestStoryDirValue(unittest.TestCase):
+    """Tests for output.story_dir_value."""
+
+    def test_canonical_bucket_file_returns_parent_name(self):
+        path = pathlib.Path("collection/my_story/story.json")
+        self.assertEqual("my_story", output.story_dir_value(path))
+
+    def test_flat_file_returns_empty_string(self):
+        path = pathlib.Path("collection/my_story.json")
+        self.assertEqual("", output.story_dir_value(path))
+
+
+class TestTsvColumns(unittest.TestCase):
+    """Tests for the TSV_COLUMNS schema."""
+
+    def test_story_dir_is_appended_at_the_end(self):
+        self.assertEqual("story_dir", output.TSV_COLUMNS[-1])
+
+    def test_empty_tsv_row_includes_story_dir(self):
+        row = output.empty_tsv_row()
+        self.assertIn("story_dir", row)
+        self.assertEqual("", row["story_dir"])
+
+
+class TestParseSpecialCharacterRows(unittest.TestCase):
+    """Tests for output.parse_special_character_rows's story_dir population."""
+
+    def test_bucket_file_populates_story_dir(self):
+        tsv_output = "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tlikely_good\tliteral"
+        path = pathlib.Path("collection/my_story/story.json")
+
+        rows = output.parse_special_character_rows(tsv_output, path, "Title")
+
+        self.assertEqual(1, len(rows))
+        self.assertEqual("my_story", rows[0]["story_dir"])
+        self.assertEqual("story.json", rows[0]["story_file"])
+
+    def test_flat_file_leaves_story_dir_empty(self):
+        tsv_output = "U+00A9\t©\tCOPYRIGHT SIGN\t1\t2\tctx\tlikely_good\tliteral"
+        path = pathlib.Path("collection/my_story.json")
+
+        rows = output.parse_special_character_rows(tsv_output, path, "Title")
+
+        self.assertEqual(1, len(rows))
+        self.assertEqual("", rows[0]["story_dir"])
+
+
+class TestFindingToRow(unittest.TestCase):
+    """Tests for output.finding_to_row's story_dir population."""
+
+    def test_bucket_file_populates_story_dir(self):
+        finding = models.Finding(
+            kind="start-contamination",
+            severity="warning",
+            span=(0, 10),
+            evidence={"line": "By Author"},
+            message="Likely author line at start of story.",
+        )
+        path = pathlib.Path("collection/my_story/story.json")
+
+        row = output.finding_to_row(path, "Title", "boundary-contamination", finding)
+
+        self.assertEqual("my_story", row["story_dir"])
+
+
+class TestCleanRow(unittest.TestCase):
+    """Tests for output.clean_row's story_dir population."""
+
+    def test_bucket_file_populates_story_dir(self):
+        path = pathlib.Path("collection/my_story/story.json")
+
+        row = output.clean_row(path, "Title")
+
+        self.assertEqual("my_story", row["story_dir"])
+
+    def test_flat_file_leaves_story_dir_empty(self):
+        path = pathlib.Path("collection/my_story.json")
+
+        row = output.clean_row(path, "Title")
+
+        self.assertEqual("", row["story_dir"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/analysis_tests/promote_test.py
+++ b/lcats/tests/analysis_tests/promote_test.py
@@ -74,6 +74,21 @@ class SurveyCollectionTest(unittest.TestCase):
 
             self.assertTrue(result.clean)
 
+    def test_zero_story_collection_is_not_clean(self):
+        """A collection with no stories is never clean, even with no
+        findings -- a writer regression or stale collection must not be
+        promoted wholesale undetected (Decision 6 of
+        PROP-LCATS-STORY-BUCKET-LAYOUT)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collection_dir = pathlib.Path(tmpdir) / "empty_collection"
+            collection_dir.mkdir(parents=True)
+
+            result = promote.survey_collection(collection_dir)
+
+            self.assertEqual(0, result.story_count)
+            self.assertEqual((), result.findings)
+            self.assertFalse(result.clean)
+
 
 class PromoteCollectionsTest(unittest.TestCase):
     """Tests for the survey-gated promotion pass (acceptance criteria)."""
@@ -116,6 +131,23 @@ class PromoteCollectionsTest(unittest.TestCase):
                 "A clean sentence.",
                 json.loads(promoted_story.read_text(encoding="utf-8"))["body"],
             )
+
+    def test_zero_story_collection_is_blocked_not_promoted(self):
+        with (
+            tempfile.TemporaryDirectory() as source_tmp,
+            tempfile.TemporaryDirectory() as dest_tmp,
+        ):
+            source_root = pathlib.Path(source_tmp)
+            dest_root = pathlib.Path(dest_tmp)
+            (source_root / "empty").mkdir(parents=True)
+
+            report = promote.promote_collections(source_root, dest_root)
+
+            self.assertEqual((), report.promoted)
+            self.assertEqual(1, len(report.blocked))
+            self.assertEqual("empty", report.blocked[0].collection)
+            self.assertEqual(0, report.blocked[0].story_count)
+            self.assertFalse((dest_root / "empty").exists())
 
     def test_mixed_collections_promote_clean_and_block_damaged_independently(self):
         with (

--- a/lcats/tests/analysis_tests/promote_test.py
+++ b/lcats/tests/analysis_tests/promote_test.py
@@ -89,6 +89,24 @@ class SurveyCollectionTest(unittest.TestCase):
             self.assertEqual((), result.findings)
             self.assertFalse(result.clean)
 
+    def test_bucket_with_only_sidecar_is_not_clean(self):
+        """A story bucket directory holding only a sidecar (no story.json)
+        must not count as a story -- this is exactly the writer-regression
+        case Decision 6's story_count > 0 check exists to catch, and
+        counting the sidecar would silently defeat it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            collection_dir = pathlib.Path(tmpdir) / "broken_collection"
+            bucket_dir = collection_dir / "broken_story"
+            bucket_dir.mkdir(parents=True)
+            (bucket_dir / "audit.json").write_text(
+                json.dumps({"unrelated": "audit data"}), encoding="utf-8"
+            )
+
+            result = promote.survey_collection(collection_dir)
+
+            self.assertEqual(0, result.story_count)
+            self.assertFalse(result.clean)
+
 
 class PromoteCollectionsTest(unittest.TestCase):
     """Tests for the survey-gated promotion pass (acceptance criteria)."""

--- a/lcats/tests/gatherers_tests/downloaders_test.py
+++ b/lcats/tests/gatherers_tests/downloaders_test.py
@@ -8,6 +8,7 @@ import unittest
 from unittest.mock import patch, Mock
 
 from lcats import constants
+from lcats.analysis.corpus import discovery
 from lcats.utils import test_utils
 from lcats.gatherers import downloaders
 from lcats.utils import capture
@@ -644,10 +645,22 @@ class TestDataGatherer(test_utils.TestCaseWithData):
         with open(license_path, encoding="utf-8") as f:
             self.assertEqual(f.read(), "MIT License")
 
+    def test_ensure_creates_story_bucket_directory(self):
+        """Test that ensure creates a per-story bucket subdirectory."""
+        _, file_path = self.gatherer.ensure("testfile")
+
+        story_dir = os.path.join(self.gatherer.path, "testfile")
+        self.assertTrue(os.path.isdir(story_dir))
+        self.assertEqual(
+            file_path, os.path.join(story_dir, discovery.CANONICAL_STORY_FILENAME)
+        )
+
     def test_ensure_returns_true_when_file_exists(self):
         """Test that ensure returns True for an already-present file."""
         self.gatherer.ensure("testfile")
-        file_path = os.path.join(self.gatherer.path, "testfile" + self.gatherer.suffix)
+        file_path = os.path.join(
+            self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
+        )
         with open(file_path, "w", encoding="utf-8") as f:
             f.write("content")
 
@@ -662,6 +675,24 @@ class TestDataGatherer(test_utils.TestCaseWithData):
             result = self.gatherer.resource("any_key")
         self.assertEqual(result, "hello")
 
+    def test_download_threads_filename_as_story_id(self):
+        """Test that download passes filename itself as story_id, not a
+        re-derivation from the write path's leaf name (Decision 7 of
+        PROP-LCATS-STORY-BUCKET-LAYOUT)."""
+        self.gatherer.resource_cache = self._make_lambda_cache()
+
+        def handler(contents):
+            del contents
+            return "Test Name", "Test body text", {}
+
+        with patch(
+            "lcats.gatherers.downloaders.normalization.normalize_story_dict"
+        ) as mock_normalize:
+            with capture.suppress_output():
+                self.gatherer.download("my_story_slug", "test_resource", handler)
+
+        self.assertEqual(mock_normalize.call_args.kwargs["story_id"], "my_story_slug")
+
     def test_download_creates_json_file(self):
         """Test that download writes a structured JSON file."""
         self.gatherer.resource_cache = self._make_lambda_cache()
@@ -673,7 +704,9 @@ class TestDataGatherer(test_utils.TestCaseWithData):
         with capture.suppress_output():
             self.gatherer.download("testfile", "test_resource", handler)
 
-        file_path = os.path.join(self.gatherer.path, "testfile" + self.gatherer.suffix)
+        file_path = os.path.join(
+            self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
+        )
         self.assertTrue(os.path.exists(file_path))
         with open(file_path, encoding="utf-8") as f:
             data = json.load(f)
@@ -697,7 +730,9 @@ class TestDataGatherer(test_utils.TestCaseWithData):
     def test_download_skips_existing_file(self):
         """Test that download does not overwrite an existing file."""
         self.gatherer.ensure("testfile")
-        file_path = os.path.join(self.gatherer.path, "testfile" + self.gatherer.suffix)
+        file_path = os.path.join(
+            self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
+        )
         original_data = {"name": "Original", "body": "original", "metadata": {}}
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(original_data, f)
@@ -736,7 +771,9 @@ class TestDataGatherer(test_utils.TestCaseWithData):
         with capture.suppress_output():
             self.gatherer.download("testfile", "test_resource", handler2, force=True)
 
-        file_path = os.path.join(self.gatherer.path, "testfile" + self.gatherer.suffix)
+        file_path = os.path.join(
+            self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
+        )
         with open(file_path, encoding="utf-8") as f:
             data = json.load(f)
         self.assertEqual(data["name"], "New Name")
@@ -744,7 +781,9 @@ class TestDataGatherer(test_utils.TestCaseWithData):
     def test_get_returns_existing_file(self):
         """Test that get reads and returns an existing JSON file."""
         self.gatherer.ensure("testfile")
-        file_path = os.path.join(self.gatherer.path, "testfile" + self.gatherer.suffix)
+        file_path = os.path.join(
+            self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
+        )
         saved = {"name": "Test", "body": "content", "metadata": {}}
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(saved, f)

--- a/lcats/tests/gatherers_tests/parser_test.py
+++ b/lcats/tests/gatherers_tests/parser_test.py
@@ -727,6 +727,7 @@ class TestGatherStory(unittest.TestCase):
     def test_happy_path_saves_story(self):
         """A valid story is saved and the function returns the story ID and path."""
         gatherer = mock.MagicMock()
+        gatherer.ensure.return_value = (False, "/fake/path/the_bell__smith/story.json")
         side_effect = _make_metadata_side_effect(
             subject=["PS", "Short stories"],
             language=["en"],
@@ -752,7 +753,11 @@ class TestGatherStory(unittest.TestCase):
                             result = parser.gather_story(gatherer, 42)
         self.assertEqual(result[0], 42)
         self.assertIsNone(result[2])
-        self.assertIsNotNone(result[1])
+        self.assertEqual(result[1], "/fake/path/the_bell__smith/story.json")
+        # gatherer.ensure is called with the extension-free slug (the bucket
+        # subdirectory name), not the leaf filename with its .json suffix.
+        called_slug = gatherer.ensure.call_args[0][0]
+        self.assertFalse(called_slug.endswith(".json"))
 
 
 class TestTestStories(unittest.TestCase):


### PR DESCRIPTION
## Summary

Implements WI-STORY-0043 (Stage 2: write-path migration) of WS-STORY-BUCKET-LAYOUT, per Decisions 5, 6, 7, and 8 of PROP-LCATS-STORY-BUCKET-LAYOUT.

- **`DataGatherer.ensure`** (`lcats/src/lcats/gatherers/downloaders.py`) now creates a per-story bucket directory and writes the reserved canonical filename (`<collection>/<story>/story.json`) instead of the flat `<collection>/<story>.json`. `download()`'s `story_id` is threaded straight through from `filename` instead of a redundant `os.path.splitext` re-derivation — `filename` was already the clean slug, and the old line was exactly the shape of bug (Decision 7) that's easy to reintroduce during a refactor like this one.
- **`parser.gather_story()`** (`lcats/src/lcats/gatherers/parser.py`) migrated to the same bucket layout (Decision 8 — a second writer site, found during PR #196's review). Also fixed a pre-existing inconsistency where this call site passed an extension-bearing filename into `DataGatherer.ensure` while independently reconstructing its own write path from `constants.DATA_ROOT` rather than using `ensure()`'s own returned path — closed by using `ensure()`'s return value directly.
- **`output.py`** gains a `story_dir` column, appended to the end of `TSV_COLUMNS` (positional consumers keep existing column positions). Populated for canonical bucket files, empty for flat files. `story_file` keeps its existing (now low-value but non-breaking) meaning — no repurposing (Decision 5).
- **`promote.py`**'s `CollectionSurveyResult.clean` now also requires `story_count > 0`, checked on every survey/promote call rather than as a one-time step (Decision 6), so a writer regression or stale mid-migration collection can't be wholesale-copied into `corpora/` undetected. `story_count` stays sourced from the existing, untouched `find_corpus_stories` specifically to avoid false-positiving on a legitimately mid-migration flat collection.

## Test plan

- [x] Updated `downloaders_test.py`/`parser_test.py` for the new bucket-layout write paths (one test previously never exercised `ensure()`'s return value at all — the old code discarded it)
- [x] `promote_test.py` extended with zero-story-count rejection coverage (both `survey_collection` and `promote_collections` levels)
- [x] New `output_test.py` for `story_dir` population across all three row builders
- [x] Fixed two `corpus_survey_test.py` assertions that hardcoded `TSV_COLUMNS`' prior length/position (`output.TSV_COLUMNS` is re-exported by `corpus_survey.py`)
- [x] `python3 -m pytest tests/` — 1555 passed, no regressions
- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — clean
- [x] `scripts/test` — 1551 passed
- [x] `lrh validate` — 0 errors (57 pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
