### PR TITLE
fix(docs): sync story-bucket-layout README frontmatter with adopted proposal

### DIFF
--- a/lcats/project/design/proposals/adopted/lcats-story-bucket-layout/README.md
+++ b/lcats/project/design/proposals/adopted/lcats-story-bucket-layout/README.md
@@ -1,8 +1,8 @@
 ---
 id: PROP-LCATS-STORY-BUCKET-LAYOUT
 type: design_proposal_set
-status: proposed
-implementation_status: not_started
+status: adopted
+implementation_status: implemented
 ---
 
 # Per-Story Bucket Directory Layout for LCATS Corpus Storage


### PR DESCRIPTION
## Summary
- `lcats/project/design/proposals/adopted/lcats-story-bucket-layout/README.md` still had `status: proposed` / `implementation_status: not_started`, out of sync with the sibling `00_proposal.md` which correctly says `status: adopted` / `implementation_status: implemented` (all 4 work items WI-STORY-0042 through WI-STORY-0045 resolved, WS-STORY-BUCKET-LAYOUT closed).
- Updated README.md's frontmatter to match.

## Test plan
- [x] `lrh validate` run from `lcats/` — 0 errors, 60 pre-existing warnings unrelated to this change
