### PR TITLE
Add work item WI-EXPERIMENTS-0046: fix stem-collision bug in check_segmentation_reliability.py

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_08_02_12_25_41_WI_EXPERIMENTS_0046.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_12_25_41_WI_EXPERIMENTS_0046.md
@@ -1,0 +1,60 @@
+---
+execution_id: 2026_08_02_12_25_41_WI_EXPERIMENTS_0046
+prompt_id: PROMPT(AD_HOC:WI_EXPERIMENTS_0046)[2026-08-02T12:22:04-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/212
+commit: d403a314603c1a7a4866f9b8c8be9bec7b93f423
+created_at: 2026-08-02T12:25:41-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-EXPERIMENTS-0046.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Created `WI-EXPERIMENTS-0046`: fix the stem-collision bug in
+`check_segmentation_reliability.py`'s per-story result caching (Batch 1 of
+a 6-batch plan for resolving `project/design/backlog.md`'s
+`WS-STORY-BUCKET-LAYOUT` follow-up items, confirmed as the single
+highest-priority item -- P0, silent data corruption).
+
+# Result
+
+- Ran the prior art check before proposing: duplication search found no
+  existing implementation (two adopted proposals mention the script in
+  passing, neither fixes it); demand search found `WI-PIPELINE-0041`
+  explicitly excludes this exact fix from its own scope, and
+  `project/design/backlog.md` has the matching entry this WI resolves.
+- Wrote `project/work_items/proposed/WI-EXPERIMENTS-0046.md` with full
+  frontmatter and body sections (Summary, Problem/Context with prior art
+  verdicts, Scope, Required Changes, Non-Goals, Acceptance Criteria,
+  Validation, Risk Notes), confirmed with the user before writing.
+- Two decisions made explicitly with the user rather than assumed: the ID
+  itself (`WI-EXPERIMENTS-0046`, a new prefix shared with the two other
+  planned batches from the same backlog audit, over reusing
+  `WI-PIPELINE-*` which would misleadingly imply checkpointing scope),
+  and `related_workstreams` left empty (standalone fix, not linked to
+  `WS-PIPELINE-CHECKPOINTING` despite living in the same script family).
+- Opened [PR #212](https://github.com/xenotaur/LCATS/pull/212).
+
+# Validation
+
+- `lrh validate` -- 0 errors, 63 warnings (2 more than baseline, both the
+  new WI's own pre-existing `owner: unassigned` pattern shared by every
+  other work item in this repo).
+
+# Follow-up
+
+- Offer (per the prior-art demand-search recommendation, not auto-closed):
+  once this PR is confirmed/merged, remove or mark resolved the matching
+  `project/design/backlog.md` entry ("`check_segmentation_reliability.py`'s
+  stem-collision bug -- P0, silent data corruption").
+- `status` is `in_progress`; update to `landed` via `/lrh-closeout` after
+  PR #212 merges. This does not resolve `WI-EXPERIMENTS-0046` itself --
+  the work item stays `proposed` until its *implementation* lands as a
+  separate PR.
+- Next batches in the resolution plan (Batch 3: bundled fix for
+  `run_comparison.py`/`smoke_test.py`; Batch 4: the two notebooks) are not
+  yet scoped -- to be created via separate `/lrh-work-item` runs.

--- a/lcats/project/executions/AD_HOC/2026_08_02_15_25_46_WI_EXPERIMENTS_0046_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_15_25_46_WI_EXPERIMENTS_0046_CONFIRM.md
@@ -1,0 +1,79 @@
+---
+execution_id: 2026_08_02_15_25_46_WI_EXPERIMENTS_0046_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EXPERIMENTS_0046_CONFIRM)[2026-08-02T15:23:49-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_02_12_25_41_WI_EXPERIMENTS_0046
+pr: https://github.com/xenotaur/LCATS/pull/212
+commit: 5987467386a5a477df9b759b4b05d5647593ba42
+created_at: 2026-08-02T15:25:46-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/212
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge verification and thread-resolution pass for PR #212
+(`WI-EXPERIMENTS-0046` creation), per `/lrh-confirm-fixes`'s protocol,
+inlined per `/lrh-land`'s Phase 1 interim invocation pattern.
+
+# Result
+
+- Gathered state: `lrh github threads`-equivalent GraphQL query showed 6
+  total threads, all `isResolved: true`. CI (`gh pr checks 212`) --
+  coverage/lint/test all `SUCCESS`.
+- All 6 threads were real, substantive findings from automated review (2
+  Codex P1, 4 Copilot) that landed on the work-item creation commit
+  without this session triggering anything. Per explicit user direction
+  this run, substituted a fresh independent subagent for the bot
+  retrigger-and-wait mechanism this skill's Step 3/Step 8 would otherwise
+  use. Verified every finding directly against actual source before
+  fixing, not just trusting the bot's claim:
+  - Codex (P1): the original scope used `path.parent.name` alone as the
+    cache key, but the governing proposal's own Decision 2 only
+    guarantees uniqueness *per collection*, and this script's
+    `--data-dir` scans the whole multi-collection `corpora/` root by
+    default -- confirmed via direct read of `select_files` and the
+    proposal text. Fixed by requiring a collection-qualified key.
+  - Codex (P1): the original scope explicitly claimed file discovery
+    (`rglob("*.json")`) was "already correct" -- confirmed via the
+    proposal's Decision 3 and the actual selector's sidecar-exclusion
+    behavior that this claim was wrong; a bucket sidecar file could be
+    sampled as an independent story. Fixed by requiring
+    `discovery.find_json_files` instead.
+  - 4 Copilot findings (missing `priority:`, missing `lrh_validate` in
+    `required_evidence`, wrong `forbidden_actions` token, unqualified
+    `backlog.md` path in 3 places) -- all verified against sibling WI
+    conventions and fixed.
+- Dispatched a fresh, independent subagent to verify the fix commit
+  (`59874673`) against actual current file content and actual current
+  code behavior, not just the commit message's claims. It confirmed all
+  6 items genuinely fixed, and caught one additional issue this session
+  hadn't noticed: `project/design/backlog.md`'s own stem-collision entry
+  still said the script's file discovery "is fine," directly
+  contradicting the now-corrected work item it cites. Verified this
+  independently (not just trusted the subagent) before fixing --
+  corrected `backlog.md`'s entry in a separate commit pushed to `main`
+  (outside this PR's own diff, since it's a different file's accuracy,
+  not part of the work item itself).
+- Re-checked for new unresolved threads after the fix commit: none. All 6
+  threads resolved via `resolveReviewThread` (diff plainly satisfies
+  each). 2 of the 6 (the `priority:` field and the `backlog.md` path
+  fixes) were found already auto-resolved by Copilot itself before this
+  session got to them -- consistent with prior-observed Copilot
+  self-resolution behavior.
+
+# Validation
+
+- `lrh validate` -- 0 errors, 63 pre-existing warnings, both before and
+  after the fix commit.
+- `gh pr checks 212` -- coverage/lint/test all `SUCCESS` on `59874673`.
+- This PR is planning-only (a work item file, no source code); no test
+  suite run was applicable to this PR's own diff. The corrected work
+  item's own `## Validation` section specifies the commands its future
+  *implementation* PR must run.
+
+# Follow-up
+
+- None -- ready for the merge gate.

--- a/lcats/project/work_items/proposed/WI-EXPERIMENTS-0046.md
+++ b/lcats/project/work_items/proposed/WI-EXPERIMENTS-0046.md
@@ -1,0 +1,173 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EXPERIMENTS-0046
+title: Fix stem-collision bug in check_segmentation_reliability.py's result caching
+type: deliverable
+status: proposed
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams: []
+related_design:
+  - project/design/backlog.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - edit_file
+  - create_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - modify_run_pilot_py
+  - change_file_discovery_logic
+acceptance:
+  - "check_segmentation_reliability.py's per-story result path/cache key is derived from the story's directory slug (path.parent.name), not path.stem"
+  - "The cached record's own story_id field matches the same directory-slug value"
+  - "A new regression test proves two distinct stories no longer collide onto the same output/cache file, and single-story behavior is unchanged"
+  - "lrh validate reports 0 errors"
+required_evidence:
+  - manual_review
+  - test_output
+artifacts_expected:
+  - experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py
+  - experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py
+---
+
+# Work Item: Fix stem-collision bug in check_segmentation_reliability.py's result caching
+
+## Summary
+
+Fix `check_segmentation_reliability.py`'s per-story output/cache file
+naming, which currently derives the filename from `path.stem` -- the
+literal string `"story"` for every bucket-layout file -- causing every
+story after the first to silently reuse the first story's cached result
+instead of processing its own.
+
+## Problem / Context
+
+Under the per-story bucket-directory layout
+(`<collection>/<story>/story.json`, adopted via
+`PROP-LCATS-STORY-BUCKET-LAYOUT`), every story's leaf filename is the same
+reserved `story.json`, so `pathlib.Path.stem` is `"story"` for every file
+-- not a usable per-story identifier.
+`experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py:193`
+still keys its per-story result cache off `path.stem`:
+`result_path = output_dir / f"{path.stem}.json"`. After the first story
+writes `output_dir/story.json`, every subsequent story hits the
+cache-check (`if result_path.exists(): cached = ...`) and silently reuses
+story #1's cached result as its own -- including a `story_id` field also
+collapsed to `"story"`. The script completes normally and prints what
+looks like real per-story progress; there is no exception, no non-zero
+exit code, and no warning. This was flagged in the governing proposal's
+own Non-Goals as a stem-collision output-naming bug, deliberately
+deferred as a separate follow-on, and confirmed re-present and re-traced
+in detail during a 2026-08-02 backlog audit (see
+`project/design/backlog.md`).
+
+### Duplication search
+- In-repo: No existing implementation found. Two adopted design proposals
+  (`lcats-pipeline-checkpointing/00_proposal.md`,
+  `lcats-story-bucket-layout/00_proposal.md`) reference this script in
+  passing but neither implements a fix.
+- Sibling repos: None identified.
+- External libraries: None identified -- internal script-specific bug fix.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: Found: `WI-PIPELINE-0041` -- explicitly excludes this exact
+  fix ("Does not change `check_segmentation_reliability.py`'s existing,
+  narrower persistence approach"). Confirms this is a deliberately
+  deferred gap, not overlapping scope.
+- Proposals: None found.
+- Backlog: Found: "`check_segmentation_reliability.py`'s stem-collision
+  bug -- P0, silent data corruption" in `project/design/backlog.md`. This
+  work item is created specifically to resolve that entry.
+- Recommendation: Offer to remove/mark-resolved the matching
+  `backlog.md` entry once this work item's creation PR is confirmed (not
+  auto-closed).
+
+## Scope
+
+- Fix the per-story result/cache file naming in
+  `check_segmentation_reliability.py` so distinct stories never collide
+  onto the same output file.
+- Add a regression test proving the fix.
+- Do not touch this script's file *discovery* (the existing
+  `rglob("*.json")` at line 149 is correct and untouched).
+
+## Required Changes
+
+1. In `check_segmentation_reliability.py`, replace the
+   `path.stem`-derived result path (`output_dir / f"{path.stem}.json"`)
+   with one derived from the story's bucket directory slug
+   (`path.parent.name`), matching the identity convention established by
+   `PROP-LCATS-STORY-BUCKET-LAYOUT` Decision 2 (directory slug, not leaf
+   filename, is the stable per-story identifier).
+2. Update the cached record's own `story_id` field (currently also
+   `path.stem`) to the same directory-slug value, so cached records are
+   self-consistent with the new file naming.
+3. Create
+   `experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py`
+   (matching the existing `run_pilot_test.py` sibling-test convention:
+   `sys.path.insert` + module import + `unittest.TestCase`, run via
+   `python -m pytest experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py`)
+   asserting: two distinct stories under bucket-layout fixtures produce
+   two distinct, non-colliding result files with correct per-story
+   content; a single-story run's existing behavior is unchanged.
+
+## Non-Goals
+
+- Does not touch this script's file discovery (`rglob("*.json")`) --
+  already correct.
+- Does not touch `run_pilot.py` or any other script in
+  `experiments/03_cross_segment_relation_pilot/` -- separate scope,
+  tracked under `WI-PIPELINE-0040`/`0041`.
+- Does not change this script's overall persistence/caching *approach*
+  (still one result file per identifier, still checked for existence
+  before reprocessing) -- only the identifier derivation.
+- Does not fix the unrelated non-recursive glob bugs in
+  `run_comparison.py`/`smoke_test.py` -- a separate backlog item, to be
+  scoped next.
+- Does not touch the two flagged notebooks -- a separate backlog item.
+
+## Acceptance Criteria
+
+- The per-story result/cache path in `check_segmentation_reliability.py`
+  is derived from `path.parent.name` (the story's bucket directory
+  slug), not `path.stem`.
+- The cached record's own `story_id` field matches the same
+  directory-slug value.
+- A new regression test proves two distinct stories no longer collide
+  onto the same output/cache file, and that existing single-story
+  behavior is unchanged.
+- `lrh validate` reports 0 errors.
+- `python -m pytest experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py`
+  passes.
+
+## Validation
+
+- `scripts/version tools`
+- `lrh validate`
+- `python -m pytest experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py`
+- `python -m pytest tests/`
+
+## Risk Notes
+
+- Changing the cache-key format means any *existing* cached result files
+  (if a prior real run exists anywhere, though none was found in-repo)
+  would no longer be recognized as cache hits under the new key -- this
+  is intentional and correct (the old cache was silently wrong), but
+  worth calling out explicitly so a real run isn't surprised by a
+  "cache miss" on files it expects to find.
+- `path.parent.name` assumes the canonical bucket layout
+  (`<collection>/<story>/story.json`); if this script is ever pointed at
+  a non-bucket input, the identifier would be wrong in a different way --
+  out of scope here since dual-layout support is already fully retracted
+  repo-wide.

--- a/lcats/project/work_items/proposed/WI-EXPERIMENTS-0046.md
+++ b/lcats/project/work_items/proposed/WI-EXPERIMENTS-0046.md
@@ -6,6 +6,7 @@ id: WI-EXPERIMENTS-0046
 title: Fix stem-collision bug in check_segmentation_reliability.py's result caching
 type: deliverable
 status: proposed
+priority: high
 owner: unassigned
 contributors: []
 assigned_agents: []
@@ -14,7 +15,7 @@ related_focus:
 related_roadmap: []
 related_workstreams: []
 related_design:
-  - project/design/backlog.md
+  - lcats/project/design/backlog.md
 depends_on: []
 blocked_by: []
 expected_actions:
@@ -25,16 +26,17 @@ expected_actions:
 forbidden_actions:
   - force_push
   - delete_branch
-  - modify_run_pilot_py
-  - change_file_discovery_logic
+  - modify_run_pilot_script
 acceptance:
-  - "check_segmentation_reliability.py's per-story result path/cache key is derived from the story's directory slug (path.parent.name), not path.stem"
-  - "The cached record's own story_id field matches the same directory-slug value"
-  - "A new regression test proves two distinct stories no longer collide onto the same output/cache file, and single-story behavior is unchanged"
+  - "check_segmentation_reliability.py's per-story result path/cache key is derived from both the collection name and the story's directory slug, not path.stem alone -- two different collections sharing a story slug must not collide"
+  - "File discovery uses the canonical story-file selector (discovery.find_json_files), not a raw rglob('*.json'), so bucket sidecar files (analysis.json etc.) are never sampled as if they were stories"
+  - "The cached record's own story_id field matches the same collection-qualified value"
+  - "A new regression test proves two distinct stories -- including two different collections sharing the same story slug -- no longer collide onto the same output/cache file, that a bucket sidecar file is never treated as a sampled story, and that single-story behavior is unchanged"
   - "lrh validate reports 0 errors"
 required_evidence:
   - manual_review
   - test_output
+  - lrh_validate
 artifacts_expected:
   - experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py
   - experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py
@@ -69,7 +71,34 @@ exit code, and no warning. This was flagged in the governing proposal's
 own Non-Goals as a stem-collision output-naming bug, deliberately
 deferred as a separate follow-on, and confirmed re-present and re-traced
 in detail during a 2026-08-02 backlog audit (see
-`project/design/backlog.md`).
+`lcats/project/design/backlog.md`).
+
+**Two additional gaps found via review of this work item's own creation
+PR, before any implementation was written, and folded into scope below
+rather than left for implementation-time surprise:**
+
+1. The directory slug alone is not sufficient. `--data-dir` defaults to
+   `corpora` -- the whole multi-collection corpus root -- and
+   `select_files` (line 149) does `pathlib.Path(args.data_dir).rglob("*.json")`
+   across every collection at once. The governing proposal's Decision 2
+   only guarantees a directory slug is unique *per collection*
+   ("already unique per collection today"), not globally, so
+   `<collection-a>/foo/story.json` and `<collection-b>/foo/story.json`
+   would still collide under a plain `path.parent.name` key. The cache
+   key must include the collection name too.
+2. `rglob("*.json")` is not the canonical selector this repo's own
+   discovery layer settled on. Per Decision 3 of the same proposal, a
+   bucket directory can hold non-story sidecar JSON (`analysis.json`,
+   `scenes.json`, etc.), and `discovery.find_json_files` already exists
+   specifically to select only the canonical `story.json` and exclude
+   sidecars. `rglob("*.json")` has no such filter, so a sidecar file can
+   be sampled as if it were an independent story -- and after the
+   collection-qualified key fix above, a sidecar's parent directory is
+   the *same* as its real story's, so it would also collide with (and
+   potentially overwrite) the real story's cache entry. This work item's
+   original Non-Goals incorrectly asserted this discovery logic was
+   "already correct" -- it wasn't checked against sidecar-file behavior
+   before that claim was made.
 
 ### Duplication search
 - In-repo: No existing implementation found. Two adopted design proposals
@@ -87,7 +116,7 @@ in detail during a 2026-08-02 backlog audit (see
   deferred gap, not overlapping scope.
 - Proposals: None found.
 - Backlog: Found: "`check_segmentation_reliability.py`'s stem-collision
-  bug -- P0, silent data corruption" in `project/design/backlog.md`. This
+  bug -- P0, silent data corruption" in `lcats/project/design/backlog.md`. This
   work item is created specifically to resolve that entry.
 - Recommendation: Offer to remove/mark-resolved the matching
   `backlog.md` entry once this work item's creation PR is confirmed (not
@@ -97,41 +126,56 @@ in detail during a 2026-08-02 backlog audit (see
 
 - Fix the per-story result/cache file naming in
   `check_segmentation_reliability.py` so distinct stories never collide
-  onto the same output file.
-- Add a regression test proving the fix.
-- Do not touch this script's file *discovery* (the existing
-  `rglob("*.json")` at line 149 is correct and untouched).
+  onto the same output file -- including two different collections that
+  happen to share a story slug.
+- Switch this script's file discovery from a raw `rglob("*.json")` to
+  the canonical story-file selector (`discovery.find_json_files`), so
+  bucket sidecar files are never sampled as if they were stories.
+- Add a regression test proving both fixes.
 
 ## Required Changes
 
 1. In `check_segmentation_reliability.py`, replace the
    `path.stem`-derived result path (`output_dir / f"{path.stem}.json"`)
-   with one derived from the story's bucket directory slug
-   (`path.parent.name`), matching the identity convention established by
-   `PROP-LCATS-STORY-BUCKET-LAYOUT` Decision 2 (directory slug, not leaf
-   filename, is the stable per-story identifier).
-2. Update the cached record's own `story_id` field (currently also
-   `path.stem`) to the same directory-slug value, so cached records are
-   self-consistent with the new file naming.
-3. Create
+   with one that includes both the collection name and the story's
+   bucket directory slug -- e.g. nesting by collection
+   (`output_dir / path.parent.parent.name / f"{path.parent.name}.json"`)
+   -- so two different collections sharing a story slug cannot collide.
+   This matches `PROP-LCATS-STORY-BUCKET-LAYOUT` Decision 2 (directory
+   slug is the per-*collection* identity), extended with the
+   collection-qualification this script's own multi-collection
+   `--data-dir` scan requires.
+2. Update the cached record's own `story_id` field (currently
+   `path.stem`) to reflect the same collection-qualified identity.
+3. Replace `select_files`'s `pathlib.Path(args.data_dir).rglob("*.json")`
+   (line 149) with `discovery.find_json_files([args.data_dir])` (see
+   `lcats/src/lcats/datasets/torchdata.py` for the same call shape
+   against a single directory), so sidecar JSON files inside a bucket
+   directory are never selected as candidate stories. Import
+   `lcats.analysis.corpus.discovery`.
+4. Create
    `experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py`
    (matching the existing `run_pilot_test.py` sibling-test convention:
    `sys.path.insert` + module import + `unittest.TestCase`, run via
    `python -m pytest experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py`)
-   asserting: two distinct stories under bucket-layout fixtures produce
-   two distinct, non-colliding result files with correct per-story
-   content; a single-story run's existing behavior is unchanged.
+   asserting: two distinct stories in two different collections sharing
+   the same story slug produce two distinct, non-colliding result files;
+   a bucket sidecar file (e.g. `analysis.json`) is never selected as a
+   sampled story; a single-story run's existing behavior is unchanged.
 
 ## Non-Goals
 
-- Does not touch this script's file discovery (`rglob("*.json")`) --
-  already correct.
 - Does not touch `run_pilot.py` or any other script in
   `experiments/03_cross_segment_relation_pilot/` -- separate scope,
   tracked under `WI-PIPELINE-0040`/`0041`.
 - Does not change this script's overall persistence/caching *approach*
   (still one result file per identifier, still checked for existence
-  before reprocessing) -- only the identifier derivation.
+  before reprocessing) -- only the identifier derivation and the file
+  selector it's built on.
+- Does not add a `--story-list`-path identity fix beyond what the
+  collection-qualified key already provides -- an explicit story list
+  passed via `--story-list` is assumed to already resolve to real bucket
+  paths under some collection root.
 - Does not fix the unrelated non-recursive glob bugs in
   `run_comparison.py`/`smoke_test.py` -- a separate backlog item, to be
   scoped next.
@@ -140,13 +184,15 @@ in detail during a 2026-08-02 backlog audit (see
 ## Acceptance Criteria
 
 - The per-story result/cache path in `check_segmentation_reliability.py`
-  is derived from `path.parent.name` (the story's bucket directory
-  slug), not `path.stem`.
+  is derived from both the collection name and the story's bucket
+  directory slug, not `path.stem` and not the directory slug alone.
+- File discovery uses `discovery.find_json_files`, not a raw
+  `rglob("*.json")`.
 - The cached record's own `story_id` field matches the same
-  directory-slug value.
-- A new regression test proves two distinct stories no longer collide
-  onto the same output/cache file, and that existing single-story
-  behavior is unchanged.
+  collection-qualified value.
+- A new regression test proves: two stories in different collections
+  sharing a story slug produce distinct result files; a bucket sidecar
+  file is never sampled as a story; single-story behavior is unchanged.
 - `lrh validate` reports 0 errors.
 - `python -m pytest experiments/03_cross_segment_relation_pilot/check_segmentation_reliability_test.py`
   passes.
@@ -166,8 +212,16 @@ in detail during a 2026-08-02 backlog audit (see
   is intentional and correct (the old cache was silently wrong), but
   worth calling out explicitly so a real run isn't surprised by a
   "cache miss" on files it expects to find.
-- `path.parent.name` assumes the canonical bucket layout
-  (`<collection>/<story>/story.json`); if this script is ever pointed at
-  a non-bucket input, the identifier would be wrong in a different way --
-  out of scope here since dual-layout support is already fully retracted
-  repo-wide.
+- The collection-qualified key assumes the canonical bucket layout
+  (`<collection>/<story>/story.json`, two levels below the scanned
+  root); if this script is ever pointed at a non-bucket input, the
+  identifier would be wrong in a different way -- out of scope here
+  since dual-layout support is already fully retracted repo-wide.
+- Switching file discovery from `rglob("*.json")` to
+  `discovery.find_json_files` changes which files are eligible for
+  `random.Random(args.seed).shuffle(files)`'s sample -- a bucket sidecar
+  file that was previously (incorrectly) eligible will no longer appear,
+  so a seeded sample computed before this fix is not reproducible after
+  it. This is a correctness improvement, not a regression, but worth
+  noting since this script's whole design goal is a stable, reproducible
+  sample.


### PR DESCRIPTION
## Summary

Creates `WI-EXPERIMENTS-0046`: fix the stem-collision bug in `experiments/03_cross_segment_relation_pilot/check_segmentation_reliability.py`'s per-story result caching. `path.stem` is literally `"story"` for every bucket-layout file, so every story after the first silently reuses story #1's cached result — no exception, no non-zero exit code, no warning. Confirmed via a 2026-08-02 backlog audit as the single highest-priority (P0, silent data corruption) item in `project/design/backlog.md`.

This PR creates the planning artifact only — no implementation.

## Type

`deliverable`

## Related workstream

None — a standalone, self-contained bug fix with no dependency on `WS-PIPELINE-CHECKPOINTING` (whose own `WI-PIPELINE-0041` explicitly excludes this exact fix from its scope).

## Acceptance criteria

- `check_segmentation_reliability.py`'s per-story result path/cache key is derived from the story's directory slug (`path.parent.name`), not `path.stem`
- The cached record's own `story_id` field matches the same directory-slug value
- A new regression test proves two distinct stories no longer collide onto the same output/cache file, and single-story behavior is unchanged
- `lrh validate` reports 0 errors

## Prior art

- **Duplication:** none found — proceed.
- **Demand:** `WI-PIPELINE-0041` explicitly defers this exact fix; `project/design/backlog.md` has the matching entry this WI resolves (offer to remove/mark-resolved once this PR is confirmed, not auto-closed).

PROMPT(AD_HOC:WI_EXPERIMENTS_0046)[2026-08-02T12:22:04-04:00]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
