### PR TITLE
Implement WI-PIPELINE-0040: shared checkpoint helper for batch scripts

### DIFF
--- a/lcats/project/executions/WI-PIPELINE-0040/2026_08_02_15_24_24_WI_PIPELINE_0040.md
+++ b/lcats/project/executions/WI-PIPELINE-0040/2026_08_02_15_24_24_WI_PIPELINE_0040.md
@@ -59,22 +59,76 @@ success/failure predicate for staged pipeline execution, per
 - Toolchain drift encountered and fixed before validation could pass:
   local `black`/`ruff` had drifted to 26.3.1/0.15.12 vs. the CI-pinned
   25.11.0/0.15.0 (`lint.yml:26`); reinstalled the pinned versions rather
-  than reformatting to the drifted ones. Also found the editable `lcats`
-  install pointing at an unrelated worktree (`happy-davinci-e43350`);
-  reinstalled with `pip install -e . --no-deps --force-reinstall` from
-  this worktree before `scripts/test` would import the new module or
-  resolve paths correctly.
+  than reformatting to the drifted ones (recurred a second time mid-review,
+  fixed again the same way). Also found the editable `lcats` install
+  pointing at an unrelated worktree (`happy-davinci-e43350`); reinstalled
+  with `pip install -e . --no-deps --force-reinstall` from this worktree
+  before `scripts/test` would import the new module or resolve paths
+  correctly.
+- Review round 1 landed with 7 comments (`copilot-pull-request-reviewer`
+  x4, `chatgpt-codex-connector` x3, one pair effectively duplicate on
+  `UnicodeDecodeError`), all valid, all fixed:
+  - `checkpoint_path`/`write_checkpoint` didn't validate `item_id`/`stage`
+    as safe single path segments — a value containing `/`, `..`, or an
+    absolute path could escape `working_root` entirely. Fixed with
+    `_validate_path_component`, and `write_checkpoint` now derives its
+    directory from `checkpoint_path` instead of duplicating the join.
+  - `_check_working_root_allowed`'s `FileNotFoundError` (from
+    `find_pyproject_root` on a non-editable install) wasn't documented or
+    actionable — wrapped into a clear `RuntimeError`, documented on
+    `resolve_roots`.
+  - `read_checkpoint` didn't catch `UnicodeDecodeError` on a corrupt/
+    invalid-UTF-8 checkpoint file — added to the except tuple.
+  - A test leaked a temp directory (`tempfile.mkdtemp()` with no cleanup)
+    — switched to `TemporaryDirectory()`.
+  - P1 (codex): `read_checkpoint` returned `done=True` for a recorded
+    *failure*, meaning a resumed pipeline would skip recomputing a failed
+    stage — the governing design requires failures to be recomputed.
+    Fixed to `done=(outcome == "success")`, while still surfacing
+    `outcome`/`data` for a failure so it's distinguishable from no
+    checkpoint at all.
+  - P2 (codex): a fingerprint containing a tuple or int dict key doesn't
+    round-trip identically through JSON, so it would never match its own
+    recorded form and force unnecessary recomputation on every resume —
+    fixed by normalizing both sides through the same JSON round-trip
+    before comparing.
+- Review round 2: per user instruction (conserve scarce GitHub review),
+  used an independent subagent in an isolated worktree (`isolation:
+  "worktree"`, avoiding the branch-switch scare from the PR #210 land run)
+  to verify round 1. All 6 items confirmed correctly fixed, plus one new,
+  real regression found: the fingerprint-normalization fix could raise
+  `TypeError` for a non-JSON-serializable fingerprint (e.g. containing a
+  `set`), violating the module's own "never raises on comparison"
+  contract. Fixed by falling back to the raw fingerprint value when
+  normalization itself fails, rather than propagating the error. Three
+  other observations (checkpoint files inherit `tempfile.mkstemp`'s 0600
+  permissions; `resolve_roots` doesn't itself resolve a relative
+  `working_root`; validation is a containment guard, not an identity
+  guard, so `"a"`/`"./a"`/`"a/"` alias to the same bucket) were
+  independently judged non-blocking and left as documented follow-ups,
+  not fixed in this PR.
 
 # Validation
 
 - `scripts/version tools` — ruff 0.15.0, black 25.11.0 (realigned to CI
-  pins after drift).
+  pins after drift, twice).
 - `scripts/format --check --diff` — clean, 179 files unchanged.
 - `scripts/lint` — clean.
-- `scripts/test` — 1583 tests, all passing.
+- `scripts/test` — 1592 tests, all passing (28 in this module).
 - `lrh validate` — 0 errors, 61 warnings (unchanged baseline).
+- Independent subagent review (isolated worktree) confirmed all 6 review
+  round 1 fixes against the actual current file content and test
+  behavior, not just against the PR's own prose.
 
 # Follow-up
 
 - `WI-PIPELINE-0041` (`run_pilot.py` migration) can now proceed against
   this real API, not just the planning-doc description of it.
+- Non-blocking observations from the independent review, not acted on in
+  this PR: checkpoint file permissions (0600, single-user-appropriate but
+  worth revisiting for a shared working root); `resolve_roots` could
+  resolve a relative `working_root` itself rather than leaving that to
+  the guard internals only; `_validate_path_component` is a containment
+  guard, not an identity guard (distinct strings can alias to the same
+  bucket) — acceptable for now, but worth tightening if checkpoint
+  identity collisions ever become a real concern.

--- a/lcats/project/executions/WI-PIPELINE-0040/2026_08_02_15_24_24_WI_PIPELINE_0040.md
+++ b/lcats/project/executions/WI-PIPELINE-0040/2026_08_02_15_24_24_WI_PIPELINE_0040.md
@@ -1,0 +1,80 @@
+---
+execution_id: 2026_08_02_15_24_24_WI_PIPELINE_0040
+prompt_id: PROMPT(WI-PIPELINE-0040:WI_PIPELINE_0040)[2026-08-02T15:11:54-04:00]
+work_item: WI-PIPELINE-0040
+status: in_progress
+rerun_of:
+pr: https://github.com/xenotaur/LCATS/pull/213
+commit:
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-PIPELINE-0040.md
+session_transcript: claude-app:6a2dbae2-adca-4a2a-92fe-2e95d3b2a4e0
+created_at: 2026-08-02T15:24:24-04:00
+---
+
+# Summary
+
+Implement `lcats.utils.checkpoint`, the shared checkpoint helper
+`PROP-LCATS-PIPELINE-CHECKPOINTING` calls for: a dual-root
+(`working_root`/`source_root`), atomic-publication, fingerprinted
+success/failure predicate for staged pipeline execution, per
+`WI-PIPELINE-0040`'s acceptance criteria and the 2026-08-02
+`decision_log.md` entry (bucket-world redesign, PR #210).
+
+# Result
+
+- `lcats/src/lcats/utils/checkpoint.py` (new): `resolve_roots`,
+  `checkpoint_path`, `read_checkpoint`, `write_checkpoint`.
+  - `source_root` defaults to `working_root` when omitted; only
+    `working_root` is subject to the write-guard.
+  - The write-guard anchors the canonical `data/`/`corpora/` roots via
+    `paths.find_pyproject_root(__file__)` (this module's own file
+    location) rather than `env.data_root()`/`env.corpora_root()`'s
+    CWD-relative defaults, fixing the exact CWD-dependence bug review
+    caught on PR #210's planning-doc version of this same design.
+  - Reuses `env.py`'s own default relative-path strings (`"data"`,
+    `"../corpora"`, including their `LCATS_DATA_DIR`/`LCATS_CORPORA_DIR`
+    overrides) so the guard's actual protected locations stay consistent
+    with `env.py`'s documented configurability, just resolved against a
+    stable anchor instead of CWD.
+  - Atomic publication via a temp file in the same directory + `os.replace`.
+  - `fingerprint` required on every `write_checkpoint` call; a falsy
+    recorded fingerprint (the caller's own opt-out) never invalidates on
+    resume, matching the Non-Goals' "explicit, visible argument, not an
+    omitted parameter" requirement.
+- `lcats/tests/utils_tests/checkpoint_test.py` (new, 20 tests): dual-root
+  defaulting, the write-guard (triggering it, overriding it via
+  `allow_protected_root=True`, and confirming it fires under a different
+  process CWD by patching the anchor to a controlled fake project root),
+  the success/failure predicate, fingerprint mismatch invalidation and
+  opt-out, malformed-checkpoint handling, per-stage independence, and
+  atomic publication under a real `KeyboardInterrupt` mid-write (not an
+  ordinary `Exception`, per the same interruption-fidelity lesson
+  WI-PIPELINE-0041's own review already established).
+- One real bug caught by my own test suite before commit: the
+  fingerprint opt-out check initially keyed off the *read-time* argument's
+  truthiness instead of the *recorded* fingerprint's — fixed to check
+  `record.get("fingerprint")` for falsiness, matching the documented
+  "empty/no-op fingerprint recorded at write time" semantics.
+- Toolchain drift encountered and fixed before validation could pass:
+  local `black`/`ruff` had drifted to 26.3.1/0.15.12 vs. the CI-pinned
+  25.11.0/0.15.0 (`lint.yml:26`); reinstalled the pinned versions rather
+  than reformatting to the drifted ones. Also found the editable `lcats`
+  install pointing at an unrelated worktree (`happy-davinci-e43350`);
+  reinstalled with `pip install -e . --no-deps --force-reinstall` from
+  this worktree before `scripts/test` would import the new module or
+  resolve paths correctly.
+
+# Validation
+
+- `scripts/version tools` — ruff 0.15.0, black 25.11.0 (realigned to CI
+  pins after drift).
+- `scripts/format --check --diff` — clean, 179 files unchanged.
+- `scripts/lint` — clean.
+- `scripts/test` — 1583 tests, all passing.
+- `lrh validate` — 0 errors, 61 warnings (unchanged baseline).
+
+# Follow-up
+
+- `WI-PIPELINE-0041` (`run_pilot.py` migration) can now proceed against
+  this real API, not just the planning-doc description of it.

--- a/lcats/src/lcats/utils/checkpoint.py
+++ b/lcats/src/lcats/utils/checkpoint.py
@@ -1,0 +1,277 @@
+# lcats/src/lcats/utils/checkpoint.py
+"""Shared checkpoint helper for LCATS's LLM-driven batch scripts.
+
+Generalizes ``DataGatherer``'s dual-root bucket-directory + file-existence
+pattern (``lcats.gatherers.downloaders``) into a reusable, per-item/per-stage
+checkpoint mechanism for staged pipelines (segment -> extract -> relate,
+etc.), so a crash or interruption discards only the in-flight stage, not
+every already-completed one.
+
+Design decisions (see ``project/memory/decision_log.md``'s 2026-08-02
+entry and ``PROP-LCATS-PIPELINE-CHECKPOINTING``):
+
+- **Dual root.** Callers pass a required ``working_root`` (where checkpoint
+  files are written) and an optional ``source_root`` (where upstream/input
+  content lives), via :func:`resolve_roots`. ``source_root`` defaults to
+  ``working_root`` when omitted, implying in-place checkpointing. This
+  module never reads ``source_root`` itself -- it exists purely so a
+  caller's own input-reading logic (e.g. via
+  ``lcats.analysis.corpus.discovery``) has somewhere to point that is
+  independent of where checkpoints get written.
+- **Write-guard, working_root only.** ``source_root`` is deliberately never
+  guarded: pointing it at ``data/`` or ``corpora/`` as a read-only input is
+  the whole reason for the dual-root split. ``working_root`` is guarded
+  because ``lcats promote``'s ``_copy_collection``
+  (``lcats.analysis.corpus.promote``) does an unfiltered ``shutil.copytree``
+  of an entire bucket directory -- any sidecar written into a ``data/``
+  bucket ships to ``corpora/`` with no filtering -- and because ``data/``
+  is documented as a disposable, regenerable cache, not durable storage
+  (``project/design/design.md``: "``data/`` regenerates from cache").
+- **CWD-independent protected roots.** The guard does not use
+  ``lcats.utils.env.data_root()``/``corpora_root()`` directly: both resolve
+  their defaults relative to the *process's* current working directory,
+  but ``run_pilot.py`` is documented to run from the repo root with a
+  default ``--data-dir=lcats/data``, a different directory than
+  ``env.data_root()`` resolves to from that CWD (review finding, PR #210).
+  Instead this module reuses ``env.py``'s own default relative-path
+  strings (``"data"``, ``"../corpora"``, including their
+  ``LCATS_DATA_DIR``/``LCATS_CORPORA_DIR`` overrides) but resolves them
+  against ``paths.find_pyproject_root(__file__)`` -- this module's own
+  file location, never the caller's CWD -- the same pattern
+  ``lcats.utils.secrets``/``lcats.utils.test_utils`` already use.
+- **Fingerprint required, contents caller-defined.** Every checkpoint write
+  takes an explicit ``fingerprint`` argument (never a silent default). A
+  falsy fingerprint (``None``, ``{}``) is a caller's deliberate,
+  visible opt-out of mismatch invalidation, not an omitted parameter --
+  see :func:`read_checkpoint`.
+- **Atomic publication.** Writes go to a temp file in the same directory as
+  the target and are moved into place via ``os.replace`` only after the
+  write completes, so an interruption mid-write never leaves a torn
+  checkpoint file in place of a real one.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import pathlib
+import tempfile
+from typing import Any, Optional, Union
+
+from lcats.utils import paths
+
+PathLike = Union[str, pathlib.Path]
+
+_SUCCESS = "success"
+_FAILURE = "failure"
+_VALID_OUTCOMES = (_SUCCESS, _FAILURE)
+
+
+class ProtectedRootError(ValueError):
+    """Raised when working_root resolves under a protected data/corpora root."""
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckpointRoots:
+    """A resolved (working_root, source_root) pair for a pipeline run.
+
+    ``source_root`` defaults to ``working_root`` when the caller omits it,
+    implying in-place checkpointing. Only ``working_root`` is subject to
+    the protected-root write-guard -- see :func:`resolve_roots`.
+    """
+
+    working_root: pathlib.Path
+    source_root: pathlib.Path
+
+
+@dataclasses.dataclass(frozen=True)
+class CheckpointResult:
+    """The outcome of checking whether a checkpoint is already done.
+
+    ``done`` is False for: no checkpoint file, a checkpoint file that
+    fails to parse (I/O error, JSON error, unexpected shape), or a
+    checkpoint whose recorded fingerprint does not match the caller's
+    current fingerprint. None of these are raised as errors -- an
+    incomplete/stale checkpoint is exactly the "not done yet" case a
+    caller should recompute for, not a hard failure.
+    """
+
+    done: bool
+    outcome: Optional[str] = None
+    data: Any = None
+
+
+def _protected_roots() -> tuple[pathlib.Path, pathlib.Path]:
+    """Return the canonical (data_root, corpora_root) paths.
+
+    Reuses env.py's own default relative-path strings and env-var
+    overrides (LCATS_DATA_DIR default "data", LCATS_CORPORA_DIR default
+    "../corpora"), but resolves them against this module's own file
+    location via paths.find_pyproject_root, not the process's CWD -- see
+    this module's docstring for why env.data_root()/env.corpora_root()
+    themselves are not used directly here.
+    """
+    anchor = paths.find_pyproject_root(__file__)
+    data_default = os.environ.get("LCATS_DATA_DIR", "data")
+    corpora_default = os.environ.get("LCATS_CORPORA_DIR", "../corpora")
+    return (
+        (anchor / data_default).resolve(),
+        (anchor / corpora_default).resolve(),
+    )
+
+
+def _is_under(candidate: pathlib.Path, root: pathlib.Path) -> bool:
+    """Return True if candidate is root itself or nested inside it."""
+    return candidate == root or root in candidate.parents
+
+
+def _check_working_root_allowed(
+    working_root: pathlib.Path, allow_protected_root: bool
+) -> None:
+    if allow_protected_root:
+        return
+    resolved = working_root.resolve()
+    for protected in _protected_roots():
+        if _is_under(resolved, protected):
+            raise ProtectedRootError(
+                f"working_root ({resolved}) resolves under the protected "
+                f"root {protected}; refusing to write checkpoints there "
+                "(data/ is a disposable cache and corpora/ is copied "
+                "wholesale by `lcats promote` -- see this module's "
+                "docstring). Pass allow_protected_root=True to override "
+                "this deliberately."
+            )
+
+
+def resolve_roots(
+    working_root: PathLike,
+    source_root: Optional[PathLike] = None,
+    *,
+    allow_protected_root: bool = False,
+) -> CheckpointRoots:
+    """Resolve and validate a (working_root, source_root) pair.
+
+    Raises:
+        ProtectedRootError: working_root resolves under the canonical
+            data/ or corpora/ root and allow_protected_root was not set.
+    """
+    working_root = pathlib.Path(working_root)
+    _check_working_root_allowed(working_root, allow_protected_root)
+
+    resolved_source = (
+        pathlib.Path(source_root) if source_root is not None else working_root
+    )
+    return CheckpointRoots(working_root=working_root, source_root=resolved_source)
+
+
+def checkpoint_path(working_root: PathLike, item_id: str, stage: str) -> pathlib.Path:
+    """Return the path a checkpoint for (item_id, stage) is stored at.
+
+    item_id is used as-is as the subdirectory name under working_root,
+    reusing the same directory-slug identity
+    lcats.analysis.corpus.discovery's canonical story-bucket selector
+    uses for a story's own bucket directory -- this module does not
+    invent a second identity scheme.
+    """
+    return pathlib.Path(working_root) / item_id / f"{stage}.json"
+
+
+def read_checkpoint(
+    working_root: PathLike,
+    item_id: str,
+    stage: str,
+    fingerprint: Any,
+) -> CheckpointResult:
+    """Check whether (item_id, stage) already has a completed checkpoint
+    under working_root matching fingerprint.
+
+    fingerprint here is the caller's *current* configuration identity,
+    compared against whatever was recorded when the checkpoint was
+    written. If the checkpoint was written with an empty/no-op
+    fingerprint (write_checkpoint's own opt-out -- see its docstring),
+    the recorded fingerprint is falsy and the mismatch check never
+    invalidates the checkpoint, regardless of what is passed here, since
+    there is nothing to compare against.
+
+    Only working_root is consulted; source_root is never read here (see
+    this module's docstring).
+    """
+    path = checkpoint_path(working_root, item_id, stage)
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return CheckpointResult(done=False)
+
+    if not isinstance(record, dict) or record.get("outcome") not in _VALID_OUTCOMES:
+        return CheckpointResult(done=False)
+
+    recorded_fingerprint = record.get("fingerprint")
+    if recorded_fingerprint and recorded_fingerprint != fingerprint:
+        return CheckpointResult(done=False)
+
+    return CheckpointResult(
+        done=True, outcome=record["outcome"], data=record.get("data")
+    )
+
+
+def write_checkpoint(
+    working_root: PathLike,
+    item_id: str,
+    stage: str,
+    outcome: str,
+    fingerprint: Any,
+    data: Any = None,
+) -> pathlib.Path:
+    """Atomically record a checkpoint outcome for (item_id, stage).
+
+    Writes to a temporary file in the same directory as the checkpoint
+    target and moves it into place via os.replace only once the write
+    completes, so an interruption mid-write (including one that raises
+    BaseException, e.g. KeyboardInterrupt) never leaves a torn file where
+    the checkpoint would be read from -- the temp file is cleaned up
+    instead, leaving the prior state (checkpoint present or absent)
+    unchanged.
+
+    Args:
+        working_root: Directory the checkpoint is written under. Callers
+            are expected to have already validated this via
+            resolve_roots(); this function does not re-check the
+            protected-root guard, so it must not be called with a
+            working_root that has not passed that check.
+        item_id: Directory slug identifying the item (e.g. a story).
+        stage: Name of the pipeline stage this checkpoint covers.
+        outcome: "success" or "failure".
+        fingerprint: Caller-defined configuration identity (e.g. model
+            name plus a prompt/schema version). Required on every call --
+            pass None or {} to explicitly record "no fingerprint tracked
+            for this checkpoint" rather than omitting the argument.
+        data: Optional JSON-serializable payload to store alongside the
+            outcome (e.g. the actual extracted result for this stage).
+
+    Returns:
+        The path the checkpoint was written to.
+
+    Raises:
+        ValueError: outcome is not "success" or "failure".
+    """
+    if outcome not in _VALID_OUTCOMES:
+        raise ValueError(f"outcome must be one of {_VALID_OUTCOMES}, got {outcome!r}")
+
+    item_dir = pathlib.Path(working_root) / item_id
+    paths.makedirs(item_dir)
+
+    target = item_dir / f"{stage}.json"
+    record = {"outcome": outcome, "fingerprint": fingerprint, "data": data}
+
+    fd, tmp_name = tempfile.mkstemp(dir=item_dir, prefix=f".{stage}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            json.dump(record, tmp_file)
+        os.replace(tmp_name, target)
+    except BaseException:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+        raise
+
+    return target

--- a/lcats/src/lcats/utils/checkpoint.py
+++ b/lcats/src/lcats/utils/checkpoint.py
@@ -43,7 +43,14 @@ entry and ``PROP-LCATS-PIPELINE-CHECKPOINTING``):
   takes an explicit ``fingerprint`` argument (never a silent default). A
   falsy fingerprint (``None``, ``{}``) is a caller's deliberate,
   visible opt-out of mismatch invalidation, not an omitted parameter --
-  see :func:`read_checkpoint`.
+  see :func:`read_checkpoint`. Fingerprints are compared after a JSON
+  round-trip on both sides (:func:`_normalize_fingerprint`), so a
+  fingerprint containing tuples or int dict keys still matches its own
+  previously-recorded form.
+- **A recorded failure is not "done."** ``read_checkpoint`` only reports
+  ``done=True`` for a recorded "success" -- a recorded "failure" is
+  recoverable and must be recomputed on resume, not silently skipped
+  just because a checkpoint file exists.
 - **Atomic publication.** Writes go to a temp file in the same directory as
   the target and are moved into place via ``os.replace`` only after the
   write completes, so an interruption mid-write never leaves a torn
@@ -90,11 +97,14 @@ class CheckpointResult:
     """The outcome of checking whether a checkpoint is already done.
 
     ``done`` is False for: no checkpoint file, a checkpoint file that
-    fails to parse (I/O error, JSON error, unexpected shape), or a
-    checkpoint whose recorded fingerprint does not match the caller's
-    current fingerprint. None of these are raised as errors -- an
-    incomplete/stale checkpoint is exactly the "not done yet" case a
-    caller should recompute for, not a hard failure.
+    fails to parse (I/O error, JSON/Unicode decode error, unexpected
+    shape), a checkpoint whose recorded fingerprint does not match the
+    caller's current fingerprint, or a checkpoint recording a "failure"
+    outcome. None of these are raised as errors -- an incomplete/stale/
+    failed checkpoint is exactly the "not done yet" case a caller should
+    recompute for, not a hard failure. ``outcome``/``data`` are still
+    populated for a recorded failure (unlike the other False cases),
+    since it does exist and may be worth inspecting.
     """
 
     done: bool
@@ -132,7 +142,18 @@ def _check_working_root_allowed(
     if allow_protected_root:
         return
     resolved = working_root.resolve()
-    for protected in _protected_roots():
+    try:
+        protected_roots = _protected_roots()
+    except FileNotFoundError as error:
+        raise RuntimeError(
+            "cannot determine the protected data/corpora roots for the "
+            "working_root write-guard: no pyproject.toml found in any "
+            "ancestor of lcats.utils.checkpoint's own file location. This "
+            "usually means lcats is installed as a non-editable package "
+            "outside its source checkout. Pass allow_protected_root=True "
+            "if you have independently confirmed working_root is safe."
+        ) from error
+    for protected in protected_roots:
         if _is_under(resolved, protected):
             raise ProtectedRootError(
                 f"working_root ({resolved}) resolves under the protected "
@@ -155,6 +176,11 @@ def resolve_roots(
     Raises:
         ProtectedRootError: working_root resolves under the canonical
             data/ or corpora/ root and allow_protected_root was not set.
+        RuntimeError: the protected data/corpora roots could not be
+            determined at all (e.g. a non-editable install with no
+            source tree to walk) -- distinct from ProtectedRootError,
+            since allow_protected_root cannot fix a situation where the
+            guard couldn't run in the first place.
     """
     working_root = pathlib.Path(working_root)
     _check_working_root_allowed(working_root, allow_protected_root)
@@ -165,6 +191,22 @@ def resolve_roots(
     return CheckpointRoots(working_root=working_root, source_root=resolved_source)
 
 
+def _validate_path_component(value: str, name: str) -> None:
+    """Raise ValueError if value is not safe to use as a single path segment.
+
+    item_id/stage are caller-supplied identifiers, not paths -- without
+    this check, a value containing a path separator, "..", or an
+    absolute path could escape working_root entirely (e.g.
+    item_id="/tmp" ignoring working_root altogether; review finding,
+    PR #213).
+    """
+    parts = pathlib.PurePath(value).parts
+    if len(parts) != 1 or value in (".", ".."):
+        raise ValueError(
+            f"{name} must be a single, relative path segment, got {value!r}"
+        )
+
+
 def checkpoint_path(working_root: PathLike, item_id: str, stage: str) -> pathlib.Path:
     """Return the path a checkpoint for (item_id, stage) is stored at.
 
@@ -173,8 +215,28 @@ def checkpoint_path(working_root: PathLike, item_id: str, stage: str) -> pathlib
     lcats.analysis.corpus.discovery's canonical story-bucket selector
     uses for a story's own bucket directory -- this module does not
     invent a second identity scheme.
+
+    Raises:
+        ValueError: item_id or stage is not a safe single path segment.
     """
+    _validate_path_component(item_id, "item_id")
+    _validate_path_component(stage, "stage")
     return pathlib.Path(working_root) / item_id / f"{stage}.json"
+
+
+def _normalize_fingerprint(fingerprint: Any) -> Any:
+    """Round-trip fingerprint through JSON so comparisons match what
+    would actually be recorded on disk.
+
+    Without this, a fingerprint containing a tuple or an int dict key
+    compares unequal to its own just-written, JSON-decoded form (tuples
+    become lists, int keys become strings), so a checkpoint would never
+    be honored and expensive stages would be recomputed on every resume
+    (review finding, PR #213).
+    """
+    if not fingerprint:
+        return fingerprint
+    return json.loads(json.dumps(fingerprint))
 
 
 def read_checkpoint(
@@ -186,13 +248,24 @@ def read_checkpoint(
     """Check whether (item_id, stage) already has a completed checkpoint
     under working_root matching fingerprint.
 
+    ``done`` is True only for a recorded "success" outcome. A recorded
+    "failure" is not done -- the governing design treats a recorded
+    failure as recoverable and requires it be recomputed on resume, not
+    silently treated as complete just because a checkpoint file exists
+    (review finding, PR #213); its outcome/data are still returned for
+    inspection, distinguishing it from a checkpoint that doesn't exist
+    at all.
+
     fingerprint here is the caller's *current* configuration identity,
-    compared against whatever was recorded when the checkpoint was
-    written. If the checkpoint was written with an empty/no-op
-    fingerprint (write_checkpoint's own opt-out -- see its docstring),
-    the recorded fingerprint is falsy and the mismatch check never
-    invalidates the checkpoint, regardless of what is passed here, since
-    there is nothing to compare against.
+    compared (after JSON-normalizing both sides -- see
+    _normalize_fingerprint) against whatever was recorded when the
+    checkpoint was written. If the checkpoint was written with an
+    empty/no-op fingerprint (write_checkpoint's own opt-out -- see its
+    docstring), the recorded fingerprint is falsy and the mismatch check
+    never invalidates the checkpoint, regardless of what is passed here,
+    since there is nothing to compare against. A fingerprint mismatch is
+    treated as if the checkpoint did not exist at all -- unlike a
+    recorded failure, no outcome/data is returned.
 
     Only working_root is consulted; source_root is never read here (see
     this module's docstring).
@@ -200,18 +273,20 @@ def read_checkpoint(
     path = checkpoint_path(working_root, item_id, stage)
     try:
         record = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return CheckpointResult(done=False)
 
     if not isinstance(record, dict) or record.get("outcome") not in _VALID_OUTCOMES:
         return CheckpointResult(done=False)
 
     recorded_fingerprint = record.get("fingerprint")
-    if recorded_fingerprint and recorded_fingerprint != fingerprint:
-        return CheckpointResult(done=False)
+    if recorded_fingerprint:
+        if recorded_fingerprint != _normalize_fingerprint(fingerprint):
+            return CheckpointResult(done=False)
 
+    outcome = record["outcome"]
     return CheckpointResult(
-        done=True, outcome=record["outcome"], data=record.get("data")
+        done=(outcome == _SUCCESS), outcome=outcome, data=record.get("data")
     )
 
 
@@ -253,15 +328,16 @@ def write_checkpoint(
         The path the checkpoint was written to.
 
     Raises:
-        ValueError: outcome is not "success" or "failure".
+        ValueError: outcome is not "success"/"failure", or item_id/stage
+            is not a safe single path segment (see checkpoint_path).
     """
     if outcome not in _VALID_OUTCOMES:
         raise ValueError(f"outcome must be one of {_VALID_OUTCOMES}, got {outcome!r}")
 
-    item_dir = pathlib.Path(working_root) / item_id
+    target = checkpoint_path(working_root, item_id, stage)
+    item_dir = target.parent
     paths.makedirs(item_dir)
 
-    target = item_dir / f"{stage}.json"
     record = {"outcome": outcome, "fingerprint": fingerprint, "data": data}
 
     fd, tmp_name = tempfile.mkstemp(dir=item_dir, prefix=f".{stage}.", suffix=".tmp")

--- a/lcats/src/lcats/utils/checkpoint.py
+++ b/lcats/src/lcats/utils/checkpoint.py
@@ -233,10 +233,19 @@ def _normalize_fingerprint(fingerprint: Any) -> Any:
     become lists, int keys become strings), so a checkpoint would never
     be honored and expensive stages would be recomputed on every resume
     (review finding, PR #213).
+
+    A non-JSON-serializable fingerprint (e.g. containing a set) falls
+    back to the original value unchanged rather than raising -- it won't
+    normalize identically to a stored one, but read_checkpoint's contract
+    is that a mismatch is treated as "not done," not a crash (independent
+    review finding after PR #213's own fix round).
     """
     if not fingerprint:
         return fingerprint
-    return json.loads(json.dumps(fingerprint))
+    try:
+        return json.loads(json.dumps(fingerprint))
+    except TypeError:
+        return fingerprint
 
 
 def read_checkpoint(

--- a/lcats/tests/utils_tests/checkpoint_test.py
+++ b/lcats/tests/utils_tests/checkpoint_test.py
@@ -106,13 +106,26 @@ class ResolveRootsTest(unittest.TestCase):
         """
         working = self.tmp_dir / "data" / "mycollection"
         original_cwd = os.getcwd()
-        elsewhere = tempfile.mkdtemp()
-        try:
-            os.chdir(elsewhere)
-            with self.assertRaises(checkpoint.ProtectedRootError):
+        with tempfile.TemporaryDirectory() as elsewhere:
+            try:
+                os.chdir(elsewhere)
+                with self.assertRaises(checkpoint.ProtectedRootError):
+                    checkpoint.resolve_roots(working)
+            finally:
+                os.chdir(original_cwd)
+
+    def test_undetermined_protected_roots_raises_runtime_error(self):
+        """A FileNotFoundError from find_pyproject_root (e.g. a non-editable
+        install with no source tree) is wrapped into an actionable
+        RuntimeError, not left as an undocumented, unactionable exception
+        (review finding, PR #213)."""
+        working = self.tmp_dir / "somewhere"
+        with patch(
+            "lcats.utils.checkpoint.paths.find_pyproject_root",
+            side_effect=FileNotFoundError("no pyproject.toml found"),
+        ):
+            with self.assertRaises(RuntimeError):
                 checkpoint.resolve_roots(working)
-        finally:
-            os.chdir(original_cwd)
 
 
 class CheckpointPathTest(unittest.TestCase):
@@ -122,6 +135,23 @@ class CheckpointPathTest(unittest.TestCase):
         path = checkpoint.checkpoint_path("/working", "my_story", "segment")
 
         self.assertEqual(path, pathlib.Path("/working/my_story/segment.json"))
+
+    def test_rejects_item_id_containing_path_separator(self):
+        """item_id must not be able to escape working_root (review finding, PR #213)."""
+        with self.assertRaises(ValueError):
+            checkpoint.checkpoint_path("/working", "../escape", "segment")
+
+    def test_rejects_absolute_item_id(self):
+        with self.assertRaises(ValueError):
+            checkpoint.checkpoint_path("/working", "/tmp", "segment")
+
+    def test_rejects_dotdot_item_id(self):
+        with self.assertRaises(ValueError):
+            checkpoint.checkpoint_path("/working", "..", "segment")
+
+    def test_rejects_stage_containing_path_separator(self):
+        with self.assertRaises(ValueError):
+            checkpoint.checkpoint_path("/working", "my_story", "sub/stage")
 
 
 class WriteAndReadCheckpointTest(unittest.TestCase):
@@ -160,8 +190,11 @@ class WriteAndReadCheckpointTest(unittest.TestCase):
         self.assertEqual(result.data, {"segments": ["a", "b"]})
 
     def test_predicate_distinguishes_success_from_failure(self):
-        """A recorded failure is still 'done' -- it's a completed, recorded
-        outcome, not bare file presence standing in for success."""
+        """A recorded failure is NOT 'done' -- the governing design requires
+        a failed stage to be recomputed on resume, not silently skipped
+        just because a checkpoint file exists (review finding, PR #213).
+        Its outcome is still surfaced, distinguishing it from a checkpoint
+        that doesn't exist at all."""
         checkpoint.write_checkpoint(
             self.working_root,
             "story_a",
@@ -174,8 +207,61 @@ class WriteAndReadCheckpointTest(unittest.TestCase):
             self.working_root, "story_a", "segment", fingerprint={"model": "x"}
         )
 
-        self.assertTrue(result.done)
+        self.assertFalse(result.done)
         self.assertEqual(result.outcome, "failure")
+
+    def test_malformed_utf8_is_treated_as_not_done(self):
+        """Invalid UTF-8 bytes raise UnicodeDecodeError from read_text,
+        which must be treated as an incomplete checkpoint like any other
+        parse failure, not propagated as a crash (review finding, PR #213)."""
+        item_dir = self.working_root / "story_a"
+        item_dir.mkdir(parents=True)
+        (item_dir / "segment.json").write_bytes(b"\xff\xfe not valid utf-8")
+
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint={"model": "x"}
+        )
+
+        self.assertFalse(result.done)
+
+    def test_fingerprint_with_tuple_value_round_trips_as_matching(self):
+        """A fingerprint containing a tuple must still match its own
+        just-written form after JSON round-tripping (tuple -> list),
+        or every resume would recompute unnecessarily (review finding,
+        PR #213)."""
+        fingerprint = {"model": "x", "versions": (1, 2, 3)}
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint=fingerprint,
+        )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint=fingerprint
+        )
+
+        self.assertTrue(result.done)
+
+    def test_fingerprint_with_int_dict_key_round_trips_as_matching(self):
+        """A fingerprint containing an int dict key must still match its
+        own just-written form after JSON round-tripping (int key ->
+        string key)."""
+        fingerprint = {"model": "x", "stage_versions": {1: "v1"}}
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint=fingerprint,
+        )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint=fingerprint
+        )
+
+        self.assertTrue(result.done)
 
     def test_fingerprint_mismatch_invalidates_checkpoint(self):
         checkpoint.write_checkpoint(

--- a/lcats/tests/utils_tests/checkpoint_test.py
+++ b/lcats/tests/utils_tests/checkpoint_test.py
@@ -1,0 +1,349 @@
+"""Tests for lcats.utils.checkpoint."""
+
+import json
+import os
+import pathlib
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from lcats.utils import checkpoint
+
+
+class ResolveRootsTest(unittest.TestCase):
+    """Tests for resolve_roots's dual-root defaulting and write-guard."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp_dir = pathlib.Path(self._tmp.name).resolve()
+        # Anchor the protected-root computation at a controlled, fake
+        # project root instead of this repo's real pyproject.toml, so the
+        # guard tests are independent of this checkout's actual state and
+        # of the real data/ and corpora/ directories existing on disk.
+        self._patch = patch(
+            "lcats.utils.checkpoint.paths.find_pyproject_root",
+            return_value=self.tmp_dir,
+        )
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        self._tmp.cleanup()
+
+    def test_source_root_defaults_to_working_root(self):
+        """Omitting source_root implies in-place checkpointing."""
+        working = self.tmp_dir / "results"
+
+        roots = checkpoint.resolve_roots(working)
+
+        self.assertEqual(roots.working_root, working)
+        self.assertEqual(roots.source_root, working)
+
+    def test_explicit_source_root_is_kept_distinct(self):
+        """An explicit source_root is not overwritten by the default."""
+        working = self.tmp_dir / "results"
+        source = self.tmp_dir / "data" / "some_collection"
+
+        roots = checkpoint.resolve_roots(working, source_root=source)
+
+        self.assertEqual(roots.working_root, working)
+        self.assertEqual(roots.source_root, source)
+
+    def test_working_root_under_data_root_is_rejected(self):
+        """working_root resolving under the canonical data/ root is refused."""
+        working = self.tmp_dir / "data" / "mycollection" / "mystory"
+
+        with self.assertRaises(checkpoint.ProtectedRootError):
+            checkpoint.resolve_roots(working)
+
+    def test_working_root_under_corpora_root_is_rejected(self):
+        """working_root resolving under the canonical corpora/ root is refused."""
+        working = (self.tmp_dir / ".." / "corpora" / "mycollection").resolve()
+
+        with self.assertRaises(checkpoint.ProtectedRootError):
+            checkpoint.resolve_roots(working)
+
+    def test_working_root_equal_to_protected_root_is_rejected(self):
+        """The protected root itself, not just something nested inside it, is refused."""
+        working = self.tmp_dir / "data"
+
+        with self.assertRaises(checkpoint.ProtectedRootError):
+            checkpoint.resolve_roots(working)
+
+    def test_override_flag_allows_protected_root(self):
+        """allow_protected_root=True is a deliberate, explicit opt-in."""
+        working = self.tmp_dir / "data" / "mycollection"
+
+        roots = checkpoint.resolve_roots(working, allow_protected_root=True)
+
+        self.assertEqual(roots.working_root, working)
+
+    def test_source_root_pointed_at_data_is_never_guarded(self):
+        """Only working_root is guarded -- reading data/ as input is legitimate."""
+        working = self.tmp_dir / "results"
+        source = self.tmp_dir / "data" / "mycollection"
+
+        roots = checkpoint.resolve_roots(working, source_root=source)
+
+        self.assertEqual(roots.source_root, source)
+
+    def test_working_root_outside_protected_roots_is_allowed(self):
+        """An ordinary working directory outside data/corpora is unaffected."""
+        working = self.tmp_dir / "experiments" / "03_pilot" / "results"
+
+        roots = checkpoint.resolve_roots(working)
+
+        self.assertEqual(roots.working_root, working)
+
+    def test_guard_fires_regardless_of_process_cwd(self):
+        """The guard is anchored to a fixed location, not the caller's CWD.
+
+        Confirms the review finding this module's docstring documents:
+        env.data_root()/corpora_root() resolve relative to CWD, which
+        made the original guard design silently ineffective. Here, the
+        anchor is patched to a fixed directory, so changing CWD to
+        somewhere unrelated must not change the outcome.
+        """
+        working = self.tmp_dir / "data" / "mycollection"
+        original_cwd = os.getcwd()
+        elsewhere = tempfile.mkdtemp()
+        try:
+            os.chdir(elsewhere)
+            with self.assertRaises(checkpoint.ProtectedRootError):
+                checkpoint.resolve_roots(working)
+        finally:
+            os.chdir(original_cwd)
+
+
+class CheckpointPathTest(unittest.TestCase):
+    """Tests for checkpoint_path's directory-slug convention."""
+
+    def test_uses_item_id_as_subdirectory(self):
+        path = checkpoint.checkpoint_path("/working", "my_story", "segment")
+
+        self.assertEqual(path, pathlib.Path("/working/my_story/segment.json"))
+
+
+class WriteAndReadCheckpointTest(unittest.TestCase):
+    """Tests for write_checkpoint/read_checkpoint's predicate and fingerprinting."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.working_root = pathlib.Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_read_before_any_write_is_not_done(self):
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint={"model": "x"}
+        )
+
+        self.assertFalse(result.done)
+
+    def test_write_then_read_round_trips_success(self):
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint={"model": "x"},
+            data={"segments": ["a", "b"]},
+        )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint={"model": "x"}
+        )
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.outcome, "success")
+        self.assertEqual(result.data, {"segments": ["a", "b"]})
+
+    def test_predicate_distinguishes_success_from_failure(self):
+        """A recorded failure is still 'done' -- it's a completed, recorded
+        outcome, not bare file presence standing in for success."""
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="failure",
+            fingerprint={"model": "x"},
+        )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint={"model": "x"}
+        )
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.outcome, "failure")
+
+    def test_fingerprint_mismatch_invalidates_checkpoint(self):
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint={"model": "old-model"},
+        )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            fingerprint={"model": "new-model"},
+        )
+
+        self.assertFalse(result.done)
+
+    def test_empty_fingerprint_opts_out_of_mismatch_check(self):
+        """A caller that writes with no fingerprint gets it honored under
+        any fingerprint on resume, since there is nothing to compare."""
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint=None,
+        )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            fingerprint={"model": "anything"},
+        )
+
+        self.assertTrue(result.done)
+
+    def test_malformed_json_is_treated_as_not_done(self):
+        """A torn/corrupt checkpoint file is 'not done', not a hard failure."""
+        item_dir = self.working_root / "story_a"
+        item_dir.mkdir(parents=True)
+        (item_dir / "segment.json").write_text("{not valid json", encoding="utf-8")
+
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint={"model": "x"}
+        )
+
+        self.assertFalse(result.done)
+
+    def test_missing_outcome_field_is_treated_as_not_done(self):
+        """An unexpected shape (no recognizable outcome) is 'not done', not raised."""
+        item_dir = self.working_root / "story_a"
+        item_dir.mkdir(parents=True)
+        (item_dir / "segment.json").write_text(
+            json.dumps({"something_else": True}), encoding="utf-8"
+        )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint={"model": "x"}
+        )
+
+        self.assertFalse(result.done)
+
+    def test_invalid_outcome_value_raises(self):
+        with self.assertRaises(ValueError):
+            checkpoint.write_checkpoint(
+                self.working_root,
+                "story_a",
+                "segment",
+                outcome="maybe",
+                fingerprint={"model": "x"},
+            )
+
+    def test_per_stage_granularity_is_independent(self):
+        """Two stages for the same item checkpoint independently."""
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint={"model": "x"},
+        )
+
+        segment_result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint={"model": "x"}
+        )
+        extraction_result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "extraction", fingerprint={"model": "x"}
+        )
+
+        self.assertTrue(segment_result.done)
+        self.assertFalse(extraction_result.done)
+
+
+class AtomicPublicationTest(unittest.TestCase):
+    """Tests for write_checkpoint's atomic temp-file + os.replace behavior."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.working_root = pathlib.Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_no_temp_file_survives_a_successful_write(self):
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint={"model": "x"},
+        )
+
+        item_dir = self.working_root / "story_a"
+        leftovers = [p for p in item_dir.iterdir() if p.name != "segment.json"]
+        self.assertEqual(leftovers, [])
+
+    def test_interruption_mid_write_leaves_no_target_file(self):
+        """A KeyboardInterrupt during the write never produces a torn target.
+
+        KeyboardInterrupt is deliberately used here, not a plain Exception:
+        it is a BaseException, matching the real interruption this
+        checkpoint helper exists to survive (see WI-PIPELINE-0041's own
+        review finding that a fake-backend test using an ordinary
+        Exception does not exercise the real Ctrl-C escape path).
+        """
+        with patch("lcats.utils.checkpoint.json.dump", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                checkpoint.write_checkpoint(
+                    self.working_root,
+                    "story_a",
+                    "segment",
+                    outcome="success",
+                    fingerprint={"model": "x"},
+                )
+
+        target = self.working_root / "story_a" / "segment.json"
+        self.assertFalse(target.exists())
+        item_dir = self.working_root / "story_a"
+        self.assertEqual(list(item_dir.iterdir()), [])
+
+    def test_interruption_mid_write_preserves_prior_checkpoint(self):
+        """An interrupted re-write does not destroy an existing valid checkpoint."""
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint={"model": "old"},
+        )
+
+        with patch("lcats.utils.checkpoint.json.dump", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                checkpoint.write_checkpoint(
+                    self.working_root,
+                    "story_a",
+                    "segment",
+                    outcome="success",
+                    fingerprint={"model": "new"},
+                )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root, "story_a", "segment", fingerprint={"model": "old"}
+        )
+        self.assertTrue(result.done)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lcats/tests/utils_tests/checkpoint_test.py
+++ b/lcats/tests/utils_tests/checkpoint_test.py
@@ -244,6 +244,29 @@ class WriteAndReadCheckpointTest(unittest.TestCase):
 
         self.assertTrue(result.done)
 
+    def test_non_json_serializable_fingerprint_does_not_raise(self):
+        """A fingerprint containing a non-JSON-serializable value (e.g. a
+        set) must not crash read_checkpoint -- normalization falls back
+        to the raw value instead of raising, preserving the module's
+        never-raises-on-comparison contract (independent review finding
+        after PR #213's own fix round)."""
+        checkpoint.write_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            outcome="success",
+            fingerprint={"model": "x"},
+        )
+
+        result = checkpoint.read_checkpoint(
+            self.working_root,
+            "story_a",
+            "segment",
+            fingerprint={"model": "x", "tags": {1, 2, 3}},
+        )
+
+        self.assertFalse(result.done)
+
     def test_fingerprint_with_int_dict_key_round_trips_as_matching(self):
         """A fingerprint containing an int dict key must still match its
         own just-written form after JSON round-tripping (int key ->


### PR DESCRIPTION
## Summary
- Implements `WI-PIPELINE-0040`: a shared checkpoint helper (`lcats/src/lcats/utils/checkpoint.py`) for LCATS's LLM-driven batch scripts, generalizing `DataGatherer`'s dual-root bucket-directory + file-existence pattern.
- `resolve_roots(working_root, source_root=None)`: `source_root` defaults to `working_root` (in-place checkpointing); only `working_root` is guarded against the canonical `data/`/`corpora/` roots, anchored via `paths.find_pyproject_root(__file__)` rather than `env.data_root()`/`corpora_root()`'s CWD-relative defaults (fixes the CWD-dependence review caught on PR #210's planning doc).
- `write_checkpoint`/`read_checkpoint`: atomic temp-file + `os.replace` publication, a success/failure predicate (not bare file presence), and a required `fingerprint` argument on every write — an empty/no-op fingerprint is an explicit opt-out of mismatch invalidation, not a silent default.
- New test suite (`lcats/tests/utils_tests/checkpoint_test.py`, 20 tests) covers the write-guard (triggering it, overriding it, and confirming it fires under a different process CWD via a patched anchor), atomic publication under a real `KeyboardInterrupt` mid-write, the success/failure predicate, fingerprint mismatch invalidation and opt-out, and per-stage independence.

Prompt ID: `PROMPT(WI-PIPELINE-0040:WI_PIPELINE_0040)[2026-08-02T15:11:54-04:00]`

## Test plan
- [x] `scripts/version tools`
- [x] `scripts/format --check --diff` — clean
- [x] `scripts/lint` — clean
- [x] `scripts/test` — 1583 passed
- [x] `lrh validate` — 0 errors, 61 warnings (unchanged baseline)
