### PR TITLE
Add work item WI-STORY-0045: retract dual-layout story discovery support

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_08_01_20_26_07_WI_STORY_0045.md
+++ b/lcats/project/executions/AD_HOC/2026_08_01_20_26_07_WI_STORY_0045.md
@@ -1,0 +1,62 @@
+---
+execution_id: 2026_08_01_20_26_07_WI_STORY_0045
+prompt_id: PROMPT(AD_HOC:WI_STORY_0045)[2026-08-01T20:00:17+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/206
+commit: 002a54f7b7a82b759325cf713a4b6f7dcdf65c2d
+created_at: 2026-08-01T20:26:07+00:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-STORY-0045.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Created `WI-STORY-0045`, a placeholder/gated work item for Part B of
+`WS-STORY-BUCKET-LAYOUT` (dual-layout retraction), split out of
+`WI-STORY-0044`'s own prose-deferred "Part B" so the workstream's exit
+criterion 4 has an actual tracked artifact instead of prose deferral
+alone, per the user's explicit request during `WI-STORY-0044`'s closeout.
+
+# Result
+
+- `project/work_items/proposed/WI-STORY-0045.md` created: `type:
+  deliverable`, `related_workstreams: [WS-STORY-BUCKET-LAYOUT]`,
+  `depends_on: [WI-STORY-0044]`. The hard gate (a real, human,
+  release-time `lcats gather` + `lcats promote` migration of the
+  production `corpora/` snapshot) is expressed via
+  `forbidden_actions: [retract_before_confirmed_corpus_migration, ...]`,
+  the first acceptance-criteria item (an explicit dated checklist
+  confirmation required before any code is touched), and extensively in
+  `## Problem / Context` and `## Risk Notes` — not via the schema's
+  `blocked: true` field, which `lrh validate` rejected for a `proposed`
+  (not `active`) status item; fixed to `blocked: false` after that real
+  validation error.
+- Prior-art check: duplication none found; demand confirmed by
+  `PROP-LCATS-STORY-BUCKET-LAYOUT` Decision 4 and
+  `WS-STORY-BUCKET-LAYOUT`'s own exit criterion 4, both of which name
+  this retraction directly.
+- Next global WI number confirmed as 0045 (max across all prefixes, per
+  the shared cross-prefix numbering convention) before minting the ID.
+
+# Validation
+
+- `lrh validate` — 0 errors. 2 new `OWNER_ROLE_INSUFFICIENT`/
+  `OWNER_NOT_IN_CONTRIBUTORS` warnings for `owner: unassigned`, matching
+  the pre-existing pattern already present on every other WI in this
+  repo (57 → 59 total pre-existing-shaped warnings, none new in kind).
+- `lrh work-items readiness WI-STORY-0045` — schema-valid,
+  `prompt_ready: yes` (the schema has no field for "blocked on an
+  external non-WI action"; the real gate relies on `/lrh-implement`'s
+  own Step 2, which reads the full work item body, encountering the
+  prose gate and forbidden_actions before any code would be touched).
+
+# Follow-up
+
+- `status` is `in_progress`; update to `landed` via `/lrh-closeout` after
+  PR #206 merges.
+- This WI stays blocked (in the practical, prose sense) until the real
+  production `corpora/` migration happens — do not implement it
+  prematurely even if it later shows as "ready" in tooling.

--- a/lcats/project/executions/AD_HOC/2026_08_01_21_11_28_WI_STORY_0045_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_08_01_21_11_28_WI_STORY_0045_REVIEW.md
@@ -1,0 +1,81 @@
+---
+execution_id: 2026_08_01_21_11_28_WI_STORY_0045_REVIEW
+prompt_id: PROMPT(AD_HOC:WI_STORY_0045_REVIEW)[2026-08-01T21:11:19+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_01_20_26_07_WI_STORY_0045
+pr: https://github.com/xenotaur/LCATS/pull/206
+commit: c77e06e334b22e64b019f880511eb5385f9a83ce
+created_at: 2026-08-01T21:11:28+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/206
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Addressed automated review feedback (Codex + Copilot, auto-triggered on
+PR open) on PR #206 (WI-STORY-0045 creation), then dispatched a fresh,
+independent Explore sub-agent to verify the bot findings and search for
+anything they missed, per the user's explicit preference for sub-agent
+re-review over re-triggering GitHub bots.
+
+# Result
+
+Four bot findings, all confirmed real before fixing:
+
+- **Codex "Register the item in the workstream"** — stale by the time
+  reviewed: an earlier commit (`2126a93b`) had already added
+  `WI-STORY-0045` to `WS-STORY-BUCKET-LAYOUT.md`'s `work_items:` list;
+  the bot's review ran against a prior commit and GitHub didn't mark the
+  file-level comment outdated. Resolved without further change.
+- **Codex "Keep rejection coverage for flat layouts"** — real design
+  gap: Required Changes item 4 said to blanket-delete flat-layout tests,
+  leaving no regression coverage that flat files are actually rejected
+  post-retraction. Fixed: item 4 now says to convert representative
+  positive cases into negative (rejection) tests instead.
+- **Copilot "forbidden_actions naming inconsistency"** — confirmed by
+  direct comparison against `WI-STORY-0044.md`'s already-merged
+  `forbidden_actions`: my new WI used a different token
+  (`retract_before_confirmed_corpus_migration`) for the same gate
+  WI-STORY-0044 calls `retract_dual_layout_without_confirmed_corpus_migration`.
+  Fixed: renamed to match the established term.
+- **Copilot "Validation formatting inconsistency"** — confirmed:
+  grepped all 14 other WI files with a `scripts/version tools`
+  Validation bullet; all 14 backtick-wrap commands, WI-STORY-0045 was
+  the sole outlier. Fixed.
+
+The independent sub-agent re-verification (not a rubber stamp — it read
+both changed files, the sibling WI-STORY-0044.md, and cross-checked
+referenced functions in `discovery.py`/`cli.py` directly) confirmed all
+4 above and found 2 more real issues neither I nor the bots caught:
+
+- The frontmatter `acceptance:` list had the **same** blanket-deletion
+  defect as Required Changes item 4, independently — and it's the list
+  `required_evidence` actually checks. Fixing only the prose would have
+  left the WI self-contradictory (Required Changes saying "convert to
+  negative tests," acceptance still saying "removed"). Both now match.
+- `WS-STORY-BUCKET-LAYOUT.md`'s narrative `## Work Items` section was
+  stale: no bullet for `WI-STORY-0045` at all, and the existing
+  `WI-STORY-0044` bullet still claimed *that* WI would perform the
+  retraction — directly contradicting WI-STORY-0044's own (already
+  merged) `resolution:` field, which says the work was split out. Fixed:
+  added a `WI-STORY-0045` bullet, corrected `WI-STORY-0044`'s.
+
+All 4 GitHub threads resolved. Thread-resolution verdict: **4/4
+resolved, 2 additional real findings caught and fixed by independent
+sub-agent review, no exceptions.**
+
+# Validation
+
+- `lrh validate` — 0 errors, 59 pre-existing-pattern warnings (2
+  `owner: unassigned` warnings for the new WI, same shape as every other
+  WI in this repo).
+
+# Follow-up
+
+- REVIEW-LANDED to be re-checked against this commit before the merge
+  verdict — per the user's stated preference, primarily via another
+  independent sub-agent pass rather than actively retriggering GitHub
+  bots (any bot response that lands on its own is still read, not
+  suppressed).

--- a/lcats/project/executions/AD_HOC/2026_08_01_21_19_37_WI_STORY_0045_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_01_21_19_37_WI_STORY_0045_CONFIRM.md
@@ -1,0 +1,64 @@
+---
+execution_id: 2026_08_01_21_19_37_WI_STORY_0045_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_STORY_0045_CONFIRM)[2026-08-01T21:19:26+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_01_20_26_07_WI_STORY_0045
+pr: https://github.com/xenotaur/LCATS/pull/206
+commit: a170623aa95c0dc1766356166a20fdf13e459ac0
+created_at: 2026-08-01T21:19:37+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/206
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge verification for PR #206 (WI-STORY-0045 creation), following
+the review-response round that fixed all 4 bot findings plus 2 more
+caught by an independent sub-agent. Per the user's explicit preference,
+this verification pass used a second fresh, independent Explore
+sub-agent rather than re-triggering GitHub bots.
+
+# Result
+
+- CI on `a170623a`: coverage/lint/both test jobs all SUCCESS.
+- Unresolved threads: 0 (all 4 from the review round resolved; no bot
+  has naturally re-reviewed this commit since it wasn't @-mentioned, per
+  instruction — none needed to, since nothing here is application code).
+- Dispatched a second, independent Explore sub-agent (isolated worktree,
+  no memory of the fix round) to re-verify all 5 fixes with fresh eyes
+  against the current file content, not trust the prior round's
+  self-report. Confirmed: all 5 fixes present and correct; the
+  frontmatter `acceptance:` list and `## Required Changes` body section
+  are consistent with each other; `forbidden_actions`' renamed term has
+  zero stale references anywhere in either changed file (repo-wide grep
+  by the sub-agent, confirmed only surviving in historical `AD_HOC`
+  execution-record logs, which are append-only history, not defects).
+  No new issues found on this second pass.
+- The sub-agent's own `lrh validate` run (from a different cwd inside
+  its isolated worktree) reported a `FILE_NOT_FOUND` error for
+  `focus/current_focus.md` — recognized as the known "must run from
+  `lcats/`" cwd gotcha, not a real error. Re-ran `lrh validate` myself
+  from the correct `lcats/` directory on the actual PR branch: 0 errors,
+  59 pre-existing-pattern warnings.
+
+Thread-resolution verdict: **4/4 resolved. Green** — all threads
+resolved, CI green, independent sub-agent re-verification confirmed
+clean on the final HEAD.
+
+# Final verdict
+
+**Green**
+
+`gh pr merge 206 --merge --match-head-commit a170623aa95c0dc1766356166a20fdf13e459ac0`
+
+# Validation
+
+- `lrh validate` (from `lcats/`, the correct cwd) — 0 errors, 59
+  pre-existing warnings.
+- CI — all 4 checks SUCCESS.
+
+# Follow-up
+
+- None.

--- a/lcats/project/work_items/proposed/WI-STORY-0045.md
+++ b/lcats/project/work_items/proposed/WI-STORY-0045.md
@@ -1,0 +1,176 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-STORY-0045
+title: Retract dual-layout story discovery support once corpora/ migration is confirmed
+type: deliverable
+status: proposed
+priority: medium
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams:
+  - WS-STORY-BUCKET-LAYOUT
+related_design:
+  - lcats/project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md
+depends_on:
+  - WI-STORY-0044
+blocked_by: []
+expected_actions:
+  - edit_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - retract_before_confirmed_corpus_migration
+  - run_real_gather_or_promote
+acceptance:
+  - An explicit, dated checklist confirmation is recorded (in this WI's execution record) that the production corpora/ snapshot has been migrated to bucket layout via a real lcats gather + lcats promote run, verified by 0 remaining flat *.json files under corpora/ (git ls-files corpora/ shows only story.json leaves) -- this must happen and be confirmed BEFORE any code in this WI is touched
+  - discovery.py's selectors (iter_collection_story_files, find_json_files) no longer accept a flat <story>.json at the collection root -- only <story>/story.json is valid; the reserved-filename warning/skip logic becomes unreachable and is removed
+  - infer_story_title's flat-file .stem fallback is removed; only the bucket-directory-slug path remains meaningful
+  - All flat-layout-specific tests and fixtures across discovery_test.py, stories_test.py, corpus_cli_test.py, torchdata_test.py are removed, not just left passing incidentally
+  - find_corpus_stories (the broad recursive JSON finder used for corpus-wide stats) is explicitly confirmed out of scope -- it is not part of the flat/bucket duality and is unaffected
+  - lrh validate reports 0 errors
+required_evidence:
+  - manual_review
+  - lrh_validate
+  - test_output
+artifacts_expected:
+  - lcats/src/lcats/analysis/corpus/discovery.py
+  - lcats/src/lcats/analysis/corpus/cli.py
+  - lcats/tests/analysis_tests/discovery_test.py
+  - lcats/tests/stories_test.py
+  - lcats/tests/analysis_tests/corpus_cli_test.py
+  - lcats/tests/datasets_tests/torchdata_test.py
+---
+
+## Summary
+
+Retracts Stage 1's dual-layout read tolerance (flat
+`<collection>/<story>.json` support) from LCATS's story discovery code,
+once -- and only once -- the real production `corpora/` snapshot has been
+confirmed migrated to the bucket layout via an actual `lcats gather` +
+`lcats promote` run. Final piece of `PROP-LCATS-STORY-BUCKET-LAYOUT`'s
+expand-contract migration (Decision 4). Part B, gated, of what was
+originally scoped as WI-STORY-0044's Stage 3.
+
+## Problem / Context
+
+Decision 4 of the governing proposal chose a staged expand-contract
+pattern (Fowler's Parallel Change) specifically to avoid a hard cutover.
+Stages 1-3 (`WI-STORY-0042`, `WI-STORY-0043`, `WI-STORY-0044`) landed the
+"expand" phase -- dual-layout read support, bucket-layout writes, and
+convergence -- while carefully preserving flat-layout reads throughout.
+Retracting that tolerance before the real `corpora/` content is migrated
+would make `survey`/`stats`/`assess` stop discovering the release
+snapshot entirely (per `WI-STORY-0044`'s own Risk Notes). As of the
+governing proposal, `corpora/` has 1,868 flat files and 0 nested
+`story.json` -- the real migration is a distinct, human, release-time
+action no WI in this workstream performs.
+
+### Duplication search
+- In-repo: No existing implementation of this retraction.
+- Sibling repos: None identified.
+- External libraries: None applicable.
+- Recommendation: Proceed (once unblocked).
+
+### Demand search
+- Work items: None found — this is the explicit final stage named in
+  `PROP-LCATS-STORY-BUCKET-LAYOUT`'s own Implementation Plan and in
+  `WI-STORY-0044`'s Non-Goals (which explicitly deferred it as "a
+  separately-gated action").
+- Proposals: `PROP-LCATS-STORY-BUCKET-LAYOUT` Decision 4 requests exactly
+  this.
+- Backlog: `WS-STORY-BUCKET-LAYOUT`'s own exit criterion 4 names this
+  work directly.
+- Recommendation: Proceed (once unblocked).
+
+## Scope
+
+- Verify and record the migration-confirmation checklist (the hard gate).
+- Remove flat-layout tolerance from `discovery.py`'s selectors.
+- Remove the now-dead flat-file fallback in `infer_story_title`.
+- Remove flat-layout-specific tests and fixtures.
+- Does not perform the actual production migration itself.
+- Does not touch `find_corpus_stories` or any writer code (already
+  bucket-only since Stage 2).
+
+## Required Changes
+
+1. Before touching any code: confirm via `git ls-files corpora/` (or
+   equivalent) that the real production `corpora/` snapshot contains 0
+   flat story files -- every story is `<collection>/<story>/story.json`.
+   Record this confirmation, with the date and evidence, in this work
+   item's execution record.
+2. Simplify `discovery.iter_collection_story_files` and
+   `discovery.find_json_files` (`lcats/src/lcats/analysis/corpus/discovery.py`)
+   to require the bucket layout exclusively -- a flat `<story>.json` at a
+   collection root is no longer a valid story source. The reserved-name
+   warning/skip logic for a flat file literally named `story.json`
+   becomes unreachable dead code once flat files aren't accepted at all,
+   and should be removed rather than left in place.
+3. Remove `infer_story_title`'s flat-file `.stem` fallback
+   (`lcats/src/lcats/analysis/corpus/cli.py`) -- once flat files are no
+   longer discoverable, that branch is unreachable.
+4. Remove flat-layout fixtures and test cases from `discovery_test.py`,
+   `stories_test.py`, `corpus_cli_test.py`, and `torchdata_test.py` that
+   specifically exercised the now-retracted tolerance; keep bucket-layout
+   coverage.
+5. Update any remaining docs/comments that describe dual-layout tolerance
+   as current behavior.
+
+## Non-Goals
+
+- Does not perform the actual production `lcats gather` + `lcats promote`
+  run migrating real corpus content -- a separate, release-time human
+  action this item depends on but does not include.
+- Does not touch `discovery.find_corpus_stories` -- a separate, broad
+  recursive JSON finder used for corpus-wide stats, not part of the
+  flat/bucket duality this item retracts.
+- Does not touch writer code (`DataGatherer.ensure`, `parser.gather_story()`)
+  -- already bucket-only since `WI-STORY-0043`.
+- Does not touch `notebooks/` or `experiments/`.
+
+## Acceptance Criteria
+
+(see frontmatter `acceptance:` above)
+
+## Validation
+
+- scripts/version tools
+- lrh validate
+- scripts/format --check --diff
+- scripts/lint
+- scripts/test
+
+## Risk Notes
+
+- The single biggest risk is the ordering itself: retracting before the
+  real migration is confirmed would silently break discovery of the
+  entire release corpus, since `survey`/`stats`/`assess` would no longer
+  find any story in a still-flat `corpora/` tree. The acceptance
+  criteria's first item (an explicit, dated, verified checklist
+  confirmation) exists specifically to make this an unmissable, checkable
+  gate rather than a prose-only promise -- per the project convention
+  that WS/WI exit criteria need an actual recorded artifact, not just
+  deferral language.
+- This item may sit blocked for an extended, indefinite period -- the
+  real production migration is scheduled at the project's discretion, not
+  this workstream's. Do not treat a long blocked duration as a signal to
+  proceed early.
+
+## Dependencies / Order
+
+Depends on `WI-STORY-0044` (Stage 3 Part A, convergence) having landed --
+it has, via PR #205. Blocked on the real production `corpora/` migration
+described above, which has not happened as of this work item's creation.
+
+## Related Workstream and Designs
+
+- Workstream: `project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md`
+- Design: `project/design/proposals/proposed/lcats-story-bucket-layout/00_proposal.md`

--- a/lcats/project/work_items/proposed/WI-STORY-0045.md
+++ b/lcats/project/work_items/proposed/WI-STORY-0045.md
@@ -27,13 +27,13 @@ expected_actions:
 forbidden_actions:
   - force_push
   - delete_branch
-  - retract_before_confirmed_corpus_migration
+  - retract_dual_layout_without_confirmed_corpus_migration
   - run_real_gather_or_promote
 acceptance:
   - An explicit, dated checklist confirmation is recorded (in this WI's execution record) that the production corpora/ snapshot has been migrated to bucket layout via a real lcats gather + lcats promote run, verified by 0 remaining flat *.json files under corpora/ (git ls-files corpora/ shows only story.json leaves) -- this must happen and be confirmed BEFORE any code in this WI is touched
   - discovery.py's selectors (iter_collection_story_files, find_json_files) no longer accept a flat <story>.json at the collection root -- only <story>/story.json is valid; the reserved-filename warning/skip logic becomes unreachable and is removed
   - infer_story_title's flat-file .stem fallback is removed; only the bucket-directory-slug path remains meaningful
-  - All flat-layout-specific tests and fixtures across discovery_test.py, stories_test.py, corpus_cli_test.py, torchdata_test.py are removed, not just left passing incidentally
+  - Representative flat-layout positive test cases across discovery_test.py, stories_test.py, corpus_cli_test.py, torchdata_test.py are converted to negative tests asserting rejection of flat-layout input, so a later regression cannot silently restore the retracted compatibility; redundant flat-layout fixtures are removed, not just left passing incidentally
   - find_corpus_stories (the broad recursive JSON finder used for corpus-wide stats) is explicitly confirmed out of scope -- it is not part of the flat/bucket duality and is unaffected
   - lrh validate reports 0 errors
 required_evidence:
@@ -117,10 +117,13 @@ action no WI in this workstream performs.
 3. Remove `infer_story_title`'s flat-file `.stem` fallback
    (`lcats/src/lcats/analysis/corpus/cli.py`) -- once flat files are no
    longer discoverable, that branch is unreachable.
-4. Remove flat-layout fixtures and test cases from `discovery_test.py`,
-   `stories_test.py`, `corpus_cli_test.py`, and `torchdata_test.py` that
-   specifically exercised the now-retracted tolerance; keep bucket-layout
-   coverage.
+4. Convert representative flat-layout positive test cases in
+   `discovery_test.py`, `stories_test.py`, `corpus_cli_test.py`, and
+   `torchdata_test.py` into negative tests asserting the selectors and
+   downstream consumers now reject or ignore flat-layout input -- do not
+   simply delete all flat-layout coverage, or a later regression could
+   silently restore the compatibility this item exists to remove. Remove
+   the remaining, now-redundant flat-layout fixtures/cases.
 5. Update any remaining docs/comments that describe dual-layout tolerance
    as current behavior.
 
@@ -142,11 +145,11 @@ action no WI in this workstream performs.
 
 ## Validation
 
-- scripts/version tools
-- lrh validate
-- scripts/format --check --diff
-- scripts/lint
-- scripts/test
+- `scripts/version tools`
+- `lrh validate`
+- `scripts/format --check --diff`
+- `scripts/lint`
+- `scripts/test`
 
 ## Risk Notes
 

--- a/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
+++ b/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
@@ -17,6 +17,7 @@ work_items:
   - WI-STORY-0042
   - WI-STORY-0043
   - WI-STORY-0044
+  - WI-STORY-0045
 exit_criteria:
   - "Stage 1 (read-path compatibility) lands: discovery/identity logic is dual-layout-tolerant (Decisions 2-3), with a canonical story-file selector and dual-layout tests, writer output unchanged"
   - "Stage 2 (write-path migration) lands: DataGatherer.ensure and parser.gather_story() both write <collection>/<story>/story.json (Decision 8); overrides story_id derivation fixed (Decision 7); output identifier semantics updated with new story_dir/story_slug column (Decision 5); lcats promote itself rejects zero-story-count collections (Decision 6)"

--- a/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
+++ b/lcats/project/workstreams/proposed/WS-STORY-BUCKET-LAYOUT.md
@@ -92,9 +92,13 @@ to closeout.
   identifier semantics (Decision 5); add standing zero-story-count
   rejection to `lcats promote` (Decision 6).
 - **WI-STORY-0044** — Convergence: normalize tests/fixtures/docs to the
-  new layout, run an explicit end-to-end gather-then-promote validation
-  pass, and land dual-layout retraction (Decision 4) as its own follow-up
-  once the tracked `corpora/` snapshot is confirmed migrated.
+  new layout and run an explicit end-to-end gather-then-promote validation
+  pass. Dual-layout retraction (Decision 4) was split out to
+  `WI-STORY-0045` rather than performed here.
+- **WI-STORY-0045** — Retraction (Decision 4), gated: remove dual-layout
+  read tolerance from story discovery once the tracked `corpora/`
+  snapshot is confirmed migrated to the bucket layout via a real
+  production `lcats gather` + `lcats promote` run.
 
 ## Exit Criteria
 


### PR DESCRIPTION
## Summary

Adds `WI-STORY-0045`, a placeholder/gated work item for Part B of the per-story bucket layout migration (`WS-STORY-BUCKET-LAYOUT`): retracting Stage 1's dual-layout read tolerance, once the real production `corpora/` snapshot is confirmed migrated to bucket layout.

This was originally described as WI-STORY-0044's own "Part B," deferred without a tracked artifact. Splitting it into its own work item gives `WS-STORY-BUCKET-LAYOUT` an actual trackable placeholder for exit criterion 4, rather than leaving it as prose deferral.

**Type**: deliverable
**Related workstream**: `WS-STORY-BUCKET-LAYOUT`
**Depends on**: `WI-STORY-0044` (Stage 3 Part A — merged, PR #205)
**Hard gate**: not implementable until a real, human, release-time `lcats gather` + `lcats promote` run migrates the production `corpora/` snapshot (currently 1,868 flat files, 0 nested `story.json`) — a `forbidden_actions` entry (`retract_before_confirmed_corpus_migration`) and the acceptance criteria's first item both encode this explicitly.

**Acceptance criteria**:
- Explicit, dated checklist confirmation of the real corpus migration, recorded before any code changes
- `discovery.py`'s selectors retract flat-layout tolerance; the now-unreachable reserved-filename warning logic is removed
- `infer_story_title`'s flat-file `.stem` fallback removed
- Flat-layout-specific tests/fixtures removed across 4 test files
- `find_corpus_stories` (a separate, broad recursive finder) explicitly confirmed out of scope
- `lrh validate` reports 0 errors

## Test plan

- [x] `lrh validate` — 0 errors (2 new pre-existing-pattern `owner: unassigned` warnings, consistent with every other WI in this repo)
- [x] `lrh work-items readiness WI-STORY-0045` — schema-valid; the real gate is expressed in prose/forbidden_actions since the schema's `blocked: true` flag is reserved for `status: active` items, not `proposed`

PROMPT(AD_HOC:WI_STORY_0045)[2026-08-01T20:00:17+00:00]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
