### PR TITLE
Add work item WI-EXPERIMENTS-0048: fix hardcoded flat-layout paths in notebooks

### DIFF
--- a/lcats/project/executions/AD_HOC/2026_08_02_21_00_15_WI_EXPERIMENTS_0048.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_21_00_15_WI_EXPERIMENTS_0048.md
@@ -1,0 +1,70 @@
+---
+execution_id: 2026_08_02_21_00_15_WI_EXPERIMENTS_0048
+prompt_id: PROMPT(AD_HOC:WI_EXPERIMENTS_0048)[2026-08-02T16:36:14-04:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 
+pr: https://github.com/xenotaur/LCATS/pull/215
+commit: 07a33e02de39e89e0fd5f4f9e4576271e7d2ae34
+created_at: 2026-08-02T21:00:15+00:00
+agent: claude_app
+instruction_source: project/work_items/proposed/WI-EXPERIMENTS-0048.md
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Created `WI-EXPERIMENTS-0048`: fix hardcoded flat-layout paths in
+`12_extract_scenes.ipynb`/`13_clean_corpus.ipynb` (Batch 4, the last item
+of the `WS-STORY-BUCKET-LAYOUT` follow-up resolution plan; Batches 1/3
+already merged via PR #212/#214).
+
+# Result
+
+- Before drafting, extracted and read the actual current notebook cell
+  content directly (not just backlog notes) via `git show
+  origin/main:... | python3 -c "json.load(...)"`, per this session's
+  repeatedly-confirmed lesson about verifying own planning claims against
+  real code/data.
+- Found a genuine scoping risk during verification: manually rewriting
+  `12_extract_scenes.ipynb`'s ~110 hardcoded literal paths would be
+  error-prone, since `mass_quantities` bucket directory names now carry
+  an author-disambiguation suffix not present in the old flat filenames
+  (confirmed directly: `give_back_a_world` -> `give_back_a_world__gallun`,
+  `george_walker_at_suez` -> `george_walker_at_suez__trollope`). Presented
+  this to the user as an explicit choice (regenerate live via the
+  notebook's own already-correct, already-present-but-commented-out
+  `random.sample(json_stories, N)` pattern, vs. hand-fixing all ~110) --
+  user confirmed regenerate-live.
+- Also examined (but deliberately left untouched, as a Non-Goal)
+  `13_clean_corpus.ipynb`'s `rename_and_fix_json_files` -- its `ext.json`
+  default/basename-validation purpose is now largely moot under bucket
+  layout (every canonical filename is uniformly `story.json`, trivially
+  valid) but isn't actively broken.
+- Ran the prior art check: duplication search found only a docstring
+  cross-reference (no fix); demand search found the matching
+  `backlog.md` entry this WI resolves.
+- Wrote `project/work_items/proposed/WI-EXPERIMENTS-0048.md`, confirmed
+  with the user before writing.
+- Opened [PR #215](https://github.com/xenotaur/LCATS/pull/215).
+
+# Validation
+
+- `lrh validate` -- 0 errors, 69 warnings (new WI's own pre-existing
+  `owner: unassigned` pattern shared by every other work item in this
+  repo).
+
+# Follow-up
+
+- Offer (per the prior-art demand-search recommendation, not
+  auto-closed): once this PR is confirmed/merged, remove or mark
+  resolved the matching `project/design/backlog.md` entry ("Hardcoded
+  flat-layout paths in two notebooks").
+- `status` is `in_progress`; update to `landed` via `/lrh-closeout` after
+  PR #215 merges. `WI-EXPERIMENTS-0048` itself stays `proposed` until its
+  implementation lands as a separate PR.
+- This is the last unscoped item (Batch 4) from the resolution plan --
+  all 4 batches are now either merged (this PR pending) or scoped as
+  work items. Remaining P3 decision-only backlog items (librarization,
+  ERW Category E, genre-reconciliation gaps, survey/promote exclusion)
+  were explicitly deferred by the user earlier in this plan.

--- a/lcats/project/executions/AD_HOC/2026_08_02_21_12_58_WI_EXPERIMENTS_0048_CONFIRM.md
+++ b/lcats/project/executions/AD_HOC/2026_08_02_21_12_58_WI_EXPERIMENTS_0048_CONFIRM.md
@@ -1,0 +1,64 @@
+---
+execution_id: 2026_08_02_21_12_58_WI_EXPERIMENTS_0048_CONFIRM
+prompt_id: PROMPT(AD_HOC:WI_EXPERIMENTS_0048_CONFIRM)[2026-08-02T21:09:45+00:00]
+work_item: AD_HOC
+status: in_progress
+rerun_of: 2026_08_02_21_00_15_WI_EXPERIMENTS_0048
+pr: https://github.com/xenotaur/LCATS/pull/215
+commit: 8cc6cc387030aacdda62d68efc129649ee4dd63f
+created_at: 2026-08-02T21:12:58+00:00
+agent: claude_app
+instruction_source: https://github.com/xenotaur/LCATS/pull/215
+session_transcript: claude-app:ca0e8b20-2e3a-44f3-90b6-c506f3b98336
+---
+
+# Summary
+
+Pre-merge verification and thread-resolution pass for PR #215
+(`WI-EXPERIMENTS-0048` creation), per `/lrh-confirm-fixes`'s protocol,
+inlined per `/lrh-land`'s Phase 1 interim invocation pattern.
+
+# Result
+
+- Gathered state: GraphQL review-threads query showed 1 thread,
+  `isResolved: true`. CI (`gh pr checks 215`) --
+  coverage/lint/test all `SUCCESS`.
+- The thread was a real, substantive Codex P2 finding that landed
+  without this session triggering anything. Per explicit user direction
+  this run, substituted a fresh independent subagent for the bot
+  retrigger-and-wait mechanism this skill's Step 3/Step 8 would
+  otherwise use. Verified before fixing: the original scope drew
+  `SAMPLE_OF_10`/`SAMPLE_OF_100` from `json_stories`
+  (`corpus_surveyor.find_corpus_stories`, a re-export of the *broad*
+  `discovery.find_corpus_stories`), which includes non-canonical
+  sidecar JSON files, not just `story.json`. Confirmed this directly
+  against `discovery.py` -- `find_json_files` is the actual
+  sidecar-excluding selector, and `corpus_surveyor.py` does not
+  re-export it. Fixed by introducing a separate `canonical_story_files`
+  variable built from `discovery.find_json_files`, without touching
+  `json_stories` itself (a different cell, `compute_corpus_stats`, also
+  depends on it and is out of this work item's scope).
+- Dispatched a fresh, independent subagent to verify the fix commit
+  (`8cc6cc38`) against actual current file content, actual current code
+  behavior, and the real corpus on disk (confirmed both cited bucket
+  directories -- `mass_quantities/george_walker_at_suez__trollope`,
+  `mass_quantities/give_back_a_world__gallun` -- exist with `story.json`
+  inside). Clean pass, no new issues found.
+- Re-checked for new unresolved threads after the fix commit: none. The
+  one thread resolved via `resolveReviewThread` (diff plainly satisfies
+  it).
+
+# Validation
+
+- `lrh validate` -- 0 errors, 69 pre-existing warnings (run from the
+  correct `lcats/` cwd; a `lrh prompt record-execution` call earlier in
+  this same step hit the known wrong-cwd trap, writing a stray
+  `project/` at the worktree root -- caught and fixed before this record
+  was finalized, no stray files reached the PR).
+- `gh pr checks 215` -- coverage/lint/test all `SUCCESS` on `8cc6cc38`.
+- This PR is planning-only (a work item file, no source code); no test
+  suite run was applicable to this PR's own diff.
+
+# Follow-up
+
+- None -- ready for the merge gate.

--- a/lcats/project/work_items/proposed/WI-EXPERIMENTS-0048.md
+++ b/lcats/project/work_items/proposed/WI-EXPERIMENTS-0048.md
@@ -1,0 +1,166 @@
+---
+resolution: null
+blocked_reason: null
+blocked: false
+id: WI-EXPERIMENTS-0048
+title: Fix hardcoded flat-layout paths in the two extract-scenes/clean-corpus notebooks
+type: deliverable
+status: proposed
+priority: low
+owner: unassigned
+contributors: []
+assigned_agents: []
+related_focus:
+  - FOCUS-WORLDCON-2026
+related_roadmap: []
+related_workstreams: []
+related_design:
+  - lcats/project/design/backlog.md
+depends_on: []
+blocked_by: []
+expected_actions:
+  - edit_file
+  - create_pr
+forbidden_actions:
+  - force_push
+  - delete_branch
+  - modify_rename_and_fix_json_files_behavior
+  - regenerate_notebook_outputs_wholesale
+acceptance:
+  - "12_extract_scenes.ipynb's SAMPLE_OF_10/SAMPLE_OF_100 are generated via a seeded random.sample(json_stories, N) call, not hardcoded literal flat-layout paths"
+  - "13_clean_corpus.ipynb's missing_stories points at the real, current bucket-layout paths for the same two stories"
+  - "Neither notebook's remaining literal path examples reference the retracted flat <collection>/<story>.json layout"
+  - "lrh validate reports 0 errors"
+required_evidence:
+  - manual_review
+  - lrh_validate
+artifacts_expected:
+  - lcats/notebooks/12_extract_scenes.ipynb
+  - lcats/notebooks/13_clean_corpus.ipynb
+---
+
+# Work Item: Fix hardcoded flat-layout paths in the two extract-scenes/clean-corpus notebooks
+
+## Summary
+
+Fix hardcoded flat-layout literal paths in `12_extract_scenes.ipynb` and
+`13_clean_corpus.ipynb`, both stale since the bucket-layout migration.
+
+## Problem / Context
+
+Re-verified 2026-08-02 directly against current notebook content (not
+just backlog notes): `12_extract_scenes.ipynb`'s `SAMPLE_OF_10`/
+`SAMPLE_OF_100` (cells 48-49) are hardcoded absolute flat-layout paths
+(e.g. `/Users/centaur/.../corpora/massQuantities/the_crystal_ray.json`)
+-- both stale in path *shape* and in the `massQuantities` casing (real
+collection name is `mass_quantities`). These feed
+`corpus_surveyor.process_files`, which catches per-file errors
+gracefully (`except Exception` in `processing.py`'s `process_file`)
+rather than crashing, so a run would report every sampled story as
+`status: "error"` without halting.
+
+**Scoping finding, verified before drafting:** manually rewriting all
+~110 of these paths would be error-prone -- checking two of
+`13_clean_corpus.ipynb`'s equivalent stale paths against the real corpus
+found that `mass_quantities` bucket directory names now carry an
+author-disambiguation suffix not present in the old flat filename
+(`give_back_a_world` -> `give_back_a_world__gallun`;
+`george_walker_at_suez` -> `george_walker_at_suez__trollope`), confirmed
+via direct directory listing. `12_extract_scenes.ipynb` already contains
+the right fix, just commented out: cell 25's
+`json_stories = corpus_surveyor.find_corpus_stories(CORPORA_ROOT)`
+already works correctly against the real bucket layout (confirmed: it's
+a direct re-export of `discovery.find_corpus_stories`, layout-agnostic),
+and cell 47 has commented-out code (`random.sample(json_stories, 100)`)
+showing the original intent was a regenerable sample, not permanently
+frozen literals.
+
+`13_clean_corpus.ipynb`'s `missing_stories` (cell 45, only 2 specific
+paths, not a bulk sample) is updated directly to the confirmed real
+bucket paths, preserving the same two specific stories.
+
+Also examined `13_clean_corpus.ipynb`'s `rename_and_fix_json_files`
+(cell 29, `ext: str = ".json"` default) -- its purpose (repairing messy
+flat filenames via basename validation) is now largely moot since every
+canonical filename is uniformly `story.json` (which trivially passes its
+basename-validity check), but it isn't actively broken or crashing. Left
+untouched -- a Non-Goal, not a bug.
+
+### Duplication search
+- In-repo: No existing implementation found. One docstring
+  cross-reference in `lcats/src/lcats/analysis/scene_analysis.py:304`
+  (mentions `12_extract_scenes.ipynb` for context, no fix).
+- Sibling repos: None identified.
+- External libraries: None identified -- internal notebook fix.
+- Recommendation: Proceed.
+
+### Demand search
+- Work items: None found.
+- Proposals: None found.
+- Backlog: Found: "Hardcoded flat-layout paths in two notebooks" in
+  `lcats/project/design/backlog.md`. This work item is created
+  specifically to resolve that entry.
+- Recommendation: Offer to remove/mark-resolved the matching
+  `backlog.md` entry once this work item's creation PR is confirmed (not
+  auto-closed).
+
+## Scope
+
+- Replace `12_extract_scenes.ipynb`'s hardcoded `SAMPLE_OF_10`/
+  `SAMPLE_OF_100` with a live, seeded `random.sample(json_stories, N)`
+  call.
+- Update `13_clean_corpus.ipynb`'s `missing_stories` to the confirmed
+  real bucket paths for the same two stories.
+- Do not touch `rename_and_fix_json_files`'s behavior or defaults.
+- Do not regenerate or re-run either notebook's existing saved cell
+  outputs wholesale -- edit source cells only.
+
+## Required Changes
+
+1. In `12_extract_scenes.ipynb`, replace the
+   `SAMPLE_OF_10 = pathify([...])` and `SAMPLE_OF_100 = pathify([...])`
+   cells with `SAMPLE_OF_10 = random.Random(42).sample(json_stories, 10)`
+   / `SAMPLE_OF_100 = random.Random(42).sample(json_stories, 100)` (a
+   fixed seed preserves the original lists' reproducibility intent;
+   `json_stories` from cell 25 is already correctly bucket-aware).
+2. In `13_clean_corpus.ipynb`, update `missing_stories` (cell 45) to
+   `[CORPORA_ROOT / 'mass_quantities/george_walker_at_suez__trollope/story.json', CORPORA_ROOT / 'mass_quantities/give_back_a_world__gallun/story.json']`.
+
+## Non-Goals
+
+- Does not change `rename_and_fix_json_files`'s `ext` default or
+  scanning behavior.
+- Does not touch `experiments/` scripts -- separate, already-scoped work
+  items (`WI-EXPERIMENTS-0046`/`0047`).
+- Does not re-execute either notebook or regenerate saved cell outputs.
+- Does not address the notebooks/experiments librarization question --
+  a separate, decision-only backlog item.
+
+## Acceptance Criteria
+
+- `12_extract_scenes.ipynb`'s `SAMPLE_OF_10`/`SAMPLE_OF_100` are
+  generated via a seeded `random.sample(json_stories, N)` call, not
+  hardcoded literal flat-layout paths.
+- `13_clean_corpus.ipynb`'s `missing_stories` points at the real,
+  current bucket-layout paths for the same two stories.
+- Neither notebook's remaining literal path examples reference the
+  retracted flat `<collection>/<story>.json` layout.
+- `lrh validate` reports 0 errors.
+
+## Validation
+
+- `scripts/version tools`
+- `lrh validate`
+- Manual: open both notebooks, confirm the edited cells' source no
+  longer contains flat-layout literal paths
+
+## Risk Notes
+
+- Switching `SAMPLE_OF_10`/`SAMPLE_OF_100` to a live seeded sample means
+  the *specific* sampled stories will differ from the original frozen
+  list (different corpus content, same collection universe) -- acceptable
+  since the notebook's own commented-out code shows this was always
+  meant to be a representative sample, not specific curated stories.
+- Per `AGENTS.md`, this is a deliberate, judgment-carrying notebook edit,
+  not a routine one -- scoped narrowly to the confirmed-stale path
+  literals only.

--- a/lcats/project/work_items/proposed/WI-EXPERIMENTS-0048.md
+++ b/lcats/project/work_items/proposed/WI-EXPERIMENTS-0048.md
@@ -27,7 +27,7 @@ forbidden_actions:
   - modify_rename_and_fix_json_files_behavior
   - regenerate_notebook_outputs_wholesale
 acceptance:
-  - "12_extract_scenes.ipynb's SAMPLE_OF_10/SAMPLE_OF_100 are generated via a seeded random.sample(json_stories, N) call, not hardcoded literal flat-layout paths"
+  - "12_extract_scenes.ipynb's SAMPLE_OF_10/SAMPLE_OF_100 are generated via a seeded random.sample() call over the canonical bucket-only selector (discovery.find_json_files), not the broad json_stories (which can include sidecar JSON) and not hardcoded literal flat-layout paths"
   - "13_clean_corpus.ipynb's missing_stories points at the real, current bucket-layout paths for the same two stories"
   - "Neither notebook's remaining literal path examples reference the retracted flat <collection>/<story>.json layout"
   - "lrh validate reports 0 errors"
@@ -75,6 +75,26 @@ and cell 47 has commented-out code (`random.sample(json_stories, 100)`)
 showing the original intent was a regenerable sample, not permanently
 frozen literals.
 
+**One additional gap found via review of this work item's own creation
+PR, before any implementation was written:** `json_stories` (cell 25) is
+`corpus_surveyor.find_corpus_stories(CORPORA_ROOT)`, a direct re-export
+of `discovery.find_corpus_stories` -- the *broad* recursive finder that
+includes every `.json` file, not just canonical `story.json` (confirmed
+against `discovery.py:13-51`). It happens to work correctly *today* only
+because the real `corpora/` tree currently has zero sidecar files
+(confirmed earlier this session). The original scope (drawing
+`SAMPLE_OF_10`/`SAMPLE_OF_100` from `json_stories` via `random.sample`)
+would have made these samples depend on that broad selector for the
+first time -- previously the hardcoded literals were always manually
+curated, genuine story files, never sidecars. If a bucket sidecar
+(`analysis.json` etc.) is ever added, this code would start silently
+sampling it as if it were an independent story. Fixed by drawing the
+sample from `discovery.find_json_files([CORPORA_ROOT])` instead (the
+canonical, sidecar-excluding selector already established across this
+codebase), as a separate variable -- not by changing `json_stories`
+itself, which cell 27's `compute_corpus_stats(json_stories)` also
+depends on and is out of this work item's scope to touch.
+
 `13_clean_corpus.ipynb`'s `missing_stories` (cell 45, only 2 specific
 paths, not a bulk sample) is updated directly to the confirmed real
 bucket paths, preserving the same two specific stories.
@@ -107,23 +127,31 @@ untouched -- a Non-Goal, not a bug.
 ## Scope
 
 - Replace `12_extract_scenes.ipynb`'s hardcoded `SAMPLE_OF_10`/
-  `SAMPLE_OF_100` with a live, seeded `random.sample(json_stories, N)`
-  call.
+  `SAMPLE_OF_100` with a live, seeded sample drawn from the canonical,
+  sidecar-excluding selector (`discovery.find_json_files`).
 - Update `13_clean_corpus.ipynb`'s `missing_stories` to the confirmed
   real bucket paths for the same two stories.
-- Do not touch `rename_and_fix_json_files`'s behavior or defaults.
+- Do not touch `rename_and_fix_json_files`'s behavior or defaults, or
+  `json_stories`'s existing broad-selector definition (cell 25, also
+  used by `compute_corpus_stats` -- out of scope to change here).
 - Do not regenerate or re-run either notebook's existing saved cell
   outputs wholesale -- edit source cells only.
 
 ## Required Changes
 
-1. In `12_extract_scenes.ipynb`, replace the
-   `SAMPLE_OF_10 = pathify([...])` and `SAMPLE_OF_100 = pathify([...])`
-   cells with `SAMPLE_OF_10 = random.Random(42).sample(json_stories, 10)`
-   / `SAMPLE_OF_100 = random.Random(42).sample(json_stories, 100)` (a
-   fixed seed preserves the original lists' reproducibility intent;
-   `json_stories` from cell 25 is already correctly bucket-aware).
-2. In `13_clean_corpus.ipynb`, update `missing_stories` (cell 45) to
+1. In `12_extract_scenes.ipynb`, add
+   `from lcats.analysis.corpus import discovery` to the existing
+   `lcats.analysis` import cell (cell 8).
+2. In the same notebook, add a new cell (near cell 25, alongside
+   `json_stories`) computing
+   `canonical_story_files = list(discovery.find_json_files([CORPORA_ROOT]))`
+   -- a separate variable, not a replacement for `json_stories`.
+3. Replace the `SAMPLE_OF_10 = pathify([...])` and
+   `SAMPLE_OF_100 = pathify([...])` cells with
+   `SAMPLE_OF_10 = random.Random(42).sample(canonical_story_files, 10)`
+   / `SAMPLE_OF_100 = random.Random(42).sample(canonical_story_files, 100)`
+   (a fixed seed preserves the original lists' reproducibility intent).
+4. In `13_clean_corpus.ipynb`, update `missing_stories` (cell 45) to
    `[CORPORA_ROOT / 'mass_quantities/george_walker_at_suez__trollope/story.json', CORPORA_ROOT / 'mass_quantities/give_back_a_world__gallun/story.json']`.
 
 ## Non-Goals
@@ -139,8 +167,10 @@ untouched -- a Non-Goal, not a bug.
 ## Acceptance Criteria
 
 - `12_extract_scenes.ipynb`'s `SAMPLE_OF_10`/`SAMPLE_OF_100` are
-  generated via a seeded `random.sample(json_stories, N)` call, not
-  hardcoded literal flat-layout paths.
+  generated via a seeded `random.sample()` call over the canonical
+  `discovery.find_json_files` selector (a new `canonical_story_files`
+  variable, not the broad `json_stories`), not hardcoded literal
+  flat-layout paths.
 - `13_clean_corpus.ipynb`'s `missing_stories` points at the real,
   current bucket-layout paths for the same two stories.
 - Neither notebook's remaining literal path examples reference the


### PR DESCRIPTION
## Summary

Creates `WI-EXPERIMENTS-0048`: fix hardcoded flat-layout literal paths in `lcats/notebooks/12_extract_scenes.ipynb` and `13_clean_corpus.ipynb`. This is Batch 4 of the `WS-STORY-BUCKET-LAYOUT` follow-up resolution plan (Batches 1/3, `WI-EXPERIMENTS-0046`/`0047`, already merged).

This PR creates the planning artifact only — no implementation.

## Type

`deliverable`

## Related workstream

None — standalone, matching the precedent of Batches 1/3.

## Scoping note

Rather than hand-fixing ~110 individual stale literal paths in `12_extract_scenes.ipynb`'s `SAMPLE_OF_10`/`SAMPLE_OF_100`, verified that the notebook already has correct, bucket-aware infrastructure (`json_stories`, cell 25) and its own commented-out sampling code showing the original intent was a regenerable sample — so this WI scopes a live `random.sample(json_stories, N)` regeneration instead. This also avoids a real correctness risk found while verifying: `mass_quantities` bucket directory names now carry an author-disambiguation suffix not present in the old flat filenames (confirmed by checking the two specific stories `13_clean_corpus.ipynb`'s `missing_stories` references), which a naive mechanical path rewrite would have gotten wrong.

## Acceptance criteria

- `12_extract_scenes.ipynb`'s `SAMPLE_OF_10`/`SAMPLE_OF_100` generated via a seeded `random.sample(json_stories, N)`, not hardcoded literals
- `13_clean_corpus.ipynb`'s `missing_stories` points at the real, current bucket-layout paths for the same two stories
- Neither notebook references the retracted flat layout
- `lrh validate` reports 0 errors

## Prior art

- **Duplication:** none found — proceed.
- **Demand:** `project/design/backlog.md` has the matching entry this WI resolves (offer to remove/mark-resolved once this PR is confirmed, not auto-closed).

PROMPT(AD_HOC:WI_EXPERIMENTS_0048)[2026-08-02T16:36:14-04:00]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
