### PR TITLE
Add work item WI-EXPERIMENTS-0047: fix non-recursive file discovery in run_comparison.py/smoke_test.py

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_08_02_15_58_31_WI_EXPERIMENTS_0047.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_15_58_31_WI_EXPERIMENTS_0047.md
@@ -1,0 +1,67 @@
+---
+execution_id: 2026_08_02_15_58_31_WI_EXPERIMENTS_0047
+prompt_id: PROMPT(AD_HOC:WI_EXPERIMENTS_0047)[2026-08-02T15:55:26-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/214
+commit: 92391e8333716e9000c147074e07dee6d2f333dd
+created_at: 2026-08-02T15:58:31-04:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-EXPERIMENTS-0047.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Created `WI-EXPERIMENTS-0047`: fix the non-recursive file-selection bug
+in `run_comparison.py`/`smoke_test.py` (Batch 3 of the
+`WS-STORY-BUCKET-LAYOUT` follow-up resolution plan; Batch 1,
+`WI-EXPERIMENTS-0046`, already merged via PR #212).
+
+# Result
+
+- Before drafting, re-verified all code claims directly against current
+  `origin/main` content rather than trusting earlier backlog notes (per
+  the just-reinforced `feedback_own_planning_docs_need_code_verification`
+  memory) -- confirmed the exact bug lines, confirmed both scripts scan a
+  single named collection directory (no cross-collection cache-collision
+  risk like Batch 1 had), and found one additional cosmetic issue
+  (`run_comparison.py`'s progress print would show the literal string
+  `"story.json"` for every story) by reading the full file rather than
+  just the flagged lines.
+- While investigating `assess_story`'s identity handling for context,
+  initially misread its code and raised a false alarm that the real
+  `lcats assess` CLI was broadly broken -- caught this myself on a
+  closer read (the `file_path.stem` line is only a pre-initialized
+  fallback, immediately overwritten by `run_preflight`'s correct value in
+  the success path) and corrected it transparently before proceeding.
+  The one real, narrow gap found (the exception-path fallback title)
+  was added to `project/design/backlog.md` as its own small P3 entry,
+  per user confirmation, in a separate commit.
+- Ran the prior art check: duplication search found no existing
+  implementation; demand search found `WI-EXPERIMENTS-0046`'s own
+  Non-Goals explicitly defers this exact fix, and
+  `project/design/backlog.md` has the matching entry this WI resolves.
+- Wrote `project/work_items/proposed/WI-EXPERIMENTS-0047.md`, confirmed
+  with the user before writing (ID chosen: `WI-EXPERIMENTS-0047`, same
+  prefix as Batch 1).
+- Opened [PR #214](https://github.com/xenotaur/LCATS/pull/214).
+
+# Validation
+
+- `lrh validate` -- 0 errors, 66 warnings (new WI's own pre-existing
+  `owner: unassigned` pattern shared by every other work item in this
+  repo).
+
+# Follow-up
+
+- Offer (per the prior-art demand-search recommendation, not
+  auto-closed): once this PR is confirmed/merged, remove or mark
+  resolved the matching `project/design/backlog.md` entry
+  ("Non-recursive glob bugs in two experiment scripts").
+- `status` is `in_progress`; update to `landed` via `/lrh-closeout` after
+  PR #214 merges. This does not resolve `WI-EXPERIMENTS-0047` itself --
+  the work item stays `proposed` until its *implementation* lands as a
+  separate PR.
+- Batch 4 (the two notebooks) remains unscoped.

--- a/lcats/project/executions/AD_HOC/2026_08_02_16_15_32_WI_EXPERIMENTS_0047_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_16_15_32_WI_EXPERIMENTS_0047_CONFIRM.md
@@ -1,0 +1,67 @@
+---
+execution_id: 2026_08_02_16_15_32_WI_EXPERIMENTS_0047_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EXPERIMENTS_0047_CONFIRM)[2026-08-02T16:08:43-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_02_15_58_31_WI_EXPERIMENTS_0047
+pr: https://github.com/xenotaur/LCATS/pull/214
+commit: 572cf51c3a29ed89cbcd6bfc7c7d11eb3ad4925f
+created_at: 2026-08-02T16:15:32-04:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/214
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge verification and thread-resolution pass for PR #214
+(`WI-EXPERIMENTS-0047` creation), per `/lrh-confirm-fixes`'s protocol,
+inlined per `/lrh-land`'s Phase 1 interim invocation pattern.
+
+# Result
+
+- Gathered state: GraphQL review-threads query showed 2 total threads,
+  both `isResolved: true`. CI (`gh pr checks 214`) --
+  coverage/lint/test all `SUCCESS`.
+- Both threads were real findings from automated review (1 Codex P1, 1
+  Copilot) that landed without this session triggering anything. Per
+  explicit user direction this run, substituted a fresh independent
+  subagent for the bot retrigger-and-wait mechanism this skill's Step
+  3/Step 8 would otherwise use. Verified both against actual source
+  before fixing:
+  - Codex (P1): `smoke_test.py`'s `_RUNS` pointed `corpus_dir` at
+    `lcats/data/lovecraft`/`lcats/data/london` -- confirmed via direct
+    read that `lcats/data/` doesn't exist in this checkout (gitignored
+    working cache, only populated by a real `lcats gather`), so even
+    with the file-selector bug fixed, the smoke test would still fail at
+    an earlier `corpus_dir.is_dir()` precondition check. Fixed by
+    repointing at the tracked, always-present `corpora/lovecraft`/
+    `corpora/london` (confirmed both exist as real bucket-layout
+    collections).
+  - Copilot: the work item cited `check_segmentation_reliability_test.py`
+    as an "existing" sibling-test convention -- confirmed via direct
+    `find` that it doesn't exist yet (it's `WI-EXPERIMENTS-0046`'s own
+    planned, not-yet-implemented artifact). Fixed to cite only the
+    actually-existing `run_pilot_test.py`.
+- Dispatched a fresh, independent subagent to verify the fix commit
+  (`572cf51c`) against actual current file content and actual current
+  code behavior. Clean pass -- both items confirmed genuinely fixed, no
+  new issues found on its own fresh read.
+- Re-checked for new unresolved threads after the fix commit: none. Both
+  threads resolved via `resolveReviewThread` (diff plainly satisfies
+  each).
+
+# Validation
+
+- `lrh validate` -- 0 errors, 66 pre-existing warnings (one transient
+  false alarm during this run was a wrong-cwd artifact -- `lrh validate`
+  run from the worktree root instead of `lcats/` reported a spurious
+  `FILE_NOT_FOUND`; re-run from the correct directory confirmed 0
+  errors).
+- `gh pr checks 214` -- coverage/lint/test all `SUCCESS` on `572cf51c`.
+- This PR is planning-only (a work item file, no source code); no test
+  suite run was applicable to this PR's own diff.
+
+# Follow-up
+
+- None -- ready for the merge gate.

--- a/lcats/project/work_items/proposed/WI-EXPERIMENTS-0047.md
+++ b/lcats/project/work_items/proposed/WI-EXPERIMENTS-0047.md
@@ -31,6 +31,7 @@ forbidden_actions:
 acceptance:
   - "run_comparison.py's story_files selection uses discovery.iter_collection_story_files, not corpus_dir.iterdir() filtered by suffix"
   - "smoke_test.py's _actual_sample uses the same selector, not corpus_dir.glob('*.json')"
+  - "smoke_test.py's _RUNS point at the always-present corpora/lovecraft and corpora/london, not lcats/data/lovecraft and lcats/data/london, which do not exist without a prior lcats gather run"
   - "Both scripts correctly find real bucket-layout story files (<collection>/<story>/story.json) under a single collection directory"
   - "run_comparison.py's per-story progress print no longer shows the literal string \"story.json\" for every story"
   - "A new regression test proves both scripts find bucket-layout stories correctly, and that the prior flat-layout-only behavior is gone"
@@ -76,6 +77,27 @@ leaf-filename-collapse issue as the identity problem elsewhere, but
 purely cosmetic here (log readability, not correctness) -- fixed in the
 same pass since it's directly adjacent to the line being changed.
 
+**One additional gap found via review of this work item's own creation
+PR, before any implementation was written:** `smoke_test.py`'s `_RUNS`
+config (lines 93-103) points `corpus_dir` at
+`_LCATS_ROOT / "data/lovecraft"` and `_LCATS_ROOT / "data/london"`
+(`_LCATS_ROOT` = the `lcats/` directory, line 183). `data/` is the
+gitignored, regenerable working cache -- it does not exist at all in a
+fresh checkout until someone runs a real `lcats gather`. Fixing the
+file-selector bug alone would not make the smoke test runnable: without
+`data/lovecraft` existing at all, `run_comparison.run()`'s own
+`if not corpus_dir.is_dir(): return 1` check fails first, for a
+different, pre-existing reason unrelated to the bucket-layout bug. The
+real, always-present, tracked collections for these two genres are
+`corpora/lovecraft` and `corpora/london` (repo root, confirmed present).
+Since either corpus source serves the smoke test's actual purpose
+(sanity-checking the assess pipeline against a small real sample)
+equally well, this work item also repoints `_RUNS` at the tracked
+`corpora/` snapshot, so the documented smoke test invocation
+(`python experiments/02_llm_backend_comparison/smoke_test.py`) actually
+works out of the box in any checkout, not just one where `lcats gather`
+has already been run.
+
 ### Duplication search
 - In-repo: No existing implementation found. Two adopted design
   proposals (`lcats-packaging-modernization/00_proposal.md`,
@@ -100,6 +122,9 @@ same pass since it's directly adjacent to the line being changed.
 
 - Fix file selection in both scripts to correctly find bucket-layout
   story files under a single collection directory.
+- Fix `smoke_test.py`'s configured corpus roots so the documented
+  invocation actually runs against the always-present tracked `corpora/`
+  snapshot, not the gitignored, gather-populated `data/` directory.
 - Fix the resulting cosmetic progress-print issue in `run_comparison.py`.
 - Add a regression test.
 - Do not touch `check_segmentation_reliability.py`
@@ -120,12 +145,21 @@ same pass since it's directly adjacent to the line being changed.
 3. In `smoke_test.py`, replace `sorted(corpus_dir.glob("*.json"))` in
    `_actual_sample` with the same
    `discovery.iter_collection_story_files(corpus_dir)` call.
-4. Create `experiments/02_llm_backend_comparison/run_comparison_test.py`
-   (matching the existing `run_pilot_test.py`/
-   `check_segmentation_reliability_test.py` sibling-test convention)
-   asserting: both scripts find real bucket-layout story files under a
-   fixture collection directory; the old flat-layout assumption is gone
-   (a flat `.json` file alongside a real bucket story is not found).
+4. In `smoke_test.py`, change `_RUNS`'s `corpus_subdir` values from
+   `"data/lovecraft"`/`"data/london"` to `"lovecraft"`/`"london"`, and
+   change line 183's `corpus_dir = _LCATS_ROOT / run_cfg["corpus_subdir"]`
+   to resolve against `_REPO_ROOT / "corpora" / run_cfg["corpus_subdir"]`
+   instead (`_REPO_ROOT` is already defined at line 42), so the smoke
+   test runs against the tracked, always-present `corpora/lovecraft` and
+   `corpora/london` collections.
+5. Create `experiments/02_llm_backend_comparison/run_comparison_test.py`
+   (matching the existing `run_pilot_test.py` sibling-test convention --
+   `check_segmentation_reliability_test.py` is planned by
+   `WI-EXPERIMENTS-0046` but does not exist yet, so it is not itself a
+   precedent to match) asserting: both scripts find real bucket-layout
+   story files under a fixture collection directory; the old
+   flat-layout assumption is gone (a flat `.json` file alongside a real
+   bucket story is not found).
 
 ## Non-Goals
 
@@ -145,8 +179,15 @@ same pass since it's directly adjacent to the line being changed.
   `corpus_dir.iterdir()` filtered by suffix.
 - `smoke_test.py`'s `_actual_sample` uses the same selector, not
   `corpus_dir.glob('*.json')`.
+- `smoke_test.py`'s `_RUNS` point at `corpora/lovecraft`/`corpora/london`,
+  not `lcats/data/lovecraft`/`lcats/data/london`.
 - Both scripts correctly find real bucket-layout story files under a
   single collection directory.
+- Running `python experiments/02_llm_backend_comparison/smoke_test.py`
+  in a fresh checkout (no prior `lcats gather` run) reaches the
+  file-discovery step -- i.e. it no longer fails at the
+  `corpus_dir.is_dir()` precondition check for a missing `data/`
+  directory.
 - `run_comparison.py`'s per-story progress print no longer shows the
   literal string `"story.json"` for every story.
 - A new regression test proves both scripts find bucket-layout stories
@@ -169,3 +210,9 @@ same pass since it's directly adjacent to the line being changed.
 - Neither script currently has any test coverage at all (confirmed: no
   `run_comparison_test.py`/`smoke_test_test.py` exist today), so this
   regression test is new coverage, not a modification to existing tests.
+- Repointing `smoke_test.py` from `data/` to `corpora/` changes which
+  corpus content the smoke test exercises (the promoted release
+  snapshot instead of a live-gathered working copy). This is an
+  intentional trade for actually being runnable out of the box; the
+  smoke test's purpose (sanity-checking the assess pipeline against a
+  small real sample) is served equally well by either source.

--- a/lcats/project/work_items/proposed/WI-EXPERIMENTS-0047.md
+++ b/lcats/project/work_items/proposed/WI-EXPERIMENTS-0047.md
@@ -1,0 +1,171 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EXPERIMENTS-0047
+title: Fix non-recursive file discovery in run_comparison.py and smoke_test.py
+type: deliverable
+status: proposed
+priority: medium
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams: []
+related_design:
+  - lcats/project/design/backlog.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - edit_file
+  - create_file
+  - run_tests
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - modify_check_segmentation_reliability_script
+  - modify_assess_story_title_fallback
+acceptance:
+  - "run_comparison.py's story_files selection uses discovery.iter_collection_story_files, not corpus_dir.iterdir() filtered by suffix"
+  - "smoke_test.py's _actual_sample uses the same selector, not corpus_dir.glob('*.json')"
+  - "Both scripts correctly find real bucket-layout story files (<collection>/<story>/story.json) under a single collection directory"
+  - "run_comparison.py's per-story progress print no longer shows the literal string \"story.json\" for every story"
+  - "A new regression test proves both scripts find bucket-layout stories correctly, and that the prior flat-layout-only behavior is gone"
+  - "lrh validate reports 0 errors"
+required_evidence:
+  - manual_review
+  - test_output
+  - lrh_validate
+artifacts_expected:
+  - experiments/02_llm_backend_comparison/run_comparison.py
+  - experiments/02_llm_backend_comparison/smoke_test.py
+  - experiments/02_llm_backend_comparison/run_comparison_test.py
+---
+
+# Work Item: Fix non-recursive file discovery in run_comparison.py and smoke_test.py
+
+## Summary
+
+Fix `run_comparison.py` and `smoke_test.py`'s non-recursive file
+selection (`corpus_dir.iterdir()` filtered by suffix, and
+`corpus_dir.glob("*.json")` respectively), which currently finds zero
+files against any real bucket-layout collection since a collection's
+immediate children are now story *directories*, not `.json` files.
+
+## Problem / Context
+
+Both scripts assume the retracted flat `<collection>/<story>.json`
+layout when selecting story files from a single collection directory
+(`--corpus-dir` / `data/lovecraft`, `data/london`). Re-verified
+2026-08-02 directly against current code: `run_comparison.py:57` does
+`sorted(f for f in corpus_dir.iterdir() if f.suffix == ".json")`; under
+bucket layout this finds **zero** files, but `run()` explicitly checks
+`if not story_files:` and exits 1 with a clear (if confusingly worded)
+error -- this fails **loud**, not silently, contrary to how earlier
+notes framed it. `smoke_test.py:109`'s `corpus_dir.glob("*.json")` has
+the same bug and propagates the same loud failure through `_run_leg` ->
+`run_comparison.run()`, correctly reporting `FAILED`/
+`Smoke test INCOMPLETE`. Also found while re-reading the full script:
+`run_comparison.py:82`'s progress print
+(`f"assessing {story_path.name} ..."`) would show the literal string
+`"story.json"` for every story once file selection is fixed -- the same
+leaf-filename-collapse issue as the identity problem elsewhere, but
+purely cosmetic here (log readability, not correctness) -- fixed in the
+same pass since it's directly adjacent to the line being changed.
+
+### Duplication search
+- In-repo: No existing implementation found. Two adopted design
+  proposals (`lcats-packaging-modernization/00_proposal.md`,
+  `lcats-story-bucket-layout/00_proposal.md`) reference these scripts in
+  passing but neither fixes this.
+- Sibling repos: None identified.
+- External libraries: None identified -- internal script-specific bug fix.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: Found: `WI-EXPERIMENTS-0046`'s own Non-Goals explicitly
+  defers this exact fix ("a separate backlog item, to be scoped next").
+- Proposals: None found.
+- Backlog: Found: "Non-recursive glob bugs in two experiment scripts"
+  in `lcats/project/design/backlog.md`. This work item is created
+  specifically to resolve that entry.
+- Recommendation: Offer to remove/mark-resolved the matching
+  `backlog.md` entry once this work item's creation PR is confirmed (not
+  auto-closed).
+
+## Scope
+
+- Fix file selection in both scripts to correctly find bucket-layout
+  story files under a single collection directory.
+- Fix the resulting cosmetic progress-print issue in `run_comparison.py`.
+- Add a regression test.
+- Do not touch `check_segmentation_reliability.py`
+  (`WI-EXPERIMENTS-0046`'s territory) or `assess_story`'s title-fallback
+  (separate, tiny backlog item).
+
+## Required Changes
+
+1. In `run_comparison.py`, replace
+   `sorted(f for f in corpus_dir.iterdir() if f.suffix == ".json")`
+   with `sorted(discovery.iter_collection_story_files(corpus_dir))` (the
+   canonical single-collection selector -- matches this call shape
+   exactly, since both scripts scan one named collection directory, not
+   a multi-collection root). Import `lcats.analysis.corpus.discovery`.
+2. In the same file, change the per-story progress print to use a real
+   per-story identifier (e.g. `story_path.parent.name`) instead of
+   `story_path.name`.
+3. In `smoke_test.py`, replace `sorted(corpus_dir.glob("*.json"))` in
+   `_actual_sample` with the same
+   `discovery.iter_collection_story_files(corpus_dir)` call.
+4. Create `experiments/02_llm_backend_comparison/run_comparison_test.py`
+   (matching the existing `run_pilot_test.py`/
+   `check_segmentation_reliability_test.py` sibling-test convention)
+   asserting: both scripts find real bucket-layout story files under a
+   fixture collection directory; the old flat-layout assumption is gone
+   (a flat `.json` file alongside a real bucket story is not found).
+
+## Non-Goals
+
+- Does not touch `check_segmentation_reliability.py` --
+  `WI-EXPERIMENTS-0046`'s territory.
+- Does not fix `assess_story`'s error-path title fallback or
+  `compare_results.py`'s similar fallback -- separate, tiny backlog
+  items.
+- Does not touch the two flagged notebooks -- a separate backlog item.
+- Does not change either script's overall CLI interface or output
+  format -- only file selection and the one cosmetic print.
+
+## Acceptance Criteria
+
+- `run_comparison.py`'s story-file selection uses
+  `discovery.iter_collection_story_files`, not
+  `corpus_dir.iterdir()` filtered by suffix.
+- `smoke_test.py`'s `_actual_sample` uses the same selector, not
+  `corpus_dir.glob('*.json')`.
+- Both scripts correctly find real bucket-layout story files under a
+  single collection directory.
+- `run_comparison.py`'s per-story progress print no longer shows the
+  literal string `"story.json"` for every story.
+- A new regression test proves both scripts find bucket-layout stories
+  correctly, and that the prior flat-layout-only behavior is gone.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `scripts/version tools`
+- `lrh validate`
+- `python -m pytest experiments/02_llm_backend_comparison/run_comparison_test.py`
+- `python -m pytest tests/`
+
+## Risk Notes
+
+- `iter_collection_story_files` applies only one level of nesting
+  relative to the directory it's given -- matches both scripts' existing
+  "one collection directory in, its stories out" usage exactly, no
+  behavior change beyond correctness.
+- Neither script currently has any test coverage at all (confirmed: no
+  `run_comparison_test.py`/`smoke_test_test.py` exist today), so this
+  regression test is new coverage, not a modification to existing tests.


### PR DESCRIPTION
## Summary

Creates `WI-EXPERIMENTS-0047`: fix the non-recursive file-selection bug in `experiments/02_llm_backend_comparison/run_comparison.py` and `smoke_test.py`, which currently find zero files against any real bucket-layout collection since a collection's immediate children are now story directories, not `.json` files. Both scripts fail **loud** (explicit error + non-zero exit), not silently — this is Batch 3 of the `WS-STORY-BUCKET-LAYOUT` follow-up resolution plan (Batch 1, `WI-EXPERIMENTS-0046`, already merged in [PR #212](https://github.com/xenotaur/LCATS/pull/212)).

This PR creates the planning artifact only — no implementation.

## Type

`deliverable`

## Related workstream

None — standalone, matching `WI-EXPERIMENTS-0046`'s precedent.

## Acceptance criteria

- `run_comparison.py`'s story-file selection uses `discovery.iter_collection_story_files`, not `corpus_dir.iterdir()` filtered by suffix
- `smoke_test.py`'s `_actual_sample` uses the same selector
- Both scripts correctly find real bucket-layout story files under a single collection directory
- `run_comparison.py`'s per-story progress print no longer shows the literal string `"story.json"` for every story
- A new regression test proves both scripts find bucket-layout stories correctly
- `lrh validate` reports 0 errors

## Prior art

- **Duplication:** none found — proceed.
- **Demand:** `WI-EXPERIMENTS-0046`'s own Non-Goals explicitly defers this exact fix; `project/design/backlog.md` has the matching entry this WI resolves (offer to remove/mark-resolved once this PR is confirmed, not auto-closed).

PROMPT(AD_HOC:WI_EXPERIMENTS_0047)[2026-08-02T15:55:26-04:00]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
