### PR TITLE
Fix DataGatherer.get() scrambling args when calling download()

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_08_01_05_13_42_GREAT_VOLHARD_22D814_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_08_01_05_13_42_GREAT_VOLHARD_22D814_REVIEW.md
@@ -1,0 +1,58 @@
+---
+execution_id: 2026_08_01_05_13_42_GREAT_VOLHARD_22D814_REVIEW
+prompt_id: PROMPT(AD_HOC:GREAT_VOLHARD_22D814_REVIEW)[2026-08-01T05:07:48+00:00]
+work_item: AD_HOC
+status: landed
+rerun_of:
+pr: https://github.com/xenotaur/LCATS/pull/204
+commit: c16460d5a6bf89e594670819aade4f00c501d5a4
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/204
+session_transcript: claude-app:2cc96e62-2184-4292-95be-3939e59d2380
+created_at: 2026-08-01T05:13:42+00:00
+---
+
+# Summary
+
+Address review feedback on PR #204 (`DataGatherer.get()` argument-scrambling
+fix): both `chatgpt-codex-connector` and `copilot-pull-request-reviewer`
+flagged that the corrected `get()` still returned `None` after triggering a
+download, contradicting its own docstring.
+
+# Result
+
+Fixed: unified `get()`'s two branches in
+`lcats/src/lcats/gatherers/downloaders.py` so that after an optional
+`download()` call, the method always reopens `file_path` and returns the
+parsed JSON contents — no more falling through to an implicit `None` on the
+download path. Both review comments were addressing the same root cause and
+are resolved by this single change.
+
+Skipped: Copilot's secondary note that a `None` `resource`/`handler` would
+raise an unhelpful `TypeError` inside `download()`. `download()` itself has
+no validation on those same parameters, so adding a guard only in `get()`
+would be inconsistent with existing style; no current caller (production or
+test) passes `None` for either. Flagged as a design note, not applied.
+
+No primary implementation record exists for this branch (`GREAT_VOLHARD_22D814`)
+— this PR's original fix was authored ad hoc, not through `/lrh-implement` —
+so `rerun_of` is left empty.
+
+Published: pushed directly to the open PR branch (commit `c16460d5`).
+
+# Validation
+
+- `pytest tests/gatherers_tests/downloaders_test.py` — 53 passed
+- `pytest tests/` (full suite) — 1559 passed
+- `scripts/format --check --diff` / `scripts/lint` — blocked by pre-existing
+  environment tool-version drift (ruff 0.15.12 installed vs. pinned
+  `==0.15.0`; black 26.3.1 installed vs. pinned `25.11.0`), confirmed
+  pre-existing via `git stash` on the same branch. Ran `ruff check` and
+  `black --check --diff` directly against a required-version-stripped config
+  as a diagnostic: both reported clean on the changed files.
+- `lrh validate` — 0 errors, 57 pre-existing warnings (unrelated
+  `owner: unassigned` metadata on old resolved work items)
+
+# Follow-up
+
+None.

--- a/lcats/project/executions/AD_HOC/2026_08_01_05_38_36_GREAT_VOLHARD_22D814_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_01_05_38_36_GREAT_VOLHARD_22D814_CONFIRM.md
@@ -1,0 +1,56 @@
+---
+execution_id: 2026_08_01_05_38_36_GREAT_VOLHARD_22D814_CONFIRM
+prompt_id: PROMPT(AD_HOC:GREAT_VOLHARD_22D814_CONFIRM)[2026-08-01T05:33:32+00:00]
+work_item: AD_HOC
+status: landed
+rerun_of:
+pr: https://github.com/xenotaur/LCATS/pull/204
+commit: 597b586cee96adfeadbc315c1338465f8cad2c76
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/204
+session_transcript: claude-app:2cc96e62-2184-4292-95be-3939e59d2380
+created_at: 2026-08-01T05:38:36+00:00
+---
+
+# Summary
+
+Pre-merge fresh-eyes verification pass on PR #204, following the
+`GREAT_VOLHARD_22D814_REVIEW` fix for both open threads (`get()` returning
+`None` on the download path).
+
+# Result
+
+Verified the current `HEAD` diff (`597b586c`) against both unresolved
+threads:
+
+- `chatgpt-codex-connector` — Clear-satisfied: `get()` now reopens and
+  returns `file_path`'s parsed contents after every download, exactly as
+  requested. Resolved.
+- `copilot-pull-request-reviewer` — Clear-satisfied on its primary concern
+  (same return-type inconsistency). Its secondary note (unhelpful
+  `TypeError` for `None` `resource`/`handler`) was a separately triaged item
+  with a documented skip-rationale in `GREAT_VOLHARD_22D814_REVIEW`, not a
+  blocker on this thread. Resolved.
+
+No exceptions surfaced. Both threads resolved via `resolveReviewThread`
+(thread-resolution verdict: green).
+
+No primary implementation record exists for this branch
+(`GREAT_VOLHARD_22D814`) — this PR's original fix was authored ad hoc, not
+through `/lrh-implement` — so `rerun_of` is left empty.
+
+# Validation
+
+- CI (post-`_CONFIRM`-push, re-checked at Step 8): `test`, `coverage`,
+  `lint` all `pass`. No `required_status_checks` rule exists on `main`
+  (confirmed via `gh api rules/branches/main` — 0 matching rules), so the
+  unfiltered `gh pr checks` aggregate is the correct read, not a
+  timing-race false negative.
+- REVIEW-LANDED: retriggered both `@codex review` and Copilot re-review
+  request against this `_CONFIRM` commit; see Step 8 readiness report for
+  the outcome recorded at merge time.
+- `lrh validate` — 0 errors before this record was committed.
+
+# Follow-up
+
+None.

--- a/lcats/src/lcats/gatherers/downloaders.py
+++ b/lcats/src/lcats/gatherers/downloaders.py
@@ -278,11 +278,11 @@ class DataGatherer:
         else:
             print(f"File {file_path} exists, skipping download.")
 
-    def get(self, filename, callback, force=False):
+    def get(self, filename, resource, handler, force=False):
         """Get the contents of a file if it exists, otherwise download it."""
         file_exists, file_path = self.ensure(filename)
         if not file_exists or force:
-            self.download(filename, callback, force)
+            self.download(filename, resource, handler, force)
         else:
             with open(file_path, "r", encoding="utf-8") as json_file:
                 return json.load(json_file)

--- a/lcats/src/lcats/gatherers/downloaders.py
+++ b/lcats/src/lcats/gatherers/downloaders.py
@@ -283,9 +283,8 @@ class DataGatherer:
         file_exists, file_path = self.ensure(filename)
         if not file_exists or force:
             self.download(filename, resource, handler, force)
-        else:
-            with open(file_path, "r", encoding="utf-8") as json_file:
-                return json.load(json_file)
+        with open(file_path, "r", encoding="utf-8") as json_file:
+            return json.load(json_file)
 
     def clear(self):
         """Remove the gatherer's directory (and everything in it)."""

--- a/lcats/tests/gatherers_tests/downloaders_test.py
+++ b/lcats/tests/gatherers_tests/downloaders_test.py
@@ -794,14 +794,15 @@ class TestDataGatherer(test_utils.TestCaseWithData):
     def test_get_downloads_and_writes_new_file(self):
         """Test that get threads resource and handler through to download
         correctly (not scrambled), by exercising the real download path
-        rather than mocking download out."""
+        rather than mocking download out, and returns the newly downloaded
+        contents rather than None."""
         self.gatherer.resource_cache = self._make_lambda_cache("raw contents")
 
         def handler(contents):
             return "Test Name", f"processed: {contents}", {"key": "value"}
 
         with capture.suppress_output():
-            self.gatherer.get("testfile", "test_resource", handler)
+            result = self.gatherer.get("testfile", "test_resource", handler)
 
         file_path = os.path.join(
             self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
@@ -811,11 +812,13 @@ class TestDataGatherer(test_utils.TestCaseWithData):
         self.assertEqual(data["name"], "Test Name")
         self.assertEqual(data["body"], "processed: raw contents")
         self.assertEqual(data["metadata"], {"key": "value"})
+        self.assertEqual(result, data)
 
     def test_get_force_redownloads_existing_file(self):
         """Test that get(force=True) actually reaches download()'s own
         force parameter, so a forced re-download overwrites the existing
-        file instead of silently being skipped."""
+        file instead of silently being skipped, and returns the refreshed
+        contents."""
         self.gatherer.resource_cache = self._make_lambda_cache("raw contents")
 
         def handler(contents):
@@ -830,7 +833,9 @@ class TestDataGatherer(test_utils.TestCaseWithData):
             return "New Name", "New Body", {}
 
         with capture.suppress_output():
-            self.gatherer.get("testfile", "test_resource", handler2, force=True)
+            result = self.gatherer.get(
+                "testfile", "test_resource", handler2, force=True
+            )
 
         file_path = os.path.join(
             self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
@@ -838,6 +843,7 @@ class TestDataGatherer(test_utils.TestCaseWithData):
         with open(file_path, encoding="utf-8") as f:
             data = json.load(f)
         self.assertEqual(data["name"], "New Name")
+        self.assertEqual(result, data)
 
     def test_clear_removes_path(self):
         """Test that clear removes the gatherer's directory."""
@@ -868,11 +874,24 @@ class TestDataGatherer(test_utils.TestCaseWithData):
         passed straight through, unscrambled, when the file does not yet
         exist."""
         handler = Mock()
-        with patch.object(self.gatherer, "download") as mock_download:
-            self.gatherer.get("missing", "some_resource", handler)
+        file_path = os.path.join(
+            self.gatherer.path, "missing", discovery.CANONICAL_STORY_FILENAME
+        )
+        saved = {"name": "Written by download", "body": "body", "metadata": {}}
+
+        def fake_download(filename, resource, handler_arg, force):
+            del filename, resource, handler_arg, force
+            with open(file_path, "w", encoding="utf-8") as f:
+                json.dump(saved, f)
+
+        with patch.object(
+            self.gatherer, "download", side_effect=fake_download
+        ) as mock_download:
+            result = self.gatherer.get("missing", "some_resource", handler)
             mock_download.assert_called_once_with(
                 "missing", "some_resource", handler, False
             )
+        self.assertEqual(result, saved)
 
     def test_clear_exception_during_removal(self):
         """Test that clear catches exceptions raised while removing items."""

--- a/lcats/tests/gatherers_tests/downloaders_test.py
+++ b/lcats/tests/gatherers_tests/downloaders_test.py
@@ -788,8 +788,56 @@ class TestDataGatherer(test_utils.TestCaseWithData):
         with open(file_path, "w", encoding="utf-8") as f:
             json.dump(saved, f)
 
-        result = self.gatherer.get("testfile", None)
+        result = self.gatherer.get("testfile", "some_resource", None)
         self.assertEqual(result, saved)
+
+    def test_get_downloads_and_writes_new_file(self):
+        """Test that get threads resource and handler through to download
+        correctly (not scrambled), by exercising the real download path
+        rather than mocking download out."""
+        self.gatherer.resource_cache = self._make_lambda_cache("raw contents")
+
+        def handler(contents):
+            return "Test Name", f"processed: {contents}", {"key": "value"}
+
+        with capture.suppress_output():
+            self.gatherer.get("testfile", "test_resource", handler)
+
+        file_path = os.path.join(
+            self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
+        )
+        with open(file_path, encoding="utf-8") as f:
+            data = json.load(f)
+        self.assertEqual(data["name"], "Test Name")
+        self.assertEqual(data["body"], "processed: raw contents")
+        self.assertEqual(data["metadata"], {"key": "value"})
+
+    def test_get_force_redownloads_existing_file(self):
+        """Test that get(force=True) actually reaches download()'s own
+        force parameter, so a forced re-download overwrites the existing
+        file instead of silently being skipped."""
+        self.gatherer.resource_cache = self._make_lambda_cache("raw contents")
+
+        def handler(contents):
+            del contents
+            return "Name", "Body", {}
+
+        with capture.suppress_output():
+            self.gatherer.get("testfile", "test_resource", handler)
+
+        def handler2(contents):
+            del contents
+            return "New Name", "New Body", {}
+
+        with capture.suppress_output():
+            self.gatherer.get("testfile", "test_resource", handler2, force=True)
+
+        file_path = os.path.join(
+            self.gatherer.path, "testfile", discovery.CANONICAL_STORY_FILENAME
+        )
+        with open(file_path, encoding="utf-8") as f:
+            data = json.load(f)
+        self.assertEqual(data["name"], "New Name")
 
     def test_clear_removes_path(self):
         """Test that clear removes the gatherer's directory."""
@@ -816,10 +864,15 @@ class TestDataGatherer(test_utils.TestCaseWithData):
         self.assertTrue(os.path.isdir(gatherer.path))
 
     def test_get_when_file_missing_delegates_to_download(self):
-        """Test that get calls download when the file does not yet exist."""
+        """Test that get calls download with filename, resource, and handler
+        passed straight through, unscrambled, when the file does not yet
+        exist."""
+        handler = Mock()
         with patch.object(self.gatherer, "download") as mock_download:
-            self.gatherer.get("missing", "some_resource")
-            mock_download.assert_called_once()
+            self.gatherer.get("missing", "some_resource", handler)
+            mock_download.assert_called_once_with(
+                "missing", "some_resource", handler, False
+            )
 
     def test_clear_exception_during_removal(self):
         """Test that clear catches exceptions raised while removing items."""


### PR DESCRIPTION
## Summary
- `DataGatherer.get()` called `download(filename, callback, force)` against `download()`'s 4-param signature `(filename, resource, handler, force)`, so the handler landed in `resource`, the `force` bool landed in `handler`, and `download()`'s own `force` silently stayed `False`.
- `get()` had no `resource` parameter at all, so it could never have worked correctly for the missing-file/download path. It's now `get(filename, resource, handler, force=False)`, forwarding all four args straight through to `download()`.
- Confirmed via repo-wide grep that no production caller currently uses `get()` — all real gatherers (`gatherlib.py`, `sherlock/gatherer.py`, `lovecraft/gatherer.py`, `mass_quantities/gatherer.py`) call `download()` directly — so this fix has no call-site fallout.
- Surfaced by Copilot's review on PR #203 (WI-STORY-0043) as a pre-existing issue out of that PR's scope.

## Test plan
- [x] Updated `test_get_returns_existing_file` and `test_get_when_file_missing_delegates_to_download` to the corrected 3-required-arg signature, with the latter asserting the exact forwarded call.
- [x] Added `test_get_downloads_and_writes_new_file` and `test_get_force_redownloads_existing_file`, which exercise the real (unmocked) download path — these would have caught the original scrambling bug.
- [x] `pytest tests/gatherers_tests/` — 320 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
