### PR TITLE
Redesign pipeline-checkpointing helper for the bucket-world architecture

### DIFF
--- a/lcats/project/design/proposals/README.md
+++ b/lcats/project/design/proposals/README.md
@@ -13,6 +13,6 @@ short index plus the proposal document.
   `WI-RELEASE-0037`/`WI-RELEASE-0039` open).
 - [`PROP-LCATS-PIPELINE-CHECKPOINTING`](adopted/lcats-pipeline-checkpointing/README.md)
   — adopted; implementation not started (governed by `WS-PIPELINE-CHECKPOINTING`).
-- [`PROP-LCATS-STORY-BUCKET-LAYOUT`](proposed/lcats-story-bucket-layout/README.md)
-  — proposed; implementation not started.
+- [`PROP-LCATS-STORY-BUCKET-LAYOUT`](adopted/lcats-story-bucket-layout/README.md)
+  — adopted; implemented (`WI-STORY-0042`/`0043`/`0044`/`0045`).
 

--- a/lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
+++ b/lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
@@ -4,7 +4,7 @@ type: design_proposal
 title: Staged, Checkpointed Pipeline Execution for LCATS Batch Scripts
 status: adopted
 created_on: 2026-07-30
-updated_on: 2026-07-30
+updated_on: 2026-08-02
 implementation_status: not_started
 implemented_by: []
 supersedes: []
@@ -13,6 +13,7 @@ related_design:
   - lcats/project/audits/2026-07-27-erw-pipeline-structured-output-reliability-audit.md
   - lcats/project/design/flat_story_layout_migration_impact_report.md
   - lcats/project/workstreams/proposed/WS-EVENT-STRUCTURED-OUTPUT-RELIABILITY.md
+  - lcats/project/design/proposals/adopted/lcats-story-bucket-layout/00_proposal.md
 ---
 
 ## Summary

--- a/lcats/project/executions/AD_HOC/2026_08_02_11_19_20_PIPELINE_CHECKPOINTING_BUCKET_REDESIGN_REVIEW.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_11_19_20_PIPELINE_CHECKPOINTING_BUCKET_REDESIGN_REVIEW.md
@@ -1,0 +1,96 @@
+---
+execution_id: 2026_08_02_11_19_20_PIPELINE_CHECKPOINTING_BUCKET_REDESIGN_REVIEW
+prompt_id: PROMPT(AD_HOC:PIPELINE_CHECKPOINTING_BUCKET_REDESIGN_REVIEW)[2026-08-02T11:19:11-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of:
+pr: https://github.com/xenotaur/LCATS/pull/210
+commit:
+agent: claude_app
+instruction_source: user request in-session (/lrh-design session covering the bucket-world impact on WI-PIPELINE-0040/0041, "Boom! Nice work, I approve. Please draft all four now.", then "/lrh-land PR 210")
+session_transcript: claude-app:6a2dbae2-adca-4a2a-92fe-2e95d3b2a4e0
+created_at: 2026-08-02T11:19:20-04:00
+---
+
+# Summary
+
+**POST-HOC BACKFILL, reconstructed at review-response time — not a
+fabricated instruction-phase record.** PR #210 (redesigning
+`WI-PIPELINE-0040`/`WI-PIPELINE-0041` for the post-bucket-migration
+architecture, via a `decision_log.md` entry rather than a new/superseding
+proposal) was authored directly in-conversation, following an `/lrh-design`
+pass, without a prompt ID minted at authoring time. This record covers
+the original authorship and both review-comment rounds.
+
+# Result
+
+- Drafted 5 file changes: a new `decision_log.md` entry recording the
+  dual-root (`working_root`/`source_root`) checkpoint API, a
+  `working_root`-only write-guard against the canonical `data/`/`corpora/`
+  roots, slug-reuse/`paths.makedirs()` decisions, and a newly-discovered
+  `run_pilot.py:201-202` discovery-selector gap; updated acceptance
+  criteria/scope/required changes on `WI-PIPELINE-0040`/`0041`; a
+  `related_design` cross-reference from `PROP-LCATS-PIPELINE-CHECKPOINTING`
+  back to `PROP-LCATS-STORY-BUCKET-LAYOUT` (metadata field only, not the
+  adopted proposal's Decision 1 prose); and a stale `project/design/proposals/README.md`
+  index entry fix.
+- **Review round 1** landed with 4 comments (`copilot-pull-request-reviewer`,
+  `chatgpt-codex-connector`), all valid and fixed:
+  - A citation to `proposal-schema.md:34` that doesn't exist as an LCATS
+    repo file (it's `/lrh-proposal`'s own skill reference doc) — fixed to
+    say so explicitly, matching this session's established
+    external-reference citation convention.
+  - P1: the `working_root` write-guard was specified against
+    `env.data_root()`/`env.corpora_root()`, which resolve relative to
+    process CWD — but `run_pilot.py` is documented to run from the repo
+    root with a default `--data-dir=lcats/data`, a different directory
+    than `env.data_root()` resolves to from that CWD. Fixed to anchor the
+    guard via `paths.find_pyproject_root(__file__)`
+    (`lcats/src/lcats/utils/paths.py:81-114`), the same CWD-independent
+    pattern `lcats.utils.secrets`/`lcats.utils.test_utils` already use.
+  - P2: `WI-PIPELINE-0041` specified `discovery.iter_collection_story_files`
+    for `run_pilot.py`'s story-input discovery, but that function only
+    examines a single collection directory's immediate children — calling
+    it on `data_dir` (a multi-collection corpus root) yields nothing.
+    Fixed to `discovery.find_json_files([data_dir])`.
+  - P2: the parent proposals README now correctly says
+    `PROP-LCATS-STORY-BUCKET-LAYOUT` is adopted/implemented, but its own
+    sidecar `README.md` still disagrees — already being fixed by a
+    separate, already-open PR (#211, since merged); not duplicated here
+    to avoid conflicting edits to the same file.
+- **Review round 2**: rather than wait on/retrigger GitHub bots for a
+  second pass, used an independent subagent (per user instruction, to
+  conserve GitHub review as a limited resource) to verify round 1's
+  fixes. It confirmed all 4 were correctly applied, but caught one real
+  miss: `decision_log.md`'s own Decisions section still asserted
+  `run_pilot.py` should move to `discovery.iter_collection_story_files`
+  — the exact function round 1 had just corrected in `WI-PIPELINE-0041.md`,
+  leaving the decision log (the authoritative record the WI cites)
+  directly contradicting the WI it governs. Also flagged two cosmetic
+  citation-range imprecisions (`paths.py:81-100` → actual function spans
+  `:81-114`; `env.py:16-33` → the referenced functions are `:21-36`). All
+  three fixed.
+- A mid-review-round accident: the subagent's own git operations left
+  this worktree checked out on an unrelated, much earlier session branch
+  (`claude/lcats-extractor-design-review-db3c01`). Recovered by checking
+  the target commit still existed in history (it did) and checking back
+  out to the correct branch; no work was lost, but worth flagging as a
+  process risk of running review subagents inside a shared worktree.
+
+CHAIN-NOTE: cycles=2; stops=0; gates=[merge]; friction=subagent review, run inside the same shared worktree, left the branch checked out on an unrelated old session branch mid-run — recovered cleanly since the commit was still in git history, but a fresh isolated worktree would have avoided the scare entirely; note="an independent subagent review (used in place of a second round of scarce GitHub bot review, per user instruction) caught a real cross-document inconsistency a same-session self-review might have missed, since I'd already mentally 'fixed' the WI and wasn't rechecking the decision log against it"
+
+# Validation
+
+- `lrh validate` (from `lcats/`) — 0 errors, 60 warnings (unchanged
+  baseline for this branch; planning-only markdown, no source code
+  changed).
+- Independent subagent review confirmed all citations (`paths.py`,
+  `env.py`, `promote.py`, `discovery.py`, `run_pilot.py` line numbers)
+  against the actual current source files, not just against the PR's own
+  prose.
+
+# Follow-up
+
+- `session_transcript` is already resolved to this session's ID.
+- Implementation of `WI-PIPELINE-0040` (the checkpoint helper itself)
+  and `WI-PIPELINE-0041` (`run_pilot.py` migration) has not started.

--- a/lcats/project/memory/decision_log.md
+++ b/lcats/project/memory/decision_log.md
@@ -1,5 +1,96 @@
 # Decision Log
 
+## 2026-08-02: Pipeline-checkpointing helper redesigned for the bucket world — dual-root API, write-guarded
+
+### Summary
+- `PROP-LCATS-PIPELINE-CHECKPOINTING` (adopted 2026-07-30) was designed
+  and its two work items (`WI-PIPELINE-0040`, `WI-PIPELINE-0041`, both
+  still `status: proposed`, unimplemented) were scoped before
+  `PROP-LCATS-STORY-BUCKET-LAYOUT` landed. That migration changed the
+  ground the checkpointing design stands on: `DataGatherer.ensure()`
+  (`lcats/src/lcats/gatherers/downloaders.py:200-233`), the exact
+  precedent `WI-PIPELINE-0040` cites, now writes to
+  `<collection>/<story>/story.json` bucket directories, not the flat
+  cache layout it was written against, and the corpus itself now expects
+  sidecar files (`audit.json`, `scenes.json`, `events.json`, etc.)
+  alongside `story.json` as normal content (`discovery.py:9-72`).
+- Decided **not** to reopen or rewrite `PROP-LCATS-PIPELINE-CHECKPOINTING`'s
+  Decision 1 text in place — per `proposal-schema.md:34`
+  ("`adopted`: ... edits go through new proposals or canonical doc
+  updates"), and per this repo having no precedent for post-adoption
+  amendment of an adopted proposal's decision prose (checked: both
+  `lcats-packaging-modernization` and `lcats-story-bucket-layout`'s
+  `updated_on` bumps correspond to their own adoption-transition commits,
+  not a later amendment). This entry is the "canonical doc update" path
+  the schema names as the lighter alternative to a new superseding
+  proposal — appropriate here because this refines Decision 1's scope
+  rather than reversing it.
+
+### Decisions
+- **The shared checkpoint helper (`WI-PIPELINE-0040`) takes two roots,
+  not one: a required `working_root` (where checkpoint files are
+  written) and an optional `source_root` (where upstream/input content
+  lives), with `source_root` defaulting to `working_root` when omitted
+  (implying in-place checkpointing).** This is precedented in the exact
+  function the helper generalizes — `DataGatherer.__init__`
+  (`downloaders.py:167-195`) already keeps two independently-defaulted
+  roots, `root` (destination bucket) and `cache` (resource cache) — and
+  matches the general read-only-source/writable-output separation used
+  in out-of-tree build systems (CMake, Bazel) and Kaggle's
+  `/kaggle/input` (read-only) vs. `/kaggle/working` convention.
+- **The checkpoint predicate (is this stage already done?) checks only
+  `working_root`; `source_root` is never consulted by it.** `source_root`
+  exists purely for the caller's own input-reading logic (e.g. via
+  `discovery.iter_collection_story_files`) — this keeps Decision 2's
+  already-adopted success/failure-plus-fingerprint predicate completely
+  unchanged.
+- **The write-guard applies to `working_root` only, never `source_root`.**
+  Reading from `corpora/`/`data/` as an immutable source is one of the
+  two legitimate use cases motivating the dual-root split in the first
+  place; guarding it would block the good case, not just the bad one.
+  If a resolved `working_root` falls under `env.data_root()` or
+  `env.corpora_root()` (`lcats/src/lcats/utils/env.py:16-33`), the
+  helper must reject the call unless an explicit override is passed —
+  modeled on `promote.py`'s existing `_validate_distinct_roots`
+  (`lcats/src/lcats/analysis/corpus/promote.py:144-170`), this repo's
+  established pattern for "resolve both paths, check containment, refuse
+  the dangerous case," even though the specific condition differs
+  (there: must-be-distinct; here: must-not-resolve-under-protected-roots).
+  This guard exists because `lcats promote`'s `_copy_collection`
+  (`promote.py:172-176`) does an unfiltered `shutil.copytree` of an
+  entire bucket directory — any sidecar present in a `data/` bucket at
+  promote time ships to `corpora/` with no filtering — and because
+  `data/` is documented as a disposable, regenerable cache, not durable
+  storage (`project/design/design.md:38`: "`data/` regenerates from
+  cache").
+- **Per-story checkpoint directories under `working_root` reuse the same
+  directory slug `discovery.py`'s canonical selector already uses for
+  `<collection>/<story>/`** (`PROP-LCATS-STORY-BUCKET-LAYOUT`'s Decision
+  2, directory-slug identity), rather than inventing a second identity
+  scheme. Directory creation reuses `lcats.utils.paths.makedirs()`
+  (symlink-safe), matching `downloaders.py:214,217,231`'s own usage,
+  not bare `os.makedirs`.
+- **`run_pilot.py`'s own story-input discovery
+  (`experiments/03_cross_segment_relation_pilot/run_pilot.py:201-202`,
+  `data_dir.rglob("*.json")`) needs to move to the bucket-aware selector
+  (`discovery.iter_collection_story_files`) as part of `WI-PIPELINE-0041`**,
+  not just as a checkpointing change — once `data/` is regenerated under
+  the new writer, the current recursive glob will pick up sidecar files
+  as spurious stories, the exact over-broad-matching problem
+  `PROP-LCATS-STORY-BUCKET-LAYOUT`'s Decision 3 fixed in the core
+  package but explicitly left unfixed in `experiments/` scripts.
+
+### Evidence
+- `project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md`
+  — `related_design` updated to cross-reference
+  `PROP-LCATS-STORY-BUCKET-LAYOUT` back.
+- `project/work_items/proposed/WI-PIPELINE-0040.md`,
+  `project/work_items/proposed/WI-PIPELINE-0041.md` — updated acceptance
+  criteria/scope/required changes to reflect the decisions above.
+
+### Status
+- Accepted
+
 ## 2026-07-20: WS-DOCS documentation cleanup workstream completed
 
 ### Summary

--- a/lcats/project/memory/decision_log.md
+++ b/lcats/project/memory/decision_log.md
@@ -15,10 +15,11 @@
   sidecar files (`audit.json`, `scenes.json`, `events.json`, etc.)
   alongside `story.json` as normal content (`discovery.py:9-72`).
 - Decided **not** to reopen or rewrite `PROP-LCATS-PIPELINE-CHECKPOINTING`'s
-  Decision 1 text in place — per `proposal-schema.md:34`
-  ("`adopted`: ... edits go through new proposals or canonical doc
-  updates"), and per this repo having no precedent for post-adoption
-  amendment of an adopted proposal's decision prose (checked: both
+  Decision 1 text in place — per the `/lrh-proposal` skill's own
+  `references/proposal-schema.md:34` (a skill reference file, not an
+  LCATS repo file: "`adopted`: ... edits go through new proposals or
+  canonical doc updates"), and per this repo having no precedent for
+  post-adoption amendment of an adopted proposal's decision prose (checked: both
   `lcats-packaging-modernization` and `lcats-story-bucket-layout`'s
   `updated_on` bumps correspond to their own adoption-transition commits,
   not a later amendment). This entry is the "canonical doc update" path
@@ -48,14 +49,27 @@
   Reading from `corpora/`/`data/` as an immutable source is one of the
   two legitimate use cases motivating the dual-root split in the first
   place; guarding it would block the good case, not just the bad one.
-  If a resolved `working_root` falls under `env.data_root()` or
-  `env.corpora_root()` (`lcats/src/lcats/utils/env.py:16-33`), the
-  helper must reject the call unless an explicit override is passed —
-  modeled on `promote.py`'s existing `_validate_distinct_roots`
-  (`lcats/src/lcats/analysis/corpus/promote.py:144-170`), this repo's
-  established pattern for "resolve both paths, check containment, refuse
-  the dangerous case," even though the specific condition differs
-  (there: must-be-distinct; here: must-not-resolve-under-protected-roots).
+  If a resolved `working_root` falls under the canonical `data/` or
+  `corpora/` root, the helper must reject the call unless an explicit
+  override is passed — modeled on `promote.py`'s existing
+  `_validate_distinct_roots` (`lcats/src/lcats/analysis/corpus/promote.py:144-170`),
+  this repo's established pattern for "resolve both paths, check
+  containment, refuse the dangerous case," even though the specific
+  condition differs (there: must-be-distinct; here:
+  must-not-resolve-under-protected-roots). **The protected roots must
+  not be `env.data_root()`/`env.corpora_root()` as-is** — both resolve
+  their defaults relative to the *process's* current working directory
+  (`lcats/src/lcats/utils/env.py:16-33`), and `run_pilot.py` is
+  documented to run from the repo root with a default `--data-dir` of
+  `lcats/data` (`experiments/03_cross_segment_relation_pilot/run_pilot.py:3-4,11`)
+  — a different directory than `env.data_root()` would resolve to from
+  that same CWD. A guard built directly on `env.data_root()`/
+  `env.corpora_root()` would silently fail to recognize the real data
+  tree for the documented invocation pattern, defeating the guard.
+  Anchor the protected roots the same CWD-independent way
+  `lcats.utils.secrets`/`lcats.utils.test_utils` already do —
+  `paths.find_pyproject_root(__file__)` (`lcats/src/lcats/utils/paths.py:81-100`)
+  — rather than trusting `env.py`'s CWD-relative defaults.
   This guard exists because `lcats promote`'s `_copy_collection`
   (`promote.py:172-176`) does an unfiltered `shutil.copytree` of an
   entire bucket directory — any sidecar present in a `data/` bucket at

--- a/lcats/project/memory/decision_log.md
+++ b/lcats/project/memory/decision_log.md
@@ -42,7 +42,9 @@
 - **The checkpoint predicate (is this stage already done?) checks only
   `working_root`; `source_root` is never consulted by it.** `source_root`
   exists purely for the caller's own input-reading logic (e.g. via
-  `discovery.iter_collection_story_files`) — this keeps Decision 2's
+  `discovery.iter_collection_story_files` for a single collection
+  directory, or `discovery.find_json_files` for a multi-collection
+  corpus root — see below) — this keeps Decision 2's
   already-adopted success/failure-plus-fingerprint predicate completely
   unchanged.
 - **The write-guard applies to `working_root` only, never `source_root`.**
@@ -59,7 +61,7 @@
   must-not-resolve-under-protected-roots). **The protected roots must
   not be `env.data_root()`/`env.corpora_root()` as-is** — both resolve
   their defaults relative to the *process's* current working directory
-  (`lcats/src/lcats/utils/env.py:16-33`), and `run_pilot.py` is
+  (`lcats/src/lcats/utils/env.py:21-36`), and `run_pilot.py` is
   documented to run from the repo root with a default `--data-dir` of
   `lcats/data` (`experiments/03_cross_segment_relation_pilot/run_pilot.py:3-4,11`)
   — a different directory than `env.data_root()` would resolve to from
@@ -68,7 +70,7 @@
   tree for the documented invocation pattern, defeating the guard.
   Anchor the protected roots the same CWD-independent way
   `lcats.utils.secrets`/`lcats.utils.test_utils` already do —
-  `paths.find_pyproject_root(__file__)` (`lcats/src/lcats/utils/paths.py:81-100`)
+  `paths.find_pyproject_root(__file__)` (`lcats/src/lcats/utils/paths.py:81-114`)
   — rather than trusting `env.py`'s CWD-relative defaults.
   This guard exists because `lcats promote`'s `_copy_collection`
   (`promote.py:172-176`) does an unfiltered `shutil.copytree` of an
@@ -86,9 +88,12 @@
   not bare `os.makedirs`.
 - **`run_pilot.py`'s own story-input discovery
   (`experiments/03_cross_segment_relation_pilot/run_pilot.py:201-202`,
-  `data_dir.rglob("*.json")`) needs to move to the bucket-aware selector
-  (`discovery.iter_collection_story_files`) as part of `WI-PIPELINE-0041`**,
-  not just as a checkpointing change — once `data/` is regenerated under
+  `data_dir.rglob("*.json")`) needs to move to `discovery.find_json_files([data_dir])`
+  as part of `WI-PIPELINE-0041`** — not `discovery.iter_collection_story_files`,
+  which only examines one collection directory's immediate children and
+  yields nothing when called on `data_dir` itself, a corpus root
+  containing multiple collection directories (review finding, PR #210).
+  This is not just a checkpointing change — once `data/` is regenerated under
   the new writer, the current recursive glob will pick up sidecar files
   as spurious stories, the exact over-broad-matching problem
   `PROP-LCATS-STORY-BUCKET-LAYOUT`'s Decision 3 fixed in the core

--- a/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
+++ b/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
@@ -33,7 +33,7 @@ acceptance:
   - A shared checkpoint helper module exists (lcats/src/lcats/utils/checkpoint.py) providing a per-item/per-stage checkpoint API generalizing DataGatherer's dual-root bucket-directory + file-existence pattern
   - The API takes a required working_root (where checkpoint files are written) and an optional source_root (where upstream/input content lives), with source_root defaulting to working_root when omitted, per the 2026-08-02 decision_log.md entry
   - The checkpoint predicate (is this stage already done?) consults working_root only; source_root is never read by the predicate itself, keeping it a caller-facing convenience for input-reading, not a helper-internal concern
-  - If a resolved working_root falls under env.data_root() or env.corpora_root(), the helper rejects the call unless an explicit override is passed; no equivalent guard applies to source_root, since pointing source_root at corpora/ or data/ as a read-only input is an intended, legitimate use
+  - If a resolved working_root falls under the canonical data/ or corpora/ root (anchored via paths.find_pyproject_root(__file__), not env.data_root()/env.corpora_root()'s CWD-relative defaults, which do not match run_pilot.py's documented repo-root invocation and default --data-dir=lcats/data), the helper rejects the call unless an explicit override is passed; no equivalent guard applies to source_root, since pointing source_root at corpora/ or data/ as a read-only input is an intended, legitimate use
   - Checkpoint publication is atomic: writes go to a temp path in the same directory and are moved into place via os.replace/Path.replace only after the write completes, per Decision 1
   - Any checkpoint file that fails to parse (I/O error, JSON error) is treated as incomplete, never as done and never as a hard failure that aborts the caller, per Decision 1
   - The checkpoint predicate distinguishes success from recorded failure (not bare file presence), per Decision 2
@@ -41,7 +41,7 @@ acceptance:
   - A caller that explicitly opts out by passing an empty/no-op fingerprint gets defined, documented resume behavior (the mismatch check never invalidates that caller's checkpoints, since there is nothing to compare) rather than an undefined or silently-broken state
   - The helper's API supports per-stage granularity (independent checkpoints for distinct pipeline stages within a single run), per Decision 3
   - Per-story checkpoint subdirectories under working_root reuse the same directory slug discovery.py's canonical selector uses for a story's own bucket directory, and directory creation uses lcats.utils.paths.makedirs() rather than bare os.makedirs
-  - New unit tests cover atomic publication under simulated interruption, the success/failure predicate, fingerprint mismatch invalidation, the dual-root default-to-working-root behavior, and the data_root()/corpora_root() write-guard (including its override)
+  - New unit tests cover atomic publication under simulated interruption, the success/failure predicate, fingerprint mismatch invalidation, the dual-root default-to-working-root behavior, and the write-guard (including its override and a case proving the guard still fires when the process CWD differs from the checkpoint module's own file location)
   - lrh validate reports 0 errors
 required_evidence:
   - manual_review
@@ -103,7 +103,11 @@ source while writing checkpoints to its own working directory.
   (`downloaders.py:167-195`) is also the direct precedent for this item's
   dual-root (`working_root`/`source_root`) API: it already keeps two
   independently-defaulted roots, `root` (destination bucket) and `cache`
-  (resource cache).
+  (resource cache). `paths.find_pyproject_root()`
+  (`lcats/src/lcats/utils/paths.py:81-100`) is the existing precedent
+  for this item's write-guard anchor: it already walks upward from a
+  file location (not CWD) to find a stable project root, and is already
+  used this way by `lcats.utils.secrets`/`lcats.utils.test_utils`.
 - Sibling repos: None identified.
 - External libraries: Prefect/Dagster/Ray considered and deferred in the
   governing proposal — not adopted now.
@@ -128,8 +132,10 @@ source while writing checkpoints to its own working directory.
   per-item checkpoint).
 - Implement the dual-root API (`working_root` required, `source_root`
   optional and defaulting to `working_root`) and the `working_root`
-  write-guard against `env.data_root()`/`env.corpora_root()`, per the
-  2026-08-02 `decision_log.md` entry.
+  write-guard against the canonical `data/`/`corpora/` roots — anchored
+  via `paths.find_pyproject_root(__file__)`, not `env.data_root()`/
+  `env.corpora_root()`'s CWD-relative defaults — per the 2026-08-02
+  `decision_log.md` entry.
 - Unit-test the helper in isolation, with no dependency on `run_pilot.py`
   or any real LLM backend.
 
@@ -142,13 +148,17 @@ source while writing checkpoints to its own working directory.
    parameters, using `lcats.utils.paths.makedirs()` for directory
    creation and a `promote.py`-style resolved-path containment check
    (`lcats/src/lcats/analysis/corpus/promote.py:144-170`) for the
-   `working_root` write-guard.
+   `working_root` write-guard — with the protected `data/`/`corpora/`
+   roots anchored via `paths.find_pyproject_root(__file__)`
+   (`lcats/src/lcats/utils/paths.py:81-100`), the same CWD-independent
+   pattern `lcats.utils.secrets`/`lcats.utils.test_utils` already use,
+   not `env.data_root()`/`env.corpora_root()`'s CWD-relative defaults.
 2. Create `lcats/tests/utils_tests/checkpoint_test.py` covering atomic
    publication (including simulated interruption of the write), the
    success/failure predicate, configuration-fingerprint mismatch
    invalidation, the dual-root default-to-`working_root` behavior, and
-   the `data_root()`/`corpora_root()` write-guard (both triggering and
-   overriding it).
+   the write-guard (triggering it, overriding it, and confirming it
+   still fires when the test's process CWD differs from the repo root).
 
 ## Non-Goals
 
@@ -195,6 +205,13 @@ source while writing checkpoints to its own working directory.
   (`Path.resolve()`), matching `promote.py`'s own `_validate_distinct_roots`
   approach — comparing unresolved paths would let a symlink or a
   relative-path variant silently bypass the guard.
+- Building the guard on `env.data_root()`/`env.corpora_root()` directly
+  (rather than anchoring via `paths.find_pyproject_root(__file__)`)
+  would make it CWD-dependent and silently ineffective for
+  `run_pilot.py`'s own documented repo-root invocation, since
+  `env.data_root()`'s CWD-relative default does not resolve to the same
+  directory as `run_pilot.py`'s own default `--data-dir=lcats/data` when
+  launched as documented (review finding, PR #210).
 
 ## Dependencies / Order
 

--- a/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
+++ b/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
@@ -104,7 +104,7 @@ source while writing checkpoints to its own working directory.
   dual-root (`working_root`/`source_root`) API: it already keeps two
   independently-defaulted roots, `root` (destination bucket) and `cache`
   (resource cache). `paths.find_pyproject_root()`
-  (`lcats/src/lcats/utils/paths.py:81-100`) is the existing precedent
+  (`lcats/src/lcats/utils/paths.py:81-114`) is the existing precedent
   for this item's write-guard anchor: it already walks upward from a
   file location (not CWD) to find a stable project root, and is already
   used this way by `lcats.utils.secrets`/`lcats.utils.test_utils`.
@@ -150,7 +150,7 @@ source while writing checkpoints to its own working directory.
    (`lcats/src/lcats/analysis/corpus/promote.py:144-170`) for the
    `working_root` write-guard — with the protected `data/`/`corpora/`
    roots anchored via `paths.find_pyproject_root(__file__)`
-   (`lcats/src/lcats/utils/paths.py:81-100`), the same CWD-independent
+   (`lcats/src/lcats/utils/paths.py:81-114`), the same CWD-independent
    pattern `lcats.utils.secrets`/`lcats.utils.test_utils` already use,
    not `env.data_root()`/`env.corpora_root()`'s CWD-relative defaults.
 2. Create `lcats/tests/utils_tests/checkpoint_test.py` covering atomic

--- a/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
+++ b/lcats/project/work_items/proposed/WI-PIPELINE-0040.md
@@ -17,6 +17,7 @@ related_workstreams:
   - WS-PIPELINE-CHECKPOINTING
 related_design:
   - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
+  - lcats/project/design/proposals/adopted/lcats-story-bucket-layout/00_proposal.md
 depends_on: []
 blocked_by: []
 expected_actions:
@@ -29,14 +30,18 @@ forbidden_actions:
   - implement_new_architecture
   - modify_run_pilot_script
 acceptance:
-  - A shared checkpoint helper module exists (lcats/src/lcats/utils/checkpoint.py) providing a per-item/per-stage checkpoint API generalizing DataGatherer.download's bucket-directory + file-existence pattern
+  - A shared checkpoint helper module exists (lcats/src/lcats/utils/checkpoint.py) providing a per-item/per-stage checkpoint API generalizing DataGatherer's dual-root bucket-directory + file-existence pattern
+  - The API takes a required working_root (where checkpoint files are written) and an optional source_root (where upstream/input content lives), with source_root defaulting to working_root when omitted, per the 2026-08-02 decision_log.md entry
+  - The checkpoint predicate (is this stage already done?) consults working_root only; source_root is never read by the predicate itself, keeping it a caller-facing convenience for input-reading, not a helper-internal concern
+  - If a resolved working_root falls under env.data_root() or env.corpora_root(), the helper rejects the call unless an explicit override is passed; no equivalent guard applies to source_root, since pointing source_root at corpora/ or data/ as a read-only input is an intended, legitimate use
   - Checkpoint publication is atomic: writes go to a temp path in the same directory and are moved into place via os.replace/Path.replace only after the write completes, per Decision 1
   - Any checkpoint file that fails to parse (I/O error, JSON error) is treated as incomplete, never as done and never as a hard failure that aborts the caller, per Decision 1
   - The checkpoint predicate distinguishes success from recorded failure (not bare file presence), per Decision 2
   - The helper's checkpoint API requires every caller to explicitly pass a fingerprint argument (no silent default) alongside a checkpoint's outcome, per Decision 2; the exact fingerprint contents are caller-defined (e.g. model name plus a prompt/schema version/hash), and a fingerprint mismatch on resume is treated as if the checkpoint did not exist
   - A caller that explicitly opts out by passing an empty/no-op fingerprint gets defined, documented resume behavior (the mismatch check never invalidates that caller's checkpoints, since there is nothing to compare) rather than an undefined or silently-broken state
   - The helper's API supports per-stage granularity (independent checkpoints for distinct pipeline stages within a single run), per Decision 3
-  - New unit tests cover atomic publication under simulated interruption, the success/failure predicate, and fingerprint mismatch invalidation
+  - Per-story checkpoint subdirectories under working_root reuse the same directory slug discovery.py's canonical selector uses for a story's own bucket directory, and directory creation uses lcats.utils.paths.makedirs() rather than bare os.makedirs
+  - New unit tests cover atomic publication under simulated interruption, the success/failure predicate, fingerprint mismatch invalidation, the dual-root default-to-working-root behavior, and the data_root()/corpora_root() write-guard (including its override)
   - lrh validate reports 0 errors
 required_evidence:
   - manual_review
@@ -72,13 +77,33 @@ added to the proposal: atomic publication (Decision 1) and a
 success/failure-plus-configuration-identity checkpoint predicate
 (Decision 2).
 
+**Updated 2026-08-02, see `project/memory/decision_log.md`'s
+2026-08-02 entry:** `PROP-LCATS-STORY-BUCKET-LAYOUT` landed after this
+item was scoped, changing `DataGatherer.ensure()`
+(`lcats/src/lcats/gatherers/downloaders.py:200-233`, superseding the
+earlier `:223-253` citation) to write `<collection>/<story>/story.json`
+bucket directories rather than the flat cache layout this item was
+originally written against. The helper must not write checkpoints into
+`data/` or `corpora/` by default — both are unsuitable write targets for
+arbitrary pipeline output (`data/` is a disposable, regenerable cache
+per `project/design/design.md:38`; `lcats promote`'s `_copy_collection`,
+`lcats/src/lcats/analysis/corpus/promote.py:172-176`, ships an entire
+bucket's contents to `corpora/` unfiltered). The helper's API takes a
+dual root (`working_root`/`source_root`) instead, per the decision log
+entry, so a caller can still read `corpora/`/`data/` as an immutable
+source while writing checkpoints to its own working directory.
+
 ### Duplication search
 - In-repo: No existing implementation. `lcats/src/lcats/pipeline.py` is a
   documented, tested module but has no disk persistence of any kind (see
   the proposal's own Prior Art Check) — not something to extend as-is.
-  `DataGatherer.download` (`lcats/src/lcats/gatherers/downloaders.py:223-253`)
+  `DataGatherer.ensure`/`download` (`lcats/src/lcats/gatherers/downloaders.py:200-233,239-`)
   is the closest existing precedent, but is bucket-specific, not a
-  reusable, importable helper.
+  reusable, importable helper. `DataGatherer.__init__`
+  (`downloaders.py:167-195`) is also the direct precedent for this item's
+  dual-root (`working_root`/`source_root`) API: it already keeps two
+  independently-defaulted roots, `root` (destination bucket) and `cache`
+  (resource cache).
 - Sibling repos: None identified.
 - External libraries: Prefect/Dagster/Ray considered and deferred in the
   governing proposal — not adopted now.
@@ -101,17 +126,29 @@ success/failure-plus-configuration-identity checkpoint predicate
 - Support Decision 3's per-stage granularity (the helper's API must let a
   caller checkpoint multiple distinct stages independently, not only one
   per-item checkpoint).
+- Implement the dual-root API (`working_root` required, `source_root`
+  optional and defaulting to `working_root`) and the `working_root`
+  write-guard against `env.data_root()`/`env.corpora_root()`, per the
+  2026-08-02 `decision_log.md` entry.
 - Unit-test the helper in isolation, with no dependency on `run_pilot.py`
   or any real LLM backend.
 
 ## Required Changes
 
 1. Create `lcats/src/lcats/utils/checkpoint.py` implementing the
-   checkpoint API described above.
+   checkpoint API described above: functions (matching the prevailing
+   function-based style of `lcats/src/lcats/utils/env.py`/`paths.py`,
+   not a stateful class) taking explicit `working_root`/`source_root`
+   parameters, using `lcats.utils.paths.makedirs()` for directory
+   creation and a `promote.py`-style resolved-path containment check
+   (`lcats/src/lcats/analysis/corpus/promote.py:144-170`) for the
+   `working_root` write-guard.
 2. Create `lcats/tests/utils_tests/checkpoint_test.py` covering atomic
    publication (including simulated interruption of the write), the
-   success/failure predicate, and configuration-fingerprint mismatch
-   invalidation.
+   success/failure predicate, configuration-fingerprint mismatch
+   invalidation, the dual-root default-to-`working_root` behavior, and
+   the `data_root()`/`corpora_root()` write-guard (both triggering and
+   overriding it).
 
 ## Non-Goals
 
@@ -127,6 +164,11 @@ success/failure-plus-configuration-identity checkpoint predicate
   per-caller fingerprint design is WI-PIPELINE-0041's concern. A caller
   may still choose an empty/no-op fingerprint, but that is an explicit,
   visible argument at the call site, not an omitted parameter.
+- Does not decide whether or how pipeline checkpoint sidecars should
+  ever be promoted or merged back into `data/`/`corpora/` as pipelines
+  mature — the `working_root` write-guard exists specifically so this
+  item does not silently make that decision by default; if/when that
+  integration is wanted, it is separately-scoped future design work.
 
 ## Acceptance Criteria
 
@@ -149,6 +191,10 @@ success/failure-plus-configuration-identity checkpoint predicate
 - An overly narrow configuration-fingerprint API (e.g. hardcoding "model
   name" as the only field) would force WI-PIPELINE-0041 to work around
   it rather than use it as designed.
+- The `working_root` write-guard must compare *resolved* paths
+  (`Path.resolve()`), matching `promote.py`'s own `_validate_distinct_roots`
+  approach — comparing unresolved paths would let a symlink or a
+  relative-path variant silently bypass the guard.
 
 ## Dependencies / Order
 

--- a/lcats/project/work_items/proposed/WI-PIPELINE-0041.md
+++ b/lcats/project/work_items/proposed/WI-PIPELINE-0041.md
@@ -17,6 +17,7 @@ related_workstreams:
   - WS-PIPELINE-CHECKPOINTING
 related_design:
   - lcats/project/design/proposals/adopted/lcats-pipeline-checkpointing/00_proposal.md
+  - lcats/project/design/proposals/adopted/lcats-story-bucket-layout/00_proposal.md
 depends_on:
   - WI-PIPELINE-0040
 blocked_by: []
@@ -35,6 +36,8 @@ acceptance:
   - A crash or Ctrl-C mid-run preserves every already-completed stage's checkpointed output, verified via a fake-backend harness that actually raises KeyboardInterrupt (or terminates a subprocess) after partial completion — not merely an ordinary Exception, which run_pilot.py's existing except Exception block would catch and continue past without ever exercising the real interruption path
   - A resumed run after interruption skips already-checkpointed, successfully-completed stages and does not re-issue their LLM calls
   - The migrated script is re-vetted against the same 8 operational criteria used to freeze it this session (unit tested, bounded small-scale trial, pipelined/resumable, stronger validation, stronger error detection, call estimation, logging, call counting), with both hard blockers (bounded trial, crash/interrupt recovery) confirmed resolved
+  - run_pilot.py's story-input discovery uses discovery.iter_collection_story_files (or an equivalent bucket-aware selector) instead of the current data_dir.rglob("*.json"), so a post-migration data/ or corpora/ source no longer has its sidecar files misread as spurious stories
+  - The checkpoint helper is invoked with working_root pointed at run_pilot.py's own results directory (never data_root()/corpora_root()) and source_root pointed at whatever data/corpora location the run reads stories from, per WI-PIPELINE-0040's dual-root API
   - lrh validate reports 0 errors
 required_evidence:
   - manual_review
@@ -64,6 +67,21 @@ script's `except Exception` catch-all, discards every already-paid-for
 result). `PROP-LCATS-PIPELINE-CHECKPOINTING` (adopted) exists to fix
 this, and this item is its second Implementation Plan item — the actual
 migration, gated on WI-PIPELINE-0040's helper landing first.
+
+**Updated 2026-08-02, see `project/memory/decision_log.md`'s
+2026-08-02 entry:** `PROP-LCATS-STORY-BUCKET-LAYOUT` landed after this
+item was scoped and surfaced a second, independent gap in `run_pilot.py`
+itself: its story-input discovery
+(`experiments/03_cross_segment_relation_pilot/run_pilot.py:201-202`,
+`data_dir.rglob("*.json")`) still does the same over-broad recursive
+JSON matching `discovery.py`'s Decision 3 replaced in the core package —
+once `data/` is regenerated under the new bucket-writing `DataGatherer`,
+this glob will pick up sidecar files (`audit.json`, etc.) as if they
+were separate stories. This item now also fixes that discovery path,
+using WI-PIPELINE-0040's dual-root API with `source_root` pointed at
+wherever the run reads stories from (`data/` or `corpora/`, read-only)
+and `working_root` pointed at this script's own results directory,
+never at `data/`/`corpora/` directly.
 
 ### Duplication search
 - In-repo: No existing migration. `check_segmentation_reliability.py`
@@ -100,6 +118,11 @@ migration, gated on WI-PIPELINE-0040's helper landing first.
 - Re-vet the migrated script against this session's 8 operational
   criteria, using a fake-backend harness for the bounded-trial and
   crash-recovery checks (no real API spend required to verify these).
+- Fix `run_pilot.py`'s story-input discovery to use a bucket-aware
+  selector instead of its current recursive `*.json` glob, and invoke
+  the checkpoint helper with `source_root` (read-only input) separate
+  from `working_root` (this script's own results directory), per
+  WI-PIPELINE-0040's dual-root API.
 
 ## Required Changes
 
@@ -122,6 +145,11 @@ migration, gated on WI-PIPELINE-0040's helper landing first.
    and document the result (e.g. in the PR description or a short
    validation note), explicitly confirming both hard blockers are
    resolved.
+5. Replace `_iter_candidate_files`'s `data_dir.rglob("*.json")`
+   (`run_pilot.py:201-202`) with a bucket-aware selector (e.g.
+   `discovery.iter_collection_story_files`), and thread `source_root`/
+   `working_root` through the script's `--data-dir`/`--output` arguments
+   so input reads and checkpoint writes go to separate roots.
 
 ## Non-Goals
 
@@ -169,6 +197,9 @@ migration, gated on WI-PIPELINE-0040's helper landing first.
   must account for upstream input, not configuration alone.
 - Re-vetting "on paper" without an actual fake-backend run would repeat
   this session's own original vetting gap.
+- Verifying the discovery-selector fix requires a corpus fixture that
+  actually contains a sidecar file alongside `story.json` — a fixture
+  with only bare story files would not exercise the bug the fix targets.
 
 ## Dependencies / Order
 

--- a/lcats/project/work_items/proposed/WI-PIPELINE-0041.md
+++ b/lcats/project/work_items/proposed/WI-PIPELINE-0041.md
@@ -36,8 +36,8 @@ acceptance:
   - A crash or Ctrl-C mid-run preserves every already-completed stage's checkpointed output, verified via a fake-backend harness that actually raises KeyboardInterrupt (or terminates a subprocess) after partial completion — not merely an ordinary Exception, which run_pilot.py's existing except Exception block would catch and continue past without ever exercising the real interruption path
   - A resumed run after interruption skips already-checkpointed, successfully-completed stages and does not re-issue their LLM calls
   - The migrated script is re-vetted against the same 8 operational criteria used to freeze it this session (unit tested, bounded small-scale trial, pipelined/resumable, stronger validation, stronger error detection, call estimation, logging, call counting), with both hard blockers (bounded trial, crash/interrupt recovery) confirmed resolved
-  - run_pilot.py's story-input discovery uses discovery.iter_collection_story_files (or an equivalent bucket-aware selector) instead of the current data_dir.rglob("*.json"), so a post-migration data/ or corpora/ source no longer has its sidecar files misread as spurious stories
-  - The checkpoint helper is invoked with working_root pointed at run_pilot.py's own results directory (never data_root()/corpora_root()) and source_root pointed at whatever data/corpora location the run reads stories from, per WI-PIPELINE-0040's dual-root API
+  - run_pilot.py's story-input discovery uses discovery.find_json_files([data_dir]) (not discovery.iter_collection_story_files, which only examines a single collection directory's immediate children and yields nothing when called on a multi-collection corpus root like the documented --data-dir default) instead of the current data_dir.rglob("*.json"), so a post-migration data/ or corpora/ source no longer has its sidecar files misread as spurious stories, and every collection under data_dir is still actually traversed
+  - The checkpoint helper is invoked with working_root pointed at run_pilot.py's own results directory (never the canonical data/corpora roots WI-PIPELINE-0040's write-guard protects) and source_root pointed at whatever data/corpora location the run reads stories from, per WI-PIPELINE-0040's dual-root API
   - lrh validate reports 0 errors
 required_evidence:
   - manual_review
@@ -146,10 +146,14 @@ never at `data/`/`corpora/` directly.
    validation note), explicitly confirming both hard blockers are
    resolved.
 5. Replace `_iter_candidate_files`'s `data_dir.rglob("*.json")`
-   (`run_pilot.py:201-202`) with a bucket-aware selector (e.g.
-   `discovery.iter_collection_story_files`), and thread `source_root`/
-   `working_root` through the script's `--data-dir`/`--output` arguments
-   so input reads and checkpoint writes go to separate roots.
+   (`run_pilot.py:201-202`) with `discovery.find_json_files([data_dir])`
+   — `data_dir` is a corpus root containing multiple collection
+   directories, and `discovery.iter_collection_story_files` only
+   examines one collection's immediate children, yielding no candidates
+   at all if called directly on `data_dir` (review finding, PR #210).
+   Thread `source_root`/`working_root` through the script's
+   `--data-dir`/`--output` arguments so input reads and checkpoint
+   writes go to separate roots.
 
 ## Non-Goals
 
@@ -200,6 +204,11 @@ never at `data/`/`corpora/` directly.
 - Verifying the discovery-selector fix requires a corpus fixture that
   actually contains a sidecar file alongside `story.json` — a fixture
   with only bare story files would not exercise the bug the fix targets.
+- Verifying the fix also requires a fixture with more than one
+  collection directory under the corpus root — a single-collection
+  fixture would not distinguish a correct multi-collection selector from
+  the broken `iter_collection_story_files`-on-`data_dir` call the
+  original scope draft mistakenly specified (review finding, PR #210).
 
 ## Dependencies / Order
 


### PR DESCRIPTION
## Summary
- `PROP-LCATS-STORY-BUCKET-LAYOUT` landed after `WI-PIPELINE-0040`/`0041` were scoped, changing `DataGatherer.ensure()` (the exact precedent `WI-PIPELINE-0040` cites) to write bucket directories instead of the flat cache layout it was written against — and `lcats promote`'s unfiltered `shutil.copytree` means any sidecar written into a `data/` bucket ships to `corpora/` with no filtering.
- Records the redesign via `/lrh-design`'s recommended Option 2 (canonical `decision_log.md` entry, not a new/superseding proposal or an in-place edit of the adopted proposal's own decision text): a dual-root API (`working_root` required, `source_root` optional, defaulting to `working_root`), a write-guard on `working_root` only against `env.data_root()`/`corpora_root()`, per-story directories reusing `discovery.py`'s canonical slug identity, and a newly-discovered second gap — `run_pilot.py`'s own story-input discovery needs the same bucket-aware fix `discovery.py`'s Decision 3 already made in the core package.
- Updates `WI-PIPELINE-0040`/`WI-PIPELINE-0041`'s acceptance criteria, scope, required changes, and risk notes accordingly; corrects a stale `downloaders.py` line citation; fixes two `related_design`/README staleness bugs noticed while cross-referencing `PROP-LCATS-STORY-BUCKET-LAYOUT`.
- Planning-only — no source code changed.

## Test plan
- [x] `lrh validate` (from `lcats/`) — 0 errors, 60 warnings (unchanged baseline for this branch).
