### PR TITLE
Retract dual-layout story discovery to bucket-only (WI-STORY-0045)

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_08_02_01_38_06_WI_STORY_0045_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_01_38_06_WI_STORY_0045_CONFIRM.md
@@ -1,0 +1,74 @@
+---
+execution_id: 2026_08_02_01_38_06_WI_STORY_0045_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_STORY_0045_CONFIRM)[2026-08-02T05:22:59+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_02_04_31_59_WI_STORY_0045
+pr: https://github.com/xenotaur/LCATS/pull/207
+commit: 4dca45ee6e2e5300a6b9eba54a723e8e81255b42
+created_at: 2026-08-02T01:38:06-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/207
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge verification and thread-resolution pass for PR #207
+(WI-STORY-0045). Verified pushed review fixes against the live `HEAD` diff,
+resolved the review thread the diff plainly satisfies, and surfaced the
+rest as exceptions per user decision, per `/lrh-confirm-fixes`'s own
+protocol (inlined per `/lrh-land`'s Phase 1 interim invocation pattern).
+
+# Result
+
+- Gathered state: `lrh github threads` (raw, all states) showed 3 total
+  threads -- 1 resolved (Codex, stale dual-layout docstrings, fixed by
+  commit `4dca45ee`), 2 unresolved (both Copilot, on the pre-existing
+  `_walk_canonical_story_files` masking bug, deliberately left open per
+  explicit user decision -- see thread IDs `PRRT_kwDOKlhIbM6Vt3Pq` and
+  `PRRT_kwDOKlhIbM6Vt3P4`, and the spawned follow-up task
+  "Fix stray story.json masking bug in discovery.py").
+- CI: `gh pr checks 207` -- coverage, lint, test (x2) all SUCCESS.
+- **Per explicit user direction, substituted a fresh independent
+  subagent review for the GitHub bot retrigger-and-wait mechanism this
+  skill's Step 3/Step 8 would otherwise use** (re-triggering Codex/Copilot
+  is expensive; see memory
+  `feedback_prefer_subagent_review_over_github_bots`). Dispatched a
+  cold-context subagent (PR URL + diff only, no session memory) to
+  independently review the full diff and re-run the test suite.
+  - Verdict: clean pass. Confirmed the retraction is correct and complete,
+    confirmed the test conversions are genuine assertions (not renamed
+    placebos), independently re-ran `pytest tests/` -- 1563 passed.
+  - One new minor finding: `output.py:95`'s `story_dir_value` "flat file"
+    branch appears to be dead code in production now (traced every real
+    caller back to the now bucket-only `find_json_files`), but reads as
+    reasonable generic defensive behavior for any non-canonical path, not
+    literally dual-layout tolerance. Verified the trace myself (not just
+    trusted the subagent) before presenting it. User elected to leave this
+    as-is -- out of WI-STORY-0045's scope, consistent with WI-STORY-0044's
+    precedent for not adding coverage/changes to already-structurally-
+    agnostic code.
+- Confirm gate: presented the full batch (resolved/unresolved threads, CI
+  state, subagent verdict, new finding) to the user; user confirmed.
+- Thread-resolution verdict (Step 6): the one Clear-satisfied thread was
+  already resolved before this record was authored; no further threads
+  were eligible for batch resolution. The 2 remaining threads are an
+  intentional, user-approved exception, not an oversight.
+
+# Validation
+
+- `python3 -m pytest tests/ -q` -- 1563 passed (run independently by the
+  dispatched subagent, cross-checked against this session's own earlier
+  run).
+- `gh pr checks 207` -- all required-adjacent checks green.
+- `lrh validate` -- to be re-run after this record is committed.
+
+# Follow-up
+
+- The 2 open Copilot threads remain open on GitHub as a deliberate marker;
+  tracked via the spawned background task rather than a code fix in this
+  PR.
+- Per this run's chain-authorization gate (Step 2 of `/lrh-land`), next is
+  the merge gate (Step 6) and closeout (Step 7) once merge readiness is
+  reported.

--- a/lcats/project/executions/WI-STORY-0045/2026_08_02_04_31_59_WI_STORY_0045.md
+++ b/lcats/project/executions/WI-STORY-0045/2026_08_02_04_31_59_WI_STORY_0045.md
@@ -9,7 +9,7 @@ commit: a0ae2af510db370c17da1b571862c4755c5b7d56
 created_at: 2026-08-02T04:31:59+00:00
 agent: claude_app
 instruction_source: project/work_items/proposed/WI-STORY-0045.md
-session_transcript: pending
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
 ---
 
 # Summary
@@ -85,7 +85,6 @@ verified via `git ls-tree`).
 
 - `status` is `in_progress`; update to `landed` via `/lrh-closeout` after
   PR #207 merges.
-- `session_transcript` is `pending`; fill in once available.
 - Next steps in the usual review chain: `/lrh-review-response` →
   `/lrh-confirm-fixes` → merge → `/lrh-closeout`, at which point
   `WI-STORY-0045` resolves and `WS-STORY-BUCKET-LAYOUT` Part B (the

--- a/lcats/project/executions/WI-STORY-0045/2026_08_02_04_31_59_WI_STORY_0045.md
+++ b/lcats/project/executions/WI-STORY-0045/2026_08_02_04_31_59_WI_STORY_0045.md
@@ -1,0 +1,92 @@
+---
+execution_id: 2026_08_02_04_31_59_WI_STORY_0045
+prompt_id: PROMPT(WI-STORY-0045:WI_STORY_0045)[2026-08-02T03:58:18+00:00]
+work_item: WI-STORY-0045
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/207
+commit: a0ae2af510db370c17da1b571862c4755c5b7d56
+created_at: 2026-08-02T04:31:59+00:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-STORY-0045.md
+session_transcript: pending
+---
+
+# Summary
+
+Implemented `WI-STORY-0045`: retracted the temporary flat/bucket dual-layout
+tolerance in story discovery (Decision 4 of
+`PROP-LCATS-STORY-BUCKET-LAYOUT`), gated on the migration-confirmation
+checklist evidence already recorded in
+`project/executions/AD_HOC/2026_08_02_03_18_05_WI_STORY_0045_MIGRATION_CONFIRMED.md`
+showing the real production `corpora/` snapshot fully migrated (1,868 files
+renamed via `lcats gather` + `lcats promote`, 0 remaining flat files
+verified via `git ls-tree`).
+
+# Result
+
+- `discovery.iter_collection_story_files` and `discovery.find_json_files`:
+  simplified to bucket-only selection (`<story>/story.json`). A flat
+  `<story>.json` file is no longer discovered, whether encountered during a
+  directory scan (any depth) or passed as an explicit literal file path
+  argument. Chose to retract the literal-path case too (not just directory
+  scans), since leaving it un-retracted would have left
+  `infer_story_title`'s flat-file `.stem` fallback technically reachable,
+  contradicting this WI's own acceptance criterion that the fallback becomes
+  dead code.
+- `cli.infer_story_title`: simplified to unconditionally return the parent
+  bucket directory's slug; the flat-file fallback branch is removed as
+  confirmed-dead code. The `data` parameter is kept in the signature
+  (unused) to avoid touching 3 unrelated call sites.
+- `find_corpus_stories` (a separate, broad recursive JSON finder): confirmed
+  out of scope per acceptance criteria and left untouched.
+- `promote.py`: fixed one stale comment that described
+  `iter_collection_story_files` as "the canonical dual-layout selector" that
+  "still tolerates a flat collection mid-migration" -- no longer accurate
+  post-retraction.
+- Converted representative flat-layout test cases (not blanket deletions) to
+  negative/rejection assertions, per the WI's Required Changes item 4, in:
+  `discovery_test.py` (23 tests), `stories_test.py` `TestCorpora` class (30
+  tests), `corpus_cli_test.py` (5 tests, all 4 old flat-layout tests removed
+  since the function has no remaining conditional logic to test, 2 new tests
+  added), `torchdata_test.py` (4 tests). Tests that used a flat-layout
+  fixture only incidentally (multi-collection aggregation, property caching,
+  subdirectory scoping) had their fixtures converted to bucket layout
+  instead of their assertions, preserving original test intent.
+- Fixed a ripple-effect breakage discovered via full-suite run:
+  `promote_test.py`'s module-level `_write_story` helper wrote flat-layout
+  fixtures, which the now bucket-only `discovery.iter_collection_story_files`
+  no longer discovers, causing 10 tests to fail against the Stage 2
+  zero-story-count gate. This file was not in the WI's explicit file list.
+  Converted `_write_story` to write bucket layout and updated 5
+  destination-path assertions that hardcoded the promoted file's exact flat
+  path to expect the corresponding bucket path instead (promotion copies
+  whatever structure the source has).
+- Swept `docs/` and remaining code comments for stale dual-layout framing
+  (Required Changes item 5): none found outside historical decision records
+  (`PROP-LCATS-STORY-BUCKET-LAYOUT` itself, prior WI files), which correctly
+  remain as historical narrative.
+
+# Validation
+
+- `python3 -m pytest tests/` -- 1563 passed, no regressions.
+- `ruff check` / `black --check --diff` on all 8 changed files -- clean.
+  The wrapper scripts (`scripts/lint`, `scripts/format`) fail on an
+  unrelated, pre-existing tool-version skew (ruff 0.15.12 vs pinned 0.15.0;
+  black 26.3.1 vs pinned 25.11.0), confirmed present on unmodified `main`
+  via `git stash` before checking -- not introduced by this change. Verified
+  actual lint/format compliance by temporarily stripping the version pins
+  from a local `pyproject.toml` copy, running the real checks, then
+  restoring the file (confirmed no diff after restore).
+- `lrh validate` -- 0 errors, 59 pre-existing warnings (all
+  `owner: unassigned`), none introduced by this change.
+
+# Follow-up
+
+- `status` is `in_progress`; update to `landed` via `/lrh-closeout` after
+  PR #207 merges.
+- `session_transcript` is `pending`; fill in once available.
+- Next steps in the usual review chain: `/lrh-review-response` →
+  `/lrh-confirm-fixes` → merge → `/lrh-closeout`, at which point
+  `WI-STORY-0045` resolves and `WS-STORY-BUCKET-LAYOUT` Part B (the
+  dual-layout retraction) becomes complete.

--- a/lcats/src/lcats/analysis/corpus/cli.py
+++ b/lcats/src/lcats/analysis/corpus/cli.py
@@ -45,24 +45,19 @@ def read_story_text(file_path: pathlib.Path) -> str:
 
 
 def infer_story_title(data: dict, file_path: pathlib.Path) -> str:
-    """Infer stable title from story data, falling back to filename stem.
+    """Infer stable title from a story's bucket directory slug.
 
     Per Decision 2 of PROP-LCATS-STORY-BUCKET-LAYOUT, the directory slug is
-    the *primary* identifier for a canonical per-story-bucket file
-    (``story.json``) -- checked first, ahead of metadata -- because metadata
-    titles are mutable and not guaranteed unique, while the slug is stable.
-    This also sidesteps the leaf stem always being the literal ``"story"``
-    for every bucket file. Flat-layout files are unaffected: they keep the
-    existing content-title-then-stem fallback chain.
+    the identifier for a canonical per-story-bucket file (``story.json``) --
+    stable and unique, unlike metadata titles (mutable, not guaranteed
+    unique) or the leaf stem (always the literal ``"story"`` for every
+    bucket file, useless as an identifier). Per Decision 4 (dual-layout
+    retraction), every discoverable file is now a bucket file, so this is
+    the only identity path -- ``data`` is unused for identity purposes but
+    kept in the signature for caller compatibility.
     """
-    if file_path.name == discovery.CANONICAL_STORY_FILENAME:
-        return file_path.parent.name
-    story_title = (
-        data.get("name") or data.get("metadata", {}).get("name") or ""
-    ).strip()
-    if story_title:
-        return story_title
-    return file_path.stem
+    del data
+    return file_path.parent.name
 
 
 def coerce_story_text(value) -> str:

--- a/lcats/src/lcats/analysis/corpus/discovery.py
+++ b/lcats/src/lcats/analysis/corpus/discovery.py
@@ -57,28 +57,20 @@ def iter_collection_story_files(
     """Yield canonical story files that are immediate entries of collection_dir.
 
     The canonical story-file selector, per Decision 3 of
-    PROP-LCATS-STORY-BUCKET-LAYOUT. Tolerates both layouts:
-
-    - Flat: any ``<story>.json`` file directly in ``collection_dir``, other
-      than the literal name ``story.json`` (reserved, see below).
-    - Bucket: ``<story>/story.json`` -- a subdirectory of ``collection_dir``
-      containing a file literally named ``story.json``.
+    PROP-LCATS-STORY-BUCKET-LAYOUT, as retracted to bucket-only by
+    Decision 4: a story is only ``<story>/story.json`` -- a subdirectory
+    of ``collection_dir`` containing a file literally named
+    ``story.json``. A flat ``<story>.json`` file directly in
+    ``collection_dir`` is no longer a valid story source; the production
+    ``corpora/`` snapshot has been confirmed fully migrated to the bucket
+    layout (see ``WI-STORY-0045``'s execution record).
 
     Applies only one level of nesting relative to ``collection_dir``. A
     subdirectory without a canonical ``story.json`` is skipped, not searched
     further -- ``collection_dir`` is assumed to already be a single
     collection's own directory. Sibling JSON artifacts inside a story's own
     bucket directory (analysis output, override sidecars) are intentionally
-    excluded once nested, since only the canonical leaf name is accepted.
-
-    ``story.json`` is reserved exclusively for the nested bucket marker: a
-    flat file directly in ``collection_dir`` literally named ``story.json``
-    is skipped (with a warning) rather than treated as an ordinary flat
-    story. Without this reservation, a directory one level up could never
-    structurally distinguish "a collection whose own flat file happens to be
-    named story.json" from "a story's own bucket directory" -- the two look
-    identical from outside. Reserving the name removes that ambiguity
-    entirely instead of trying to guess it away.
+    excluded, since only the canonical leaf name is accepted.
 
     Directory entries reached via a symlink are skipped, matching
     :func:`find_corpus_stories`'s default ``follow_symlinks=False``.
@@ -89,18 +81,7 @@ def iter_collection_story_files(
     for entry in sorted(path.iterdir()):
         if entry.is_symlink() and entry.is_dir():
             continue
-        if entry.is_file():
-            if entry.suffix == ".json":
-                if entry.name == CANONICAL_STORY_FILENAME:
-                    print(
-                        f"warning: skipping {entry} -- {CANONICAL_STORY_FILENAME!r} "
-                        "is reserved for per-story bucket directories and cannot "
-                        "be used as a flat story filename",
-                        file=sys.stderr,
-                    )
-                    continue
-                yield entry
-        elif entry.is_dir():
+        if entry.is_dir():
             nested = entry / CANONICAL_STORY_FILENAME
             if nested.is_file():
                 yield nested
@@ -113,21 +94,16 @@ def _walk_canonical_story_files(directory: pathlib.Path) -> Iterator[pathlib.Pat
     its own ``story.json``) -- if so, yields only that canonical file and
     stops, regardless of what other JSON sidecars (``audit.json``,
     ``scenes.json``, ``events.json``, and similar per-story analysis
-    artifacts) sit alongside it. This is a deliberate, unconditional rule,
-    not a best-effort heuristic: once a directory contains ``story.json``,
-    every other JSON file in it is treated as that story's own sidecar
-    content, never as an independent second story -- this is how bucket
-    directories are actually populated once the write path migrates (see
-    Decision 3 of PROP-LCATS-STORY-BUCKET-LAYOUT), so there is no
-    real-world case where "story.json plus another flat story" both belong
-    directly in the same directory. This only matters when ``directory``
-    is handed to this function directly, as a top-level scan target (e.g.
-    a caller pointing straight at one story's bucket) -- reaching a bucket
-    directory via recursion from a collection is already handled by
+    artifacts) sit alongside it. Every other JSON file in a bucket
+    directory is that story's own sidecar content, never an independent
+    second story. This only matters when ``directory`` is handed to this
+    function directly, as a top-level scan target (e.g. a caller pointing
+    straight at one story's bucket) -- reaching a bucket directory via
+    recursion from a collection is already handled by
     :func:`iter_collection_story_files`, which stops at the bucket
     boundary and never recurses into it.
 
-    Otherwise applies :func:`iter_collection_story_files`'s flat-vs-bucket
+    Otherwise applies :func:`iter_collection_story_files`'s bucket-only
     predicate to ``directory``, then recurses into subdirectories that are
     not themselves story buckets -- so this behaves correctly whether
     ``directory`` is a corpus root (immediate children are collection
@@ -151,20 +127,15 @@ def find_json_files(
 ) -> Iterator[pathlib.Path]:
     """Yield canonical story files from provided paths in deterministic order.
 
-    Tolerates both the flat and per-story-bucket layouts (Decision 3 of
-    PROP-LCATS-STORY-BUCKET-LAYOUT) via :func:`_walk_canonical_story_files`,
-    with three exceptions to "any JSON file directly in a scanned directory
-    is eligible regardless of name":
-
-    - If the directory being scanned is itself a story bucket (contains its
-      own ``story.json``), only that canonical file is yielded -- every
-      other JSON sidecar alongside it is excluded, not just files reached
-      by descending further.
-    - A flat file literally named ``story.json`` directly in a directory
-      being scanned as a collection is reserved for the bucket marker and
-      is skipped (with a warning), not treated as an ordinary flat story.
-    - A JSON file reached by descending into a subdirectory is eligible
-      only if it is literally named ``story.json``.
+    Bucket-only, per Decision 4 of PROP-LCATS-STORY-BUCKET-LAYOUT (dual-layout
+    retraction): every story is ``<story>/story.json`` via
+    :func:`_walk_canonical_story_files`. A JSON file is eligible only if it
+    is literally named ``story.json`` -- whether reached by scanning a
+    directory, or passed directly as a literal file path in ``directories``.
+    A non-canonical file path passed directly is silently skipped, matching
+    the same rule a directory scan applies; there is no longer a
+    caller-knows-best exception, since the retraction's whole point is that
+    ``story.json`` is the one and only valid marker everywhere.
     """
     for directory in directories:
         path = pathlib.Path(directory)
@@ -172,7 +143,7 @@ def find_json_files(
             print(f"warning: directory does not exist: {directory}", file=sys.stderr)
             continue
         if path.is_file():
-            if path.suffix == ".json":
+            if path.name == CANONICAL_STORY_FILENAME:
                 yield path
             continue
         yield from _walk_canonical_story_files(path)

--- a/lcats/src/lcats/analysis/corpus/promote.py
+++ b/lcats/src/lcats/analysis/corpus/promote.py
@@ -89,16 +89,14 @@ def survey_collection(
         if allowlist is not None
         else specials.load_allowlist_config(specials.default_allowlist_config_path())
     )
-    # Use the canonical dual-layout selector, not find_corpus_stories's
+    # Use the canonical bucket-only selector, not find_corpus_stories's
     # broad recursive JSON match -- a bucket directory holding only
     # sidecars (audit.json etc.) and no story.json is exactly the
     # writer-regression case Decision 6's story_count > 0 check exists to
     # catch, and find_corpus_stories would silently count the sidecar as
-    # a story instead. iter_collection_story_files still tolerates a flat
-    # collection mid-migration (Decision 3), so this is not a regression
-    # of that concern -- it's the same selector Corpora.get_corpora uses,
-    # applied here to a single known collection directory (no root-level
-    # ambiguity risk).
+    # a story instead. iter_collection_story_files is the same selector
+    # Corpora.get_corpora uses, applied here to a single known collection
+    # directory (no root-level ambiguity risk).
     story_paths = list(discovery.iter_collection_story_files(collection_dir))
     findings: list[BlockingFinding] = []
     for story_path in story_paths:

--- a/lcats/src/lcats/datasets/torchdata.py
+++ b/lcats/src/lcats/datasets/torchdata.py
@@ -18,8 +18,8 @@ class JsonDataset(Dataset):
         else:
             self.data_dir = root_dir
 
-        # Gather canonical story files (flat or per-story-bucket layout, per
-        # Decision 3 of PROP-LCATS-STORY-BUCKET-LAYOUT) in the specified
+        # Gather canonical story files (per-story-bucket layout only, per
+        # Decision 4 of PROP-LCATS-STORY-BUCKET-LAYOUT) in the specified
         # directory and its subdirectories, via the same selector discovery.py
         # uses -- so this dataset stays in sync with the rest of the corpus
         # tooling instead of re-implementing its own traversal.

--- a/lcats/src/lcats/stories.py
+++ b/lcats/src/lcats/stories.py
@@ -45,11 +45,11 @@ class Corpora:
     def get_corpora(self):
         """Utility function to load all corpora from the corpora root.
 
-        Tolerates both the flat (``<collection>/<story>.json``) and
-        per-story-bucket (``<collection>/<story>/story.json``) layouts, per
-        Decision 3 of PROP-LCATS-STORY-BUCKET-LAYOUT. Each immediate
-        subdirectory of the corpora root is treated as one collection;
-        story files within it are found via
+        Only the per-story-bucket layout (``<collection>/<story>/story.json``)
+        is accepted; a flat ``<collection>/<story>.json`` file is not a valid
+        story source, per Decision 4 of PROP-LCATS-STORY-BUCKET-LAYOUT (dual-
+        layout retraction). Each immediate subdirectory of the corpora root
+        is treated as one collection; story files within it are found via
         ``discovery.iter_collection_story_files``, which does not recurse
         past one level -- so a story's own bucket directory is never
         mistaken for a second collection. Symlinked directories directly

--- a/lcats/tests/analysis_tests/corpus_cli_test.py
+++ b/lcats/tests/analysis_tests/corpus_cli_test.py
@@ -9,26 +9,6 @@ from lcats.analysis.corpus import cli
 class TestInferStoryTitle(unittest.TestCase):
     """Tests for cli.infer_story_title."""
 
-    def test_flat_layout_uses_name_field_when_present(self):
-        data = {"name": "Explicit Title"}
-        path = pathlib.Path("collection/my_story.json")
-        self.assertEqual(cli.infer_story_title(data, path), "Explicit Title")
-
-    def test_flat_layout_uses_metadata_name_when_top_level_name_absent(self):
-        data = {"metadata": {"name": "Metadata Title"}}
-        path = pathlib.Path("collection/my_story.json")
-        self.assertEqual(cli.infer_story_title(data, path), "Metadata Title")
-
-    def test_flat_layout_falls_back_to_file_stem(self):
-        data = {}
-        path = pathlib.Path("collection/my_story.json")
-        self.assertEqual(cli.infer_story_title(data, path), "my_story")
-
-    def test_flat_layout_blank_name_field_falls_back_to_stem(self):
-        data = {"name": "   "}
-        path = pathlib.Path("collection/my_story.json")
-        self.assertEqual(cli.infer_story_title(data, path), "my_story")
-
     def test_bucket_layout_falls_back_to_directory_slug(self):
         data = {}
         path = pathlib.Path("collection/my_story/story.json")
@@ -46,6 +26,23 @@ class TestInferStoryTitle(unittest.TestCase):
     def test_bucket_layout_prefers_directory_slug_over_metadata_name(self):
         data = {"metadata": {"name": "Mutable Metadata Title"}}
         path = pathlib.Path("collection/my_story/story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "my_story")
+
+    def test_data_argument_is_entirely_ignored(self):
+        """Regression test for Decision 4 (dual-layout retraction):
+        infer_story_title no longer has any conditional flat-vs-bucket
+        logic -- it always returns the parent directory slug, regardless
+        of story data content."""
+        data = {"name": "Anything At All", "metadata": {"name": "Also Anything"}}
+        path = pathlib.Path("collection/my_story/story.json")
+        self.assertEqual(cli.infer_story_title(data, path), "my_story")
+
+    def test_returns_parent_directory_name_regardless_of_leaf_filename(self):
+        """infer_story_title no longer branches on the leaf filename at
+        all -- every discoverable file is a bucket file post-retraction, so
+        the parent directory name is returned unconditionally."""
+        data = {}
+        path = pathlib.Path("collection/my_story/anything.json")
         self.assertEqual(cli.infer_story_title(data, path), "my_story")
 
 

--- a/lcats/tests/analysis_tests/discovery_test.py
+++ b/lcats/tests/analysis_tests/discovery_test.py
@@ -3,7 +3,6 @@
 import pathlib
 import unittest
 
-from lcats.utils import capture
 from lcats.utils import test_utils
 from lcats.analysis.corpus import discovery
 
@@ -22,21 +21,27 @@ class TestIterCollectionStoryFiles(test_utils.TestCaseWithData):
         p.write_text("{}", encoding="utf-8")
         return p
 
-    def test_finds_flat_story_any_name(self):
-        p = self._write("story1.json")
+    def test_rejects_flat_story_any_name(self):
+        """Regression test for Decision 4 (dual-layout retraction): a flat
+        <story>.json file directly in a collection is no longer a valid
+        story source, now that the production corpora/ snapshot is
+        confirmed fully migrated to the bucket layout."""
+        self._write("story1.json")
         found = list(discovery.iter_collection_story_files(self.root))
-        self.assertEqual(found, [p])
+        self.assertEqual(found, [])
 
     def test_finds_nested_bucket_story(self):
         p = self._write("story1/story.json")
         found = list(discovery.iter_collection_story_files(self.root))
         self.assertEqual(found, [p])
 
-    def test_mixed_flat_and_bucket(self):
-        flat = self._write("flat_story.json")
+    def test_ignores_flat_sibling_and_finds_bucket(self):
+        """A flat file alongside a real bucket story: the flat file is
+        rejected, the bucket story is still found."""
+        self._write("flat_story.json")
         bucket = self._write("bucket_story/story.json")
-        found = set(discovery.iter_collection_story_files(self.root))
-        self.assertEqual(found, {flat, bucket})
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [bucket])
 
     def test_ignores_sidecar_json_in_bucket_dir(self):
         self._write("story1/story.json")
@@ -64,18 +69,13 @@ class TestIterCollectionStoryFiles(test_utils.TestCaseWithData):
         found = list(discovery.iter_collection_story_files(self.root / "nonexistent"))
         self.assertEqual(found, [])
 
-    def test_flat_file_literally_named_story_json_is_reserved(self):
-        """story.json is reserved for the bucket marker; a flat file with
-        that literal name is skipped (with a warning), not treated as an
-        ordinary flat story -- otherwise a directory one level up could
-        never tell "collection with an oddly-named flat file" apart from
-        "story's own bucket directory"."""
+    def test_rejects_flat_file_literally_named_story_json(self):
+        """A flat file directly in a collection, even if literally named
+        story.json, is not a bucket -- story.json only counts when nested
+        one level inside its own story subdirectory."""
         self._write("story.json")
-        other = self._write("other_story.json")
-        with capture.capture_output() as captured:
-            found = list(discovery.iter_collection_story_files(self.root))
-        self.assertEqual(found, [other])
-        self.assertIn("reserved", captured.stderr.getvalue())
+        found = list(discovery.iter_collection_story_files(self.root))
+        self.assertEqual(found, [])
 
     def test_skips_symlinked_directories(self):
         real_target = self.root.parent / "outside_target"
@@ -89,7 +89,9 @@ class TestIterCollectionStoryFiles(test_utils.TestCaseWithData):
         found = list(discovery.iter_collection_story_files(self.root))
         self.assertEqual(found, [])
 
-    def test_preserves_symlinked_flat_files(self):
+    def test_rejects_symlinked_flat_files(self):
+        """A symlinked flat file is still a flat file -- rejected the same
+        as any other flat file, not a special case."""
         real_target = self.root.parent / "real_story.json"
         real_target.write_text("{}", encoding="utf-8")
         link = self.root / "linked_story.json"
@@ -98,7 +100,7 @@ class TestIterCollectionStoryFiles(test_utils.TestCaseWithData):
         except (OSError, NotImplementedError):
             self.skipTest("symlinks not supported in this environment")
         found = list(discovery.iter_collection_story_files(self.root))
-        self.assertEqual(found, [link])
+        self.assertEqual(found, [])
 
 
 class TestFindJsonFiles(test_utils.TestCaseWithData):
@@ -115,10 +117,10 @@ class TestFindJsonFiles(test_utils.TestCaseWithData):
         p.write_text("{}", encoding="utf-8")
         return p
 
-    def test_finds_flat_story_at_collection_root(self):
+    def test_rejects_flat_story_at_collection_root(self):
         p = self._write("fantasy/story1.json")
         found = list(discovery.find_json_files([self.root]))
-        self.assertIn(p, found)
+        self.assertNotIn(p, found)
 
     def test_finds_nested_bucket_story(self):
         p = self._write("fantasy/story1/story.json")
@@ -131,14 +133,25 @@ class TestFindJsonFiles(test_utils.TestCaseWithData):
         found = list(discovery.find_json_files([self.root]))
         self.assertNotIn(sidecar, found)
 
-    def test_mixed_layout_across_collections(self):
+    def test_only_bucket_layout_survives_mixed_collections(self):
         flat = self._write("fantasy/story1.json")
         bucket = self._write("horror/story2/story.json")
         found = set(discovery.find_json_files([self.root]))
-        self.assertEqual(found, {flat, bucket})
+        self.assertEqual(found, {bucket})
+        self.assertNotIn(flat, found)
 
-    def test_single_json_file_path_is_yielded(self):
+    def test_rejects_literal_flat_file_path(self):
+        """A literal file path passed directly is only accepted if it is
+        literally named story.json -- there is no caller-knows-best
+        exception once dual-layout support is retracted."""
         p = self._write("standalone.json")
+        found = list(discovery.find_json_files([p]))
+        self.assertEqual(found, [])
+
+    def test_finds_literal_story_json_path(self):
+        """A literal path directly naming story.json is still accepted,
+        unlike an arbitrarily-named literal path."""
+        p = self._write("fantasy/story1/story.json")
         found = list(discovery.find_json_files([p]))
         self.assertEqual(found, [p])
 
@@ -146,10 +159,15 @@ class TestFindJsonFiles(test_utils.TestCaseWithData):
         found = list(discovery.find_json_files([self.root / "nonexistent"]))
         self.assertEqual(found, [])
 
-    def test_works_when_pointed_directly_at_collection_dir(self):
-        p = self._write("fantasy/story1.json")
+    def test_bucket_layout_survives_pointing_directly_at_collection_dir(self):
+        p = self._write("fantasy/story1/story.json")
         found = list(discovery.find_json_files([self.root / "fantasy"]))
         self.assertEqual(found, [p])
+
+    def test_flat_layout_rejected_when_pointed_directly_at_collection_dir(self):
+        self._write("fantasy/story1.json")
+        found = list(discovery.find_json_files([self.root / "fantasy"]))
+        self.assertEqual(found, [])
 
     def test_works_when_pointed_directly_at_story_bucket_dir(self):
         p = self._write("fantasy/story1/story.json")
@@ -165,15 +183,17 @@ class TestFindJsonFiles(test_utils.TestCaseWithData):
         found = list(discovery.find_json_files([self.root / "fantasy" / "story1"]))
         self.assertEqual(found, [p])
 
-    def test_ordinary_flat_filenames_survive_root_level_scan(self):
-        """Regression test: a collection with plainly-named flat stories
-        (no collision with the reserved story.json name) is fully found
-        when scanning starts at the corpus root, not just at the
-        collection itself."""
+    def test_flat_filenames_are_rejected_at_every_scan_depth(self):
+        """Regression test for Decision 4 (dual-layout retraction): plainly
+        named flat stories, with no reserved-name collision, are still
+        rejected at every scan depth (root, collection, direct file) --
+        confirming the retraction is not just a narrow special case."""
         s1 = self._write("sherlock/story1.json")
         s2 = self._write("sherlock/story2.json")
         found = set(discovery.find_json_files([self.root]))
-        self.assertEqual(found, {s1, s2})
+        self.assertEqual(found, set())
+        self.assertNotIn(s1, found)
+        self.assertNotIn(s2, found)
 
 
 if __name__ == "__main__":

--- a/lcats/tests/analysis_tests/promote_test.py
+++ b/lcats/tests/analysis_tests/promote_test.py
@@ -12,8 +12,9 @@ from lcats.analysis.corpus import promote_cli
 
 
 def _write_story(collection_dir: pathlib.Path, name: str, body: str) -> None:
-    collection_dir.mkdir(parents=True, exist_ok=True)
-    story_path = collection_dir / f"{name}.json"
+    bucket_dir = collection_dir / name
+    bucket_dir.mkdir(parents=True, exist_ok=True)
+    story_path = bucket_dir / "story.json"
     story_path.write_text(
         json.dumps({"name": name, "body": body, "metadata": {}}),
         encoding="utf-8",
@@ -143,7 +144,7 @@ class PromoteCollectionsTest(unittest.TestCase):
             self.assertEqual(("clean",), report.promoted)
             self.assertEqual((), report.blocked)
             self.assertTrue(report.all_promoted)
-            promoted_story = dest_root / "clean" / "story_one.json"
+            promoted_story = dest_root / "clean" / "story_one" / "story.json"
             self.assertTrue(promoted_story.exists())
             self.assertEqual(
                 "A clean sentence.",
@@ -209,14 +210,15 @@ class PromoteCollectionsTest(unittest.TestCase):
             source_root = pathlib.Path(source_tmp)
             dest_root = pathlib.Path(dest_tmp)
             stale_dest = dest_root / "clean"
-            stale_dest.mkdir(parents=True)
-            (stale_dest / "removed_story.json").write_text("{}", encoding="utf-8")
+            stale_bucket = stale_dest / "removed_story"
+            stale_bucket.mkdir(parents=True)
+            (stale_bucket / "story.json").write_text("{}", encoding="utf-8")
             _write_story(source_root / "clean", "story_one", "A clean sentence.")
 
             promote.promote_collections(source_root, dest_root)
 
-            self.assertFalse((dest_root / "clean" / "removed_story.json").exists())
-            self.assertTrue((dest_root / "clean" / "story_one.json").exists())
+            self.assertFalse((dest_root / "clean" / "removed_story").exists())
+            self.assertTrue((dest_root / "clean" / "story_one" / "story.json").exists())
 
     def test_collection_names_scopes_to_requested_collections(self):
         with (
@@ -246,7 +248,7 @@ class PromoteCollectionsTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 promote.promote_collections(root, root)
 
-            self.assertTrue((root / "clean" / "story_one.json").exists())
+            self.assertTrue((root / "clean" / "story_one" / "story.json").exists())
 
     def test_refuses_when_dest_is_nested_inside_source(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/lcats/tests/datasets_tests/torchdata_test.py
+++ b/lcats/tests/datasets_tests/torchdata_test.py
@@ -26,11 +26,14 @@ class TestJsonDataset(unittest.TestCase):
             json.dump(data, f)
         return path
 
-    def test_finds_flat_story(self):
+    def test_rejects_flat_story(self):
+        """Regression test for Decision 4 (dual-layout retraction):
+        JsonDataset no longer discovers a flat <story>.json file, now that
+        the production corpora/ snapshot is confirmed fully migrated to the
+        bucket layout."""
         self._write("collection/story1.json", {"name": "Flat1"})
         dataset = torchdata.JsonDataset(root_dir=self.tmp)
-        self.assertEqual(len(dataset), 1)
-        self.assertEqual(dataset[0]["name"], "Flat1")
+        self.assertEqual(len(dataset), 0)
 
     def test_finds_nested_bucket_story(self):
         self._write("collection/story1/story.json", {"name": "Bucket1"})
@@ -45,8 +48,8 @@ class TestJsonDataset(unittest.TestCase):
         self.assertEqual(len(dataset), 1)
 
     def test_subdirectory_argument_scopes_search(self):
-        self._write("collectionA/story1.json", {"name": "A1"})
-        self._write("collectionB/story2.json", {"name": "B1"})
+        self._write("collectionA/story1/story.json", {"name": "A1"})
+        self._write("collectionB/story2/story.json", {"name": "B1"})
         dataset = torchdata.JsonDataset(root_dir=self.tmp, subdirectory="collectionA")
         self.assertEqual(len(dataset), 1)
         self.assertEqual(dataset[0]["name"], "A1")

--- a/lcats/tests/datasets_tests/torchdata_test.py
+++ b/lcats/tests/datasets_tests/torchdata_test.py
@@ -9,7 +9,7 @@ from lcats.datasets import torchdata
 
 
 class TestJsonDataset(unittest.TestCase):
-    """Tests for JsonDataset's dual-layout file discovery."""
+    """Tests for JsonDataset's bucket-only file discovery."""
 
     def setUp(self):
         self.tmp = tempfile.mkdtemp()

--- a/lcats/tests/stories_test.py
+++ b/lcats/tests/stories_test.py
@@ -259,26 +259,32 @@ class TestCorpora(unittest.TestCase):
         result = corpora.get_corpora()
         self.assertEqual(result, {})
 
-    def test_get_corpora_loads_stories(self):
-        """get_corpora finds JSON files within subdirectories."""
+    def test_get_corpora_rejects_flat_stories(self):
+        """Regression test for Decision 4 (dual-layout retraction):
+        get_corpora no longer finds a flat <story>.json file, now that the
+        production corpora/ snapshot is confirmed fully migrated to the
+        bucket layout."""
         story_data = {"name": "S1", "body": "Body1", "metadata": {}}
         self._make_corpus_dir("fantasy", [story_data])
         corpora = stories.Corpora(self.tmp)
         result = corpora.get_corpora()
         self.assertIn("fantasy", result)
-        self.assertEqual(len(result["fantasy"]), 1)
-        self.assertIsInstance(result["fantasy"][0], stories.Story)
-        self.assertEqual(result["fantasy"][0].name, "S1")
+        self.assertEqual(result["fantasy"], [])
 
     def test_get_corpora_multiple_corpora(self):
-        """get_corpora handles multiple subdirectories."""
-        self._make_corpus_dir("scifi", [{"name": "S2", "body": "B2", "metadata": {}}])
-        self._make_corpus_dir(
-            "horror",
-            [
-                {"name": "S3", "body": "B3", "metadata": {}},
-                {"name": "S4", "body": "B4", "metadata": {}},
-            ],
+        """get_corpora handles multiple subdirectories (bucket layout)."""
+        scifi_dir = os.path.join(self.tmp, "scifi")
+        os.makedirs(scifi_dir)
+        self._make_bucket_story(
+            scifi_dir, "story1", {"name": "S2", "body": "B2", "metadata": {}}
+        )
+        horror_dir = os.path.join(self.tmp, "horror")
+        os.makedirs(horror_dir)
+        self._make_bucket_story(
+            horror_dir, "story1", {"name": "S3", "body": "B3", "metadata": {}}
+        )
+        self._make_bucket_story(
+            horror_dir, "story2", {"name": "S4", "body": "B4", "metadata": {}}
         )
         corpora = stories.Corpora(self.tmp)
         result = corpora.get_corpora()
@@ -302,7 +308,11 @@ class TestCorpora(unittest.TestCase):
 
     def test_corpora_property_lazy_loads(self):
         """corpora property is loaded once and cached."""
-        self._make_corpus_dir("mystery", [{"name": "M1", "body": "B", "metadata": {}}])
+        mystery_dir = os.path.join(self.tmp, "mystery")
+        os.makedirs(mystery_dir)
+        self._make_bucket_story(
+            mystery_dir, "story1", {"name": "M1", "body": "B", "metadata": {}}
+        )
         corpora = stories.Corpora(self.tmp)
         self.assertIsNone(corpora._corpora)
         first = corpora.corpora
@@ -312,7 +322,11 @@ class TestCorpora(unittest.TestCase):
 
     def test_stories_property_lazy_loads(self):
         """stories property is loaded once and cached."""
-        self._make_corpus_dir("drama", [{"name": "D1", "body": "B", "metadata": {}}])
+        drama_dir = os.path.join(self.tmp, "drama")
+        os.makedirs(drama_dir)
+        self._make_bucket_story(
+            drama_dir, "story1", {"name": "D1", "body": "B", "metadata": {}}
+        )
         corpora = stories.Corpora(self.tmp)
         self.assertIsNone(corpora._stories)
         first = corpora.stories
@@ -322,18 +336,18 @@ class TestCorpora(unittest.TestCase):
 
     def test_get_stories_returns_flat_list(self):
         """get_stories returns a flat list of all Story objects."""
-        self._make_corpus_dir(
-            "corpA",
-            [
-                {"name": "A1", "body": "BA1", "metadata": {}},
-                {"name": "A2", "body": "BA2", "metadata": {}},
-            ],
+        corp_a_dir = os.path.join(self.tmp, "corpA")
+        os.makedirs(corp_a_dir)
+        self._make_bucket_story(
+            corp_a_dir, "story1", {"name": "A1", "body": "BA1", "metadata": {}}
         )
-        self._make_corpus_dir(
-            "corpB",
-            [
-                {"name": "B1", "body": "BB1", "metadata": {}},
-            ],
+        self._make_bucket_story(
+            corp_a_dir, "story2", {"name": "A2", "body": "BA2", "metadata": {}}
+        )
+        corp_b_dir = os.path.join(self.tmp, "corpB")
+        os.makedirs(corp_b_dir)
+        self._make_bucket_story(
+            corp_b_dir, "story1", {"name": "B1", "body": "BB1", "metadata": {}}
         )
         corpora = stories.Corpora(self.tmp)
         result = corpora.get_stories()
@@ -362,8 +376,11 @@ class TestCorpora(unittest.TestCase):
         self.assertEqual(len(result["fantasy"]), 1)
         self.assertEqual(result["fantasy"][0].name, "Bucket1")
 
-    def test_get_corpora_mixed_flat_and_bucket_layout(self):
-        """get_corpora combines flat and bucket stories within one collection."""
+    def test_get_corpora_ignores_flat_sibling_finds_bucket_story(self):
+        """Regression test for Decision 4 (dual-layout retraction): a flat
+        sibling file is ignored, while a real bucket story in the same
+        collection is still found -- get_corpora no longer combines the
+        two layouts."""
         corpus_dir = self._make_corpus_dir(
             "mixed", [{"name": "Flat1", "body": "F1", "metadata": {}}]
         )
@@ -374,9 +391,9 @@ class TestCorpora(unittest.TestCase):
         )
         corpora = stories.Corpora(self.tmp)
         result = corpora.get_corpora()
-        self.assertEqual(len(result["mixed"]), 2)
+        self.assertEqual(len(result["mixed"]), 1)
         names = {s.name for s in result["mixed"]}
-        self.assertEqual(names, {"Flat1", "Bucket1"})
+        self.assertEqual(names, {"Bucket1"})
 
     def test_get_corpora_bucket_story_not_treated_as_new_collection(self):
         """A nested story bucket is grouped under its real collection, not


### PR DESCRIPTION
## Summary

Implements WI-STORY-0045: retracts the temporary flat/bucket dual-layout tolerance in story discovery (Decision 4 of PROP-LCATS-STORY-BUCKET-LAYOUT), now that the production `corpora/` snapshot is confirmed fully migrated to the bucket layout (1,868 files renamed via `lcats gather` + `lcats promote`; evidence recorded in WI-STORY-0045's execution record).

- `discovery.iter_collection_story_files` and `discovery.find_json_files`: bucket-only selection (`<story>/story.json`); flat `<story>.json` files are no longer discovered, at any scan depth or via an explicit literal path argument. `find_corpus_stories` (a separate, broad recursive JSON finder) is explicitly out of scope and untouched.
- `cli.infer_story_title`: simplified to unconditionally return the bucket directory slug; the flat-file `.stem` fallback is now unreachable and removed.
- `promote.py`: updated a stale comment that described the selector as still tolerating a flat collection mid-migration.
- Converted representative flat-layout test cases (not blanket deletions) to negative/rejection assertions in `discovery_test.py`, `stories_test.py`, `corpus_cli_test.py`, and `torchdata_test.py`, guarding against a future silent regression reintroducing flat-layout tolerance.

## Test plan
- [x] `pytest tests/` — 1563 passed
- [x] `ruff check` / `black --check` on all changed files — clean (verified with the project's tool-version pins temporarily bypassed; local ruff 0.15.12 / black 26.3.1 vs pinned 0.15.0 / 25.11.0 is a pre-existing environment skew, confirmed present on unmodified `main` too, unrelated to this change)
- [x] `lrh validate` — 0 errors, 59 warnings (all pre-existing `owner: unassigned` warnings across the repo, none introduced by this change)
- [x] Grepped docs/ and code comments for stale "dual-layout"/"flat-layout" framing — none found outside historical decision records

PROMPT(WI-STORY-0045:WI_STORY_0045)[2026-08-02T03:58:18+00:00]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
