### PR TITLE
docs: update for WS-STORY-BUCKET-LAYOUT (bucket migration)

### DIFF
--- a/lcats/docs/explanation/story-bucket-layout.md
+++ b/lcats/docs/explanation/story-bucket-layout.md
@@ -45,15 +45,19 @@ data/<collection>/<story>/story.json
   collection — it's simply the old flat filename's stem, promoted from a
   filename convention to an actual directory name.
 - **`story.json` is a reserved, canonical name** — the one and only file
-  in a story's bucket that discovery tooling (`lcats survey`, `lcats
-  assess`, `lcats stats`, `lcats promote`) treats as *the* story. Every
-  other file in that directory is sidecar content: expected, not an
-  ambiguity to resolve case by case.
-- **Output that reports a story's identity** (survey/assess TSV output)
-  gained a dedicated `story_dir` column for this directory-slug identifier,
+  in a story's bucket that `lcats survey`, `lcats assess`, and `lcats
+  promote` treat as *the* story. Every other file in that directory is
+  sidecar content: expected, not an ambiguity to resolve case by case.
+  (`lcats stats` is a partial exception — it still uses the broader,
+  older `find_corpus_stories` selector rather than this canonical one, so
+  it can pick up sidecar files too; this is a known, unresolved gap, not
+  part of the migration's own design.)
+- **`lcats survey`'s output that reports a story's identity** gained a
+  dedicated `story_dir` column for this directory-slug identifier,
   alongside the existing columns — rather than repurposing an existing
   column's meaning, which would have silently broken anything already
-  parsing it.
+  parsing it. (`lcats assess`'s separate TSV schema does not have this
+  column.)
 - **`lcats promote`** (the `data/` → `corpora/` release-promotion gate)
   now standingly rejects a collection where zero canonical stories are
   found — not just a collection with mojibake findings — so a writer
@@ -95,7 +99,7 @@ evidence-backed migration closed that gap.
 
 As of the migration's completion, the flat layout is fully retracted: it
 is not read, written, or tolerated anywhere in LCATS's story-discovery or
--writing code. Every story under `data/` and `corpora/` is a bucket
+story-writing code. Every story under `data/` and `corpora/` is a bucket
 directory. If you're looking for a specific story file on disk or in a
 command's output, it's always `<collection>/<story>/story.json` — never a
 flat `<collection>/<story>.json`.

--- a/lcats/docs/explanation/story-bucket-layout.md
+++ b/lcats/docs/explanation/story-bucket-layout.md
@@ -1,0 +1,111 @@
+# Why stories live in per-story bucket directories
+
+Every story in LCATS's `data/` and `corpora/` trees is stored as
+`<collection>/<story>/story.json` — a dedicated directory per story,
+holding a canonical `story.json` file and, often, sibling analysis
+artifacts (`audit.json`, `scenes.json`, `events.json`, and similar
+per-story outputs) alongside it.
+
+This wasn't always the layout. Through mid-2026, a story was a single
+flat file: `<collection>/<story>.json`. This page explains why LCATS
+migrated away from that, what changed, and what's still true today.
+
+## The problem with a flat file per story
+
+A flat `<collection>/<story>.json` file conflates two different things
+under one name: the story's own identity, and the one and only place its
+content can live. That was fine as long as a story was *only* its own
+JSON content. It stopped being fine once LCATS started producing sibling
+analysis artifacts for a story — QA audits, scene segmentations,
+extracted events — because there was no natural place to put them next to
+the story they describe without inventing an ad hoc naming convention
+(`<story>_audit.json`, `<story>.scenes.json`, ...) that would only get
+messier as more artifact types appeared.
+
+There was a second, quieter problem: identity. Code that needed to name a
+story — for logging, for TSV output, for cross-referencing — used the
+flat file's name stem (`<story>.json` → `<story>`). That's a reasonable
+identifier only as long as the leaf filename varies per story. Once a
+story becomes a directory holding a *canonical*, identically-named leaf
+file (as any per-story-bucket scheme requires), the leaf stem is no longer
+useful for identity — every story's leaf file has the same name. Something
+else has to serve as the identifier instead.
+
+## What changed
+
+LCATS moved to one directory per story, with a single reserved leaf
+filename:
+
+```
+data/<collection>/<story>/story.json
+```
+
+- **The directory's own name (its slug) is the story's identity**, not the
+  leaf filename. It's stable, human-legible, and was already unique per
+  collection — it's simply the old flat filename's stem, promoted from a
+  filename convention to an actual directory name.
+- **`story.json` is a reserved, canonical name** — the one and only file
+  in a story's bucket that discovery tooling (`lcats survey`, `lcats
+  assess`, `lcats stats`, `lcats promote`) treats as *the* story. Every
+  other file in that directory is sidecar content: expected, not an
+  ambiguity to resolve case by case.
+- **Output that reports a story's identity** (survey/assess TSV output)
+  gained a dedicated `story_dir` column for this directory-slug identifier,
+  alongside the existing columns — rather than repurposing an existing
+  column's meaning, which would have silently broken anything already
+  parsing it.
+- **`lcats promote`** (the `data/` → `corpora/` release-promotion gate)
+  now standingly rejects a collection where zero canonical stories are
+  found — not just a collection with mojibake findings — so a writer
+  regression that silently stopped producing real story buckets would be
+  caught before reaching the release snapshot, not just once at
+  migration time.
+
+## How the migration was staged
+
+This was a deliberately staged migration — Martin Fowler's [Parallel
+Change](https://martinfowler.com/bliki/ParallelChange.html) (expand-contract)
+pattern — rather than one atomic cutover:
+
+1. **Read-path compatibility** — discovery and identity logic learned to
+   recognize *both* the old flat layout and the new bucket layout, so nothing
+   broke while the write side hadn't moved yet.
+2. **Write-path migration** — the tools that actually produce story files
+   (`lcats gather`'s downloaders and story-writing paths) switched to
+   writing the bucket layout exclusively.
+3. **Convergence** — tests, fixtures, and docs were normalized to the new
+   layout, and an explicit end-to-end `lcats gather` → `lcats promote`
+   validation pass confirmed the whole pipeline worked correctly against
+   the new layout.
+4. **Retraction** — once the real, tracked `corpora/` snapshot was
+   confirmed fully migrated via an actual production `lcats gather` +
+   `lcats promote` run (not just the code being ready), the temporary
+   flat-layout read tolerance from step 1 was removed. A flat
+   `<collection>/<story>.json` file is no longer recognized as a story by
+   any LCATS tooling.
+
+Step 4's timing was deliberate, not an oversight: retracting flat-layout
+support in the same change that landed the convergence work would have
+made every LCATS command stop finding the (still-flat) production corpus
+until someone actually ran the real migration — an outage with no
+code-level trigger to prevent it. Gating retraction on a confirmed,
+evidence-backed migration closed that gap.
+
+## Current state
+
+As of the migration's completion, the flat layout is fully retracted: it
+is not read, written, or tolerated anywhere in LCATS's story-discovery or
+-writing code. Every story under `data/` and `corpora/` is a bucket
+directory. If you're looking for a specific story file on disk or in a
+command's output, it's always `<collection>/<story>/story.json` — never a
+flat `<collection>/<story>.json`.
+
+## See also
+
+- [Quickstart](../tutorials/quickstart.md) — worked examples using the
+  current bucket-layout paths.
+- [Preparing a corpora release](../reference/prepare-corpora-release.md) —
+  the runbook that regenerates and promotes story buckets.
+- [Per-story gather-time overrides](../reference/gather-overrides.md) —
+  how per-story fixes are keyed by the directory-slug identity this page
+  describes.

--- a/lcats/docs/index.md
+++ b/lcats/docs/index.md
@@ -32,5 +32,6 @@ cd LCATS/lcats
 
 ### Explanation
 
+- [Why stories live in per-story bucket directories](explanation/story-bucket-layout.md) — the storage-layout migration, what changed, and why
 - Control-plane concepts live in [`project/README.md`](../project/README.md).
 - Corpus-analysis architecture details live in [`lcats/analysis/corpus/README.md`](../src/lcats/analysis/corpus/README.md).

--- a/lcats/docs/reference/prepare-corpora-release.md
+++ b/lcats/docs/reference/prepare-corpora-release.md
@@ -136,10 +136,16 @@ lcats survey --mode specials data/ --no-progress
 **Problem result:** one block per flagged file, e.g.:
 
 ```
-data/mass_quantities/deny_the_slake__wilson.json
+data/mass_quantities/deny_the_slake__wilson/story.json
   [spchar] error: Special character finding. (U+00C3, 'Ã')
     context: em a resumÃ©.\n\n"As I s
 ```
+
+> **Note:** the path reflects the current per-story-bucket layout
+> (`<collection>/<story>/story.json`). This specific illustrative finding
+> no longer reproduces — the real corpus has since been cleaned by a
+> separate workstream (`WS-SPECIALS-CLEANUP`) — but the output *shape* is
+> otherwise still accurate. See `project/design/backlog.md`.
 
 and a non-zero exit code. If you see findings after a genuine fresh
 regeneration (step 2 done first), that's real information, not a false
@@ -153,7 +159,7 @@ For any flagged file, this shows exactly what the repair pipeline would
 propose, without changing anything:
 
 ```bash
-lcats repair-specials data/mass_quantities/deny_the_slake__wilson.json --format jsonl
+lcats repair-specials data/mass_quantities/deny_the_slake__wilson/story.json --format jsonl
 ```
 
 Each line is one proposed fix (`rule_id`, `original_text`, `replacement_text`,

--- a/lcats/docs/tutorials/quickstart.md
+++ b/lcats/docs/tutorials/quickstart.md
@@ -92,15 +92,12 @@ Expected output:
 > (`WS-SPECIALS-CLEANUP`) — this block is under review for a fresh worked
 > example; see `project/design/backlog.md`.
 
-Exit code `1`. That's expected, not a failure — `boscombe_valley.json` genuinely has two
-mojibake findings (mangled accented characters from a bad encoding round-trip somewhere upstream),
-and `survey`'s exit code reflects that. Each finding shows the Unicode codepoint involved and a
-snippet of surrounding text so you can see exactly where it occurs.
-
-**What just happened:** `survey`'s `[spchar]` check flagged two spots where accented characters
-(`é` in "métier" and "outré") were mangled into `Ã©` sequences — a classic UTF-8-decoded-as-Latin-1
-mojibake pattern. This was real, pre-existing content in the bundled corpus when this tutorial was
-written (see the note above). For the full flag reference, see
+The output block above shows exit code `1` and two mojibake findings — that was the real,
+reproducible result when this tutorial was written: `boscombe_valley`'s story text had two
+mangled accented characters (`é` in "métier" and "outré", corrupted into `Ã©` sequences, a classic
+UTF-8-decoded-as-Latin-1 pattern) that `survey`'s `[spchar]` check flagged. As the note above says,
+running this exact command today no longer reproduces these findings — see the note for why. For
+the full flag reference, see
 [`docs/reference/cli-commands.md`](../reference/cli-commands.md#survey).
 
 ## 4. An alternative first command: `lcats assess --dry-run`
@@ -133,8 +130,9 @@ Expected output:
 
 Exit code `0` on this run — a dry run doesn't call the API, so it succeeds for any valid input
 (it can still exit non-zero for invalid arguments or an unexpected runtime error, just not for QA
-findings). Here it's reporting the same two findings `survey` found, just as a curation pre-check
-rather than a standalone report.
+findings). The output above was reporting the same two findings `survey` found, as a curation
+pre-check rather than a standalone report — see the note above for why running this today looks
+different.
 
 ## 5. Next steps
 

--- a/lcats/docs/tutorials/quickstart.md
+++ b/lcats/docs/tutorials/quickstart.md
@@ -72,18 +72,25 @@ contamination, and similar defects — without changing anything. Point it at a 
 from the bundled `corpora/` collection:
 
 ```bash
-lcats survey ../corpora/sherlock/boscombe_valley.json --no-progress
+lcats survey ../corpora/sherlock/boscombe_valley/story.json --no-progress
 ```
 
 Expected output:
 
 ```
-../corpora/sherlock/boscombe_valley.json
+../corpora/sherlock/boscombe_valley/story.json
   [spchar] error: Special character finding. (U+00A9, '©')
     context: lies my mÃ©tier,\nand
   [spchar] error: Special character finding. (U+00A9, '©')
     context: g so outrÃ© as a dyin
 ```
+
+> **Note:** the path above reflects the current per-story-bucket layout
+> (`<collection>/<story>/story.json`, per `PROP-LCATS-STORY-BUCKET-LAYOUT`).
+> The findings shown are no longer reproducible as-is — the underlying
+> mojibake was cleaned up by a separate, later workstream
+> (`WS-SPECIALS-CLEANUP`) — this block is under review for a fresh worked
+> example; see `project/design/backlog.md`.
 
 Exit code `1`. That's expected, not a failure — `boscombe_valley.json` genuinely has two
 mojibake findings (mangled accented characters from a bad encoding round-trip somewhere upstream),
@@ -92,8 +99,8 @@ snippet of surrounding text so you can see exactly where it occurs.
 
 **What just happened:** `survey`'s `[spchar]` check flagged two spots where accented characters
 (`é` in "métier" and "outré") were mangled into `Ã©` sequences — a classic UTF-8-decoded-as-Latin-1
-mojibake pattern. This is real, pre-existing content in the bundled corpus, not a fabricated
-example. For the full flag reference, see
+mojibake pattern. This was real, pre-existing content in the bundled corpus when this tutorial was
+written (see the note above). For the full flag reference, see
 [`docs/reference/cli-commands.md`](../reference/cli-commands.md#survey).
 
 ## 4. An alternative first command: `lcats assess --dry-run`
@@ -103,13 +110,13 @@ quality and genre fit. `--dry-run` runs only the pre-flight checks (file discove
 without calling the API, so it costs nothing and needs no key:
 
 ```bash
-lcats assess ../corpora/sherlock/boscombe_valley.json --dry-run
+lcats assess ../corpora/sherlock/boscombe_valley/story.json --dry-run
 ```
 
 Expected output:
 
 ```
-[dry-run] ../corpora/sherlock/boscombe_valley.json
+[dry-run] ../corpora/sherlock/boscombe_valley/story.json
   Title:    Sherlock Holmes - The Boscombe Valley Mystery
   Author:   Arthur Conan Doyle
   Genre:    (detect mode)
@@ -117,6 +124,12 @@ Expected output:
     [ERROR] mojibake-sequence: Likely mojibake sequence.
     [ERROR] mojibake-sequence: Likely mojibake sequence.
 ```
+
+> **Note:** same as the `survey` example above — the path reflects the
+> current bucket layout, but the QA findings and displayed title no longer
+> match current output verbatim (content cleanup plus an unrelated title-
+> display change since this was written). Under review; see
+> `project/design/backlog.md`.
 
 Exit code `0` on this run — a dry run doesn't call the API, so it succeeds for any valid input
 (it can still exit non-zero for invalid arguments or an unexpected runtime error, just not for QA

--- a/lcats/project/executions/AD_HOC/2026_08_02_10_38_54_DOC_WORK_WS_STORY_BUCKET_LAYOUT.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_10_38_54_DOC_WORK_WS_STORY_BUCKET_LAYOUT.md
@@ -1,0 +1,77 @@
+---
+execution_id: 2026_08_02_10_38_54_DOC_WORK_WS_STORY_BUCKET_LAYOUT
+prompt_id: PROMPT(AD_HOC:DOC_WORK_WS_STORY_BUCKET_LAYOUT)[2026-08-02T10:24:14-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/209
+commit: 431c785abcb5a2521d74e6c3399f0bff173851e2
+created_at: 2026-08-02T10:38:54-04:00
+agent: claude_app
+instruction_source: WS-STORY-BUCKET-LAYOUT
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Ran `/lrh-doc-work` against `WS-STORY-BUCKET-LAYOUT` (closed 2026-08-02) as
+the work reference -- the user's own framing was "let's document the
+bucket migration." Updated user-facing docs to reflect the completed
+per-story bucket-directory migration (WI-STORY-0042-0045, plus the PR
+#208 masking-bug follow-up).
+
+# Result
+
+- `docs/tutorials/quickstart.md`: fixed 2 stale example paths
+  (`corpora/sherlock/boscombe_valley.json` -> `.../boscombe_valley/story.json`)
+  -- verified the flat path no longer exists in the real, tracked
+  `corpora/` tree, and the bucket path does. Added a stale-content notice
+  on both "expected output" blocks rather than fabricating new output.
+- `docs/reference/prepare-corpora-release.md`: same fix for 2 illustrative
+  flat-path examples (`data/mass_quantities/deny_the_slake__wilson.json`
+  -> `.../deny_the_slake__wilson/story.json`).
+- New `docs/explanation/story-bucket-layout.md`: an Explanation-quadrant
+  doc grounded directly in the adopted proposal's 8 decisions, covering
+  why the bucket layout exists (identity, discovery predicate, sidecar
+  support) and the staged expand-contract migration approach. No prior
+  doc explained this as a concept.
+- `docs/index.md`: linked the new Explanation doc under the Diataxis map.
+- Surveyed all 10 files under `docs/` plus the corpus-analysis subsystem
+  README (cross-referenced from docs); confirmed `corpus-promotion.md`,
+  `cli-commands.md`, `gather-overrides.md`, `run-assess.md`, and others
+  needed no changes (already directory-level-only examples, or already
+  updated during earlier WI doc sweeps).
+- Presented the full plan at the confirm gate, including one judgment
+  call: both stale examples' claimed mojibake findings no longer
+  reproduce (verified: zero mojibake findings anywhere in the real
+  `corpora/` tree), but this is caused by a separate, already-closed
+  workstream (`WS-SPECIALS-CLEANUP`), not this migration. User chose to
+  scope this run to the path fix + stale-content notice only, and file
+  the fuller example rework to `project/design/backlog.md` as its own
+  follow-up (landed ahead of this PR, commit on `main`).
+- Flagged, but did not fix (unrelated, out of scope): `corpus-promotion.md`'s
+  "One-time manual cleanup" section describes a step
+  (`git rm -r corpora/ohenry corpora/wilde`) that appears already
+  completed in the real repo -- a candidate for a future doc-audit pass.
+
+# Validation
+
+- `python3 -m pytest tests/` -- 1565 passed (doc-only change, no
+  regressions; 2 more than the 1563 baseline, from PR #208's own new
+  tests).
+- `lrh validate` -- 0 errors, 60 pre-existing warnings.
+- Every relative link in new/edited docs verified to resolve.
+- `scripts/lint`/`scripts/format` -- not applicable (no Python files
+  touched); the wrapper scripts fail on the same pre-existing,
+  already-confirmed-unrelated tool-version-pin skew as prior sessions.
+
+# Follow-up
+
+- `status` is `in_progress`; update to `landed` via `/lrh-closeout` after
+  PR #209 merges.
+- Backlog item for the fuller mojibake-example rework already landed on
+  `main` ahead of this PR -- see `project/design/backlog.md`.
+- Flagged doc-audit candidate (`corpus-promotion.md`'s stale one-time
+  cleanup section) not tracked anywhere yet; not added to backlog.md
+  since it's a minor, low-urgency structural nit rather than a
+  functional gap.

--- a/lcats/project/executions/AD_HOC/2026_08_02_10_56_18_DOC_WORK_WS_STORY_BUCKET_LAYOUT_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_10_56_18_DOC_WORK_WS_STORY_BUCKET_LAYOUT_CONFIRM.md
@@ -1,0 +1,77 @@
+---
+execution_id: 2026_08_02_10_56_18_DOC_WORK_WS_STORY_BUCKET_LAYOUT_CONFIRM
+prompt_id: PROMPT(AD_HOC:DOC_WORK_WS_STORY_BUCKET_LAYOUT_CONFIRM)[2026-08-02T10:55:40-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_02_10_38_54_DOC_WORK_WS_STORY_BUCKET_LAYOUT
+pr: https://github.com/xenotaur/LCATS/pull/209
+commit: f3e8ffa20fef6dc46fd236b5512007e13bb2f7e4
+created_at: 2026-08-02T10:56:18-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/209
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge verification and thread-resolution pass for PR #209 (doc-work on
+`WS-STORY-BUCKET-LAYOUT`), per `/lrh-confirm-fixes`'s protocol, inlined per
+`/lrh-land`'s Phase 1 interim invocation pattern.
+
+# Result
+
+- Gathered state: `lrh github threads --mode raw --state all` showed 4
+  total threads, all `isResolved: true`. CI (`gh pr checks 209`) --
+  coverage/lint/test all `SUCCESS`.
+- All 4 threads were real, substantive findings from automated review
+  (2 Copilot, 2 Codex) that landed on the initial doc-work commit
+  without this session triggering anything -- per explicit user
+  direction this run, substituted a fresh independent subagent for the
+  bot retrigger-and-wait mechanism this skill's Step 3/Step 8 would
+  otherwise use (see `feedback_prefer_subagent_review_over_github_bots`).
+  Verified each finding directly against the actual source
+  (`cli.py`'s `run_stats`/`run_survey`/`assess_cli.py`'s `TSV_COLUMNS`)
+  before fixing, not just trusting the bot's claim:
+  - Copilot: a paragraph in `quickstart.md` still asserted stale mojibake
+    findings as current fact immediately after an added stale-content
+    notice said otherwise -- reworded to past tense (fixed in the PR's
+    2nd commit, `f3e8ffa2`).
+  - Copilot: a markdown line-break in the new explanation doc turned
+    "-writing code" into an unintended list item -- fixed.
+  - Codex (P2): the new explanation doc overclaimed that `lcats stats`
+    uses the canonical-only story-file selector -- verified `run_stats`
+    actually calls the broader `find_corpus_stories`, not
+    `iter_collection_story_files`/`find_json_files`. Corrected to call
+    this out as a known, unrelated gap rather than removing the
+    inconvenient fact.
+  - Codex (P2): the new explanation doc overclaimed that `lcats assess`'s
+    TSV output has a `story_dir` column -- verified `assess_cli.py`'s
+    own `TSV_COLUMNS` has no such field (only `survey`'s does, via
+    `output.py`). Narrowed the claim.
+  - Also independently caught and fixed a second instance of the same
+    stale-content contradiction pattern in the `assess --dry-run`
+    example paragraph, which Copilot's finding didn't explicitly name
+    but shared the identical defect.
+- Dispatched a fresh, independent subagent (no shared session context) to
+  verify the fix commit against the actual current file content and
+  actual current code behavior, not just the commit message's claims --
+  clean pass, all 4 confirmed resolved, no new issues found.
+- Re-checked for new unresolved threads on the fix commit (`f3e8ffa2`):
+  none. All 4 original threads resolved via `resolveReviewThread` (diff
+  plainly satisfies each; no new comment posted, since resolving what the
+  diff already fixes is autonomous under this session's established
+  rule, distinct from posting a new public comment).
+- No Clear-satisfied batch was pending resolution at this record's
+  authoring time -- all 4 threads were already resolved as part of the
+  review-response fix.
+
+# Validation
+
+- `python3 -m pytest tests/ -q` -- 1565 passed (doc-only change, no
+  regressions).
+- `lrh validate` -- 0 errors, 60 pre-existing warnings.
+- `gh pr checks 209` -- coverage/lint/test all `SUCCESS` on `f3e8ffa2`.
+
+# Follow-up
+
+- None -- ready for the merge gate.


### PR DESCRIPTION
## Work reference

`WS-STORY-BUCKET-LAYOUT` (closed 2026-08-02) — the full per-story bucket-directory migration (WI-STORY-0042–0045, plus the PR #208 masking-bug follow-up).

## Docs updated

- [`docs/tutorials/quickstart.md`](https://github.com/xenotaur/LCATS/blob/main/lcats/docs/tutorials/quickstart.md) — fixed 2 stale example paths (`corpora/sherlock/boscombe_valley.json` → `.../boscombe_valley/story.json`; that exact flat file no longer exists in the real, tracked `corpora/`). Added a stale-content notice on both "expected output" blocks (see below).
- [`docs/reference/prepare-corpora-release.md`](https://github.com/xenotaur/LCATS/blob/main/lcats/docs/reference/prepare-corpora-release.md) — same fix for 2 illustrative flat-path examples (`data/mass_quantities/deny_the_slake__wilson.json` → `.../deny_the_slake__wilson/story.json`).
- **New:** `docs/explanation/story-bucket-layout.md` — an Explanation-quadrant doc covering why the bucket-directory layout exists (identity, discovery predicate, sidecar-file support), what changed, and the staged expand-contract migration approach. No doc previously explained this as a concept, only as scattered reference-level mentions.
- `docs/index.md` — linked the new Explanation doc under the Diátaxis map (otherwise orphaned).

## Deliberately not fixed (flagged to backlog instead)

Both stale examples' claimed mojibake findings no longer reproduce against the real `corpora/` tree (verified: zero mojibake findings anywhere in `corpora/` currently) — but not because of this migration. A separate, already-closed workstream (`WS-SPECIALS-CLEANUP`) cleaned that content since these docs were written. Fixing the *path* is in scope for this migration's doc-work; finding/constructing a genuinely reproducible example is a different workstream's concern. Added to `project/design/backlog.md` as its own follow-up item (landed on `main` ahead of this PR).

## Test plan

- [x] `python3 -m pytest tests/` — 1565 passed (doc-only change, no regressions)
- [x] `lrh validate` — 0 errors, 60 pre-existing warnings
- [x] Every relative link in new/edited docs verified to resolve
- [x] `ruff`/`black` — not applicable (no Python files touched); pre-existing tool-version-pin skew confirmed unrelated

PROMPT(AD_HOC:DOC_WORK_WS_STORY_BUCKET_LAYOUT)[2026-08-02T10:24:14-04:00]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
