### PR TITLE
Fix recursive-selector ambiguity in _walk_canonical_story_files

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_08_02_02_11_01_XENODOCHIAL_VARAHAMIHIRA_7EF676_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_02_11_01_XENODOCHIAL_VARAHAMIHIRA_7EF676_REVIEW.md
@@ -5,7 +5,7 @@ work_item: AD_HOC
 status: in_progress
 rerun_of: 
 pr: https://github.com/xenotaur/LCATS/pull/208
-commit: 1d6e3ea674c56d86a1fd3590d69fe5adb49996d3
+commit: 3f076228b437da548113d736f0f3d78a83137c1e
 agent: claude_app
 instruction_source: https://github.com/xenotaur/LCATS/pull/208
 session_transcript: pending
@@ -71,10 +71,19 @@ was applied; re-ran to confirm the branch is still clean):
 
 # Follow-up
 
-The flat-sibling variant of this ambiguity (`collection/story.json` +
-`collection/<other>.json`, no subdirectories) remains unresolved and is a
-candidate for a future work item: it needs either an explicit hint from
-the caller about which directory level it's pointing at, or a domain
-convention that removes the ambiguity by definition -- the same class of
-gap this PR's fix addressed for the nested-subdirectory case, per
-`feedback_recursive_selector_ambiguity_needs_convention`.
+Superseded by events, not left open: `WI-STORY-0045` (dual-layout
+retraction) merged into `main` via PR #207 while this `/lrh-land` chain
+was running, requiring PR #208 to be rebased (see commit note below). Per
+the retraction, a collection directory can only ever contain bucket
+subdirectories -- there is no such thing as a legitimate flat story
+anymore, so `collection/story.json` + `collection/<other>.json` stops
+being ambiguous: `<other>.json` is simply not a story, full stop. The
+flat-sibling gap this comment flagged is therefore structurally resolved
+by the retraction, not left as an open follow-up. No new work item was
+filed (a WI-STORY-0046 draft was considered and discarded for this
+reason).
+
+**Commit note:** the `commit:` field above is the post-rebase SHA. The
+original commit this review addressed was `1d6e3ea674c56d86a1fd3590d69fe5adb49996d3`
+(now rewritten); the reply URL, thread ID, and all triage content above
+are unchanged and still accurate against the rebased code.

--- a/lcats/project/executions/AD_HOC/2026_08_02_02_11_01_XENODOCHIAL_VARAHAMIHIRA_7EF676_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_02_11_01_XENODOCHIAL_VARAHAMIHIRA_7EF676_REVIEW.md
@@ -1,0 +1,80 @@
+---
+execution_id: 2026_08_02_02_11_01_XENODOCHIAL_VARAHAMIHIRA_7EF676_REVIEW
+prompt_id: PROMPT(AD_HOC:XENODOCHIAL_VARAHAMIHIRA_7EF676_REVIEW)[2026-08-02T02:06:22-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/208
+commit: 1d6e3ea674c56d86a1fd3590d69fe5adb49996d3
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/208
+session_transcript: pending
+created_at: 2026-08-02T02:11:01-04:00
+---
+
+# Summary
+
+Review-response pass on PR #208 ("Fix recursive-selector ambiguity in
+_walk_canonical_story_files"). No primary implementation record exists yet
+for this PR (backfill path -- one will be authored at closeout).
+
+# Result
+
+One open review comment, from `chatgpt-codex-connector[bot]` (P1), on
+`lcats/src/lcats/analysis/corpus/discovery.py:141`:
+
+> Preserve flat siblings when classifying leaf buckets -- when a collection
+> contains the reserved `story.json` alongside valid flat stories but has
+> no immediate `<story>/story.json` child, `_is_leaf_story_bucket` still
+> classifies the collection as a leaf bucket, silently dropping the flat
+> siblings.
+
+Triage:
+- **Presence check** -- confirmed present: traced `collection/story.json`
+  (stray) + `collection/valid.json` (no subdirectories) through
+  `_is_leaf_story_bucket` and `find_json_files`; `valid.json` is dropped.
+- **Validity check** -- valid finding, not a false positive.
+- **Feasibility check** -- not feasible within this PR's scope. Traced the
+  same input against the pre-existing code (before this PR): identical
+  result -- `valid.json` was already silently dropped, byte-for-byte. This
+  PR does not regress this case; it is a different manifestation of the
+  same class of ambiguity this PR fixes (a directory's own `story.json`
+  can't always be trusted as the bucket marker), but this variant has no
+  reliable disambiguating signal available: unlike the nested-subdirectory
+  case (where a subdirectory's own `story.json` is self-evident, reliable
+  evidence that the parent is a collection), a flat sibling file's name
+  alone cannot distinguish "a legitimate flat story" from "an ordinary
+  sidecar of a genuine bucket" (e.g. `analysis.json`). A rule of "any other
+  flat `.json` file means not-a-leaf-bucket" would break the existing,
+  deliberately-tested sidecar-exclusion contract
+  (`test_ignores_sidecar_json_in_bucket_dir`,
+  `test_pointed_directly_at_bucket_dir_excludes_sidecar`).
+
+Skipped -- feasibility. Replied on the review thread with the trace
+evidence and the scope rationale:
+https://github.com/xenotaur/LCATS/pull/208#discussion_r3698071199
+
+No code change made; PR unchanged from commit `1d6e3ea6`.
+
+# Validation
+
+Ran against `1d6e3ea6` (no working-tree changes to validate, since no fix
+was applied; re-ran to confirm the branch is still clean):
+
+- `scripts/version tools` -- ruff 0.15.0, black 25.11.0, Python 3.11.9
+- `scripts/format --check --diff` -- 177 files unchanged
+- `scripts/lint` -- ruff and black clean
+- `scripts/test` -- 1561 tests, OK
+- `lrh validate` -- 0 errors, 59 pre-existing warnings (unrelated
+  `OWNER_ROLE_INSUFFICIENT` / `OWNER_NOT_IN_CONTRIBUTORS` noise present
+  before this PR)
+
+# Follow-up
+
+The flat-sibling variant of this ambiguity (`collection/story.json` +
+`collection/<other>.json`, no subdirectories) remains unresolved and is a
+candidate for a future work item: it needs either an explicit hint from
+the caller about which directory level it's pointing at, or a domain
+convention that removes the ambiguity by definition -- the same class of
+gap this PR's fix addressed for the nested-subdirectory case, per
+`feedback_recursive_selector_ambiguity_needs_convention`.

--- a/lcats/project/executions/AD_HOC/2026_08_02_02_27_05_XENODOCHIAL_VARAHAMIHIRA_7EF676_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_02_27_05_XENODOCHIAL_VARAHAMIHIRA_7EF676_CONFIRM.md
@@ -1,0 +1,77 @@
+---
+execution_id: 2026_08_02_02_27_05_XENODOCHIAL_VARAHAMIHIRA_7EF676_CONFIRM
+prompt_id: PROMPT(AD_HOC:XENODOCHIAL_VARAHAMIHIRA_7EF676_CONFIRM)[2026-08-02T02:17:49-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/208
+commit: c2177627d965acafde72121b6b852000945aa321
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/208
+session_transcript: pending
+created_at: 2026-08-02T02:27:05-04:00
+---
+
+# Summary
+
+Pre-merge confirm-fixes pass on PR #208, verifying the state left by the
+`..._XENODOCHIAL_VARAHAMIHIRA_7EF676_REVIEW` record. No primary
+implementation record exists yet for this PR (backfill path).
+
+# Result
+
+Thread listing (`lrh github threads --mode raw --state all`, filtered to
+`isResolved == false`): 1 unresolved thread, on
+`lcats/src/lcats/analysis/corpus/discovery.py:141` (Codex P1 "Preserve
+flat siblings when classifying leaf buckets" + the review-response reply).
+
+Fresh-eyes classification dispatched to an independent cold-context
+subagent (no session memory -- PR URL, diff, and comment bodies only),
+since this session authored both the flagged code and the reply. The
+subagent independently re-traced all three factual claims in the reply
+against the diff and confirmed each:
+1. `_is_leaf_story_bucket` does misclassify `collection/story.json` +
+   `collection/valid.json` (no subdirectories) as a leaf bucket -- PASS.
+2. The pre-existing code (before this PR) produces byte-identical
+   behavior for that input -- PASS, not a regression.
+3. A "no other flat .json ⇒ not a leaf bucket" rule would break
+   `test_ignores_sidecar_json_in_bucket_dir` and
+   `test_pointed_directly_at_bucket_dir_excludes_sidecar` -- PASS.
+
+Classification: **Problematic comment** -- a real, confirmed finding, but
+the deferral rationale is sound and grounded in a verifiable constraint.
+No Clear-satisfied threads (nothing auto-eligible for batch resolution).
+
+Confirm gate presented to the human with this summary; human selected
+"Resolve it now, proceed to merge gate." Thread resolved via
+`resolveReviewThread` GraphQL mutation
+(`PRRT_kwDOKlhIbM6VuUuV` → `isResolved: true`).
+
+Follow-up work item was considered (drafted as WI-STORY-0046) but not
+filed: the human pointed out that `WI-STORY-0045` (already proposed,
+actively being landed) retracts flat-layout support entirely -- once
+bucket-only, a stray flat file in a collection is simply not a story at
+all, so this specific ambiguity is structurally eliminated rather than
+needing its own fix. The resolved PR #208 thread + reply
+(https://github.com/xenotaur/LCATS/pull/208#discussion_r3698071199) is
+the retained record; no new work item was created.
+
+**Thread-resolution verdict (Step 6): green** -- every verifiable thread
+resolved, no exceptions remain open.
+
+# Validation
+
+- `lrh github threads <pr-url> --mode raw --state all` -- 1 thread found,
+  now resolved (0 remaining unresolved)
+- CI: `gh pr checks 208 --required` errored with "no required checks
+  reported"; confirmed via `gh api repos/xenotaur/LCATS/rules/branches/main`
+  (0 `required_status_checks` rules) that this repo has no required-check
+  branch protection, so fell back to unfiltered `gh pr checks 208
+  --json name,state,bucket` → `test`: `SUCCESS` (green)
+- `resolveReviewThread` mutation confirmed `isResolved: true`
+
+# Follow-up
+
+None outstanding for this PR. The flat-sibling ambiguity itself remains a
+known, documented gap (see the resolved thread), expected to become moot
+once `WI-STORY-0045` lands.

--- a/lcats/project/executions/AD_HOC/2026_08_02_02_27_05_XENODOCHIAL_VARAHAMIHIRA_7EF676_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_02_27_05_XENODOCHIAL_VARAHAMIHIRA_7EF676_CONFIRM.md
@@ -5,7 +5,7 @@ work_item: AD_HOC
 status: in_progress
 rerun_of: 
 pr: https://github.com/xenotaur/LCATS/pull/208
-commit: c2177627d965acafde72121b6b852000945aa321
+commit: 58d95972e030d2e71a530bdd142feb1317c3ffca
 agent: claude_app
 instruction_source: https://github.com/xenotaur/LCATS/pull/208
 session_transcript: pending
@@ -69,9 +69,39 @@ resolved, no exceptions remain open.
   branch protection, so fell back to unfiltered `gh pr checks 208
   --json name,state,bucket` → `test`: `SUCCESS` (green)
 - `resolveReviewThread` mutation confirmed `isResolved: true`
+- Self-review via a fresh independent subagent on the `_CONFIRM` commit
+  itself (in place of retriggering Codex/Copilot, per the operator's
+  standing instruction that bot review is an expensive, limited resource):
+  reported no findings, verified the record's frontmatter, cited SHAs,
+  thread state, and CI claims all match live state
+- **Post-rebase re-validation** (see commit note below): `scripts/format
+  --check --diff` (177 files unchanged), `scripts/lint` (clean),
+  `scripts/test` (1561 tests, OK), `lrh validate` (0 errors, 60
+  pre-existing warnings, one new and unrelated to this PR --
+  `EXECUTION_INSTRUCTION_SOURCE_ABSOLUTE_PATH` on PR #207's own closeout
+  note)
 
 # Follow-up
 
-None outstanding for this PR. The flat-sibling ambiguity itself remains a
-known, documented gap (see the resolved thread), expected to become moot
-once `WI-STORY-0045` lands.
+None outstanding for this PR. `WI-STORY-0045` landed via PR #207 --
+concurrently with this `/lrh-land` run, discovered as a merge conflict at
+the Step 6 merge gate (`the merge commit cannot be cleanly created`).
+Confirmed the flat-sibling ambiguity's fix in PR #208 is not obsoleted by
+the retraction (`_walk_canonical_story_files`'s own leaf-vs-collection
+ambiguity, unrelated to flat-file handling, was untouched by PR #207 and
+still present on `main` verbatim) -- rebased PR #208 onto the new `main`,
+re-derived `_walk_canonical_story_files` to keep the
+`_is_leaf_story_bucket` disambiguation while dropping all flat-file-
+yielding logic (`_eligible_flat_story_file` removed entirely -- no longer
+valid post-retraction), and rewrote the two stray-file regression tests
+to drop the now-obsolete "reserved" stderr-warning assertion (that
+warning was retired along with flat-layout support by PR #207). All
+tests pass against the rebased baseline (see Validation).
+
+**Commit note:** the `commit:` field above is the post-rebase SHA. The
+original commit this confirm-fixes pass verified was
+`c2177627d965acafde72121b6b852000945aa321` (now rewritten); the thread
+ID, resolution, and CI/subagent evidence above were all captured against
+that pre-rebase commit but remain valid -- the rebase only reconciled the
+implementation with PR #207's concurrent retraction, it did not reopen or
+invalidate the resolved thread.

--- a/lcats/src/lcats/analysis/corpus/discovery.py
+++ b/lcats/src/lcats/analysis/corpus/discovery.py
@@ -87,38 +87,63 @@ def iter_collection_story_files(
                 yield nested
 
 
+def _is_leaf_story_bucket(directory: pathlib.Path) -> bool:
+    """True if ``directory`` is unambiguously one story's own bucket.
+
+    A directory containing an immediate ``story.json`` is ambiguous on its
+    own: it might be a story's own bucket, or it might be a collection
+    whose layout happens to include a stray flat file literally named
+    ``story.json`` -- the two look identical from that single check alone
+    (see Decision 3 of PROP-LCATS-STORY-BUCKET-LAYOUT). A subdirectory
+    that is itself a real story bucket (has its own immediate
+    ``story.json``) settles it: genuine story buckets never contain other
+    story buckets, so that sibling evidence means ``directory`` is
+    actually a collection, not a leaf bucket -- its ``story.json`` is the
+    stray file, not the marker.
+    """
+    if not (directory / CANONICAL_STORY_FILENAME).is_file():
+        return False
+    for entry in directory.iterdir():
+        if entry.is_symlink():
+            continue
+        if entry.is_dir() and (entry / CANONICAL_STORY_FILENAME).is_file():
+            return False
+    return True
+
+
 def _walk_canonical_story_files(directory: pathlib.Path) -> Iterator[pathlib.Path]:
     """Recursively yield canonical story files under directory.
 
-    First checks whether ``directory`` is itself a story bucket (contains
-    its own ``story.json``) -- if so, yields only that canonical file and
-    stops, regardless of what other JSON sidecars (``audit.json``,
-    ``scenes.json``, ``events.json``, and similar per-story analysis
-    artifacts) sit alongside it. Every other JSON file in a bucket
-    directory is that story's own sidecar content, never an independent
-    second story. This only matters when ``directory`` is handed to this
-    function directly, as a top-level scan target (e.g. a caller pointing
-    straight at one story's bucket) -- reaching a bucket directory via
-    recursion from a collection is already handled by
-    :func:`iter_collection_story_files`, which stops at the bucket
-    boundary and never recurses into it.
+    First checks whether ``directory`` is unambiguously a leaf story
+    bucket (see :func:`_is_leaf_story_bucket`) -- if so, yields only its
+    ``story.json`` and stops, regardless of what other JSON sidecars
+    (``audit.json``, ``scenes.json``, ``events.json``, and similar
+    per-story analysis artifacts) sit alongside it.
 
-    Otherwise applies :func:`iter_collection_story_files`'s bucket-only
-    predicate to ``directory``, then recurses into subdirectories that are
-    not themselves story buckets -- so this behaves correctly whether
-    ``directory`` is a corpus root (immediate children are collection
-    directories), a single collection directory, or a single story's own
-    directory.
+    Otherwise treats ``directory`` as a collection and recurses into every
+    subdirectory, letting the recursive call's own
+    :func:`_is_leaf_story_bucket` check decide whether that subdirectory is
+    a leaf bucket or another collection level to descend through. This
+    behaves correctly whether ``directory`` is a corpus root (immediate
+    children are collection directories), a single collection directory,
+    or a single story's own bucket directory -- without relying on
+    presence-of-story.json alone to decide which, since a collection
+    directory can itself hold a stray flat file literally named
+    ``story.json`` alongside real nested buckets. Flat files are never
+    yielded here, per Decision 4's bucket-only retraction -- the only
+    file ever eligible is a directory's own canonical ``story.json``,
+    reached via the leaf-bucket check above.
+
+    Directory entries reached via a symlink are skipped, matching
+    :func:`find_corpus_stories`'s default ``follow_symlinks=False``.
     """
-    canonical = directory / CANONICAL_STORY_FILENAME
-    if canonical.is_file():
-        yield canonical
+    if _is_leaf_story_bucket(directory):
+        yield directory / CANONICAL_STORY_FILENAME
         return
-    yield from iter_collection_story_files(directory)
     for entry in sorted(directory.iterdir()):
         if entry.is_symlink():
             continue
-        if entry.is_dir() and not (entry / CANONICAL_STORY_FILENAME).is_file():
+        if entry.is_dir():
             yield from _walk_canonical_story_files(entry)
 
 
@@ -136,6 +161,11 @@ def find_json_files(
     the same rule a directory scan applies; there is no longer a
     caller-knows-best exception, since the retraction's whole point is that
     ``story.json`` is the one and only valid marker everywhere.
+
+    A directory scan additionally resolves an ambiguity presence-of-
+    ``story.json`` alone cannot: see :func:`_is_leaf_story_bucket` for how a
+    directory is told apart from a collection whose layout happens to
+    include a stray flat file literally named ``story.json``.
     """
     for directory in directories:
         path = pathlib.Path(directory)

--- a/lcats/tests/analysis_tests/discovery_test.py
+++ b/lcats/tests/analysis_tests/discovery_test.py
@@ -195,6 +195,33 @@ class TestFindJsonFiles(test_utils.TestCaseWithData):
         self.assertNotIn(s1, found)
         self.assertNotIn(s2, found)
 
+    def test_stray_collection_story_json_does_not_mask_nested_buckets(self):
+        """Regression test: a collection directory with a stray flat file
+        literally named story.json alongside real nested <story>/story.json
+        buckets must not be mistaken for a single story's own bucket -- the
+        real buckets underneath must still be found, when the collection
+        directory itself is the scan target. Since Decision 4's retraction,
+        the stray file is simply ignored (it's an ordinary rejected flat
+        file, not a reserved name needing a warning)."""
+        self._write("fantasy/story.json")
+        s1 = self._write("fantasy/story1/story.json")
+        s2 = self._write("fantasy/story2/story.json")
+        found = set(discovery.find_json_files([self.root / "fantasy"]))
+        self.assertEqual(found, {s1, s2})
+
+    def test_stray_collection_story_json_does_not_mask_nested_buckets_from_corpus_root(
+        self,
+    ):
+        """Same ambiguity as above, but reached by recursion from a corpus
+        root that contains multiple collections -- the realistic call
+        pattern (e.g. scanning the whole corpora/ directory)."""
+        self._write("fantasy/story.json")
+        s1 = self._write("fantasy/story1/story.json")
+        s2 = self._write("fantasy/story2/story.json")
+        other = self._write("horror/story3/story.json")
+        found = set(discovery.find_json_files([self.root]))
+        self.assertEqual(found, {s1, s2, other})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Fixes a pre-existing recursive-selector ambiguity in `_walk_canonical_story_files` (`lcats/src/lcats/analysis/corpus/discovery.py`), surfaced by Copilot review on PR #207 (WI-STORY-0045) but confirmed out of that PR's scope — the function's logic was untouched there, only docstring wording changed.
- The bug: the top-of-function check treated any directory with an immediate `story.json` as a single story's own bucket, without checking for sibling subdirectories that are themselves real buckets. A collection directory with a stray flat file literally named `story.json` (e.g. `fantasy/story.json`) alongside real nested buckets (`fantasy/story1/story.json`, `fantasy/story2/story.json`) was mistaken for one story's bucket — only the stray file was yielded, and the collection's real subdirectories were never recursed into, silently masking every genuine story underneath.
- Fix: added `_is_leaf_story_bucket()`, which only treats a directory's own `story.json` as the bucket marker when no subdirectory is itself a real bucket, and applies that check consistently to both the short-circuit decision and the recursion decision (previously the recursion relied on the same ambiguous presence-only signal). Also extracted `_eligible_flat_story_file()` so `iter_collection_story_files` and `_walk_canonical_story_files` share one implementation of the reserved-name warning instead of two copies that could drift.
- `iter_collection_story_files` itself was already correct (it only accepts a nested `<story>/story.json`, one level deep) — this PR only touches `_walk_canonical_story_files`, its supporting helper, and `find_json_files`'s docstring.

## Test plan
- [x] Added `test_stray_collection_story_json_does_not_mask_nested_buckets` (Copilot's exact named scenario, scanning the collection directory directly)
- [x] Added `test_stray_collection_story_json_does_not_mask_nested_buckets_from_corpus_root` (the realistic call pattern: scanning a corpus root containing multiple collections, matching `find_json_files`'s real callers like `torchdata.JsonDataset` and the corpus CLI, which default to a multi-collection root)
- [x] `python -m pytest tests/analysis_tests/discovery_test.py -v` — 23/23 pass
- [x] `python -m pytest tests/` — 1565/1565 pass
- [x] `scripts/lint` — ruff and black clean
- [x] Sanity-checked against the real `corpora/` directory (1868 files found, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
